### PR TITLE
deps(deps): bump chrono to 0.4.44, serde_with to 3.17.0, and indicatif to 0.18.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -102,7 +102,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -589,7 +589,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -649,7 +649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1876,7 +1876,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1933,7 +1933,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2818,7 +2818,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3388,7 +3388,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/shipper-cli/Cargo.toml
+++ b/crates/shipper-cli/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 serde_json = "1"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4.44", features = ["serde"] }
 
 [lints]
 workspace = true

--- a/crates/shipper-config/Cargo.toml
+++ b/crates/shipper-config/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools"]
 serde.workspace = true
 anyhow = "1.0"
 toml = "1.0"
-serde_with = "3.12.0"
+serde_with = "3.17.0"
 shipper-types = { path = "../shipper-types" }
 shipper-encrypt = { path = "../shipper-encrypt" }
 shipper-storage = { path = "../shipper-storage" }

--- a/crates/shipper-engine-parallel/Cargo.toml
+++ b/crates/shipper-engine-parallel/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools", "development-tools::build-utils"]
 
 [dependencies]
 anyhow = "1.0.101"
-chrono = { version = "0.4.43", features = ["serde"] }
+chrono = { version = "0.4.44", features = ["serde"] }
 humantime = "2.3.0"
 shipper-chunking = { path = "../shipper-chunking" }
 shipper-execution-core = { path = "../shipper-execution-core" }

--- a/crates/shipper-environment/Cargo.toml
+++ b/crates/shipper-environment/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools"]
 [dependencies]
 serde.workspace = true
 anyhow = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4.44", features = ["serde"] }
 shipper-types = { path = "../shipper-types" }
 
 [dev-dependencies]

--- a/crates/shipper-events/Cargo.toml
+++ b/crates/shipper-events/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools"]
 serde.workspace = true
 serde_json = "1.0"
 anyhow = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4.44", features = ["serde"] }
 shipper-types = { path = "../shipper-types" }
 
 [dev-dependencies]

--- a/crates/shipper-execution-core/Cargo.toml
+++ b/crates/shipper-execution-core/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 
 [dependencies]
 anyhow = "1.0.101"
-chrono = { version = "0.4.43", features = ["serde"] }
+chrono = { version = "0.4.44", features = ["serde"] }
 shipper-cargo-failure = { path = "../shipper-cargo-failure" }
 shipper-retry = { path = "../shipper-retry" }
 shipper-state = { path = "../shipper-state" }

--- a/crates/shipper-lock/Cargo.toml
+++ b/crates/shipper-lock/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["filesystem", "concurrency"]
 serde.workspace = true
 serde_json = "1.0"
 anyhow = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4.44", features = ["serde"] }
 gethostname = "1.1"
 
 [dev-dependencies]

--- a/crates/shipper-plan/Cargo.toml
+++ b/crates/shipper-plan/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools"]
 [dependencies]
 anyhow = "1.0"
 cargo_metadata = "0.23.1"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4.44", features = ["serde"] }
 hex = "0.4"
 sha2 = "0.10"
 shipper-cargo = { path = "../shipper-cargo" }

--- a/crates/shipper-progress/Cargo.toml
+++ b/crates/shipper-progress/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 
 [dependencies]
 atty = "0.2"
-indicatif = "0.18"
+indicatif = "0.18.4"
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/shipper-state/Cargo.toml
+++ b/crates/shipper-state/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools"]
 serde.workspace = true
 serde_json = "1.0"
 anyhow = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4.44", features = ["serde"] }
 shipper-types = { path = "../shipper-types" }
 shipper-environment = { path = "../shipper-environment" }
 shipper-encrypt = { path = "../shipper-encrypt" }

--- a/crates/shipper-store/Cargo.toml
+++ b/crates/shipper-store/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools"]
 anyhow = "1.0"
 serde.workspace = true
 serde_json = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4.44", features = ["serde"] }
 shipper-events = { path = "../shipper-events" }
 shipper-types = { path = "../shipper-types" }
 shipper-state = { path = "../shipper-state" }

--- a/crates/shipper-types/Cargo.toml
+++ b/crates/shipper-types/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["development-tools"]
 
 [dependencies]
 serde.workspace = true
-chrono = { version = "0.4", features = ["serde"] }
-serde_with = "3.12.0"
+chrono = { version = "0.4.44", features = ["serde"] }
+serde_with = "3.17.0"
 shipper-encrypt = { path = "../shipper-encrypt" }
 shipper-webhook = { path = "../shipper-webhook" }
 shipper-retry = { path = "../shipper-retry" }

--- a/crates/shipper/Cargo.toml
+++ b/crates/shipper/Cargo.toml
@@ -47,10 +47,10 @@ thiserror = "2.0.18"
 cargo_metadata = "0.23.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-serde_with = "3.12.0"
+serde_with = "3.17.0"
 reqwest = { version = "0.13.2", features = ["blocking", "json", "rustls"] }
 rand = { version = "0.10.0", features = ["std"] }
-chrono = { version = "0.4.43", features = ["serde"] }
+chrono = { version = "0.4.44", features = ["serde"] }
 humantime = "2.3.0"
 toml = "1.0.3"
 hex = "0.4.3"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -25,7 +25,7 @@ shipper-levels = { path = "../crates/shipper-levels" }
 shipper-chunking = { path = "../crates/shipper-chunking" }
 shipper-sparse-index = { path = "../crates/shipper-sparse-index" }
 shipper-webhook = { path = "../crates/shipper-webhook" }
-chrono = "0.4.43"
+chrono = "0.4.44"
 hmac = "0.12"
 sha2 = "0.10"
 url = "2"


### PR DESCRIPTION
Summary

Updates Rust dependency pins for:
- chrono -> 0.4.44
- serde_with -> 3.17.0
- indicatif -> 0.18.4

Scope

- manifests + Cargo.lock only
- no workflow changes
- no docs or unrelated files

Validation

- cargo update -p chrono
- cargo update -p serde_with
- cargo update -p indicatif
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings

Notes

A single sandboxed full-workspace test run was not reliable because some tests are network-sensitive in this environment.
The affected targets were rerun outside the sandbox and passed:
- cargo test -p shipper-cargo --all-features
- cargo test -p shipper-cli --test cli_e2e -- --nocapture

CI should be treated as the final gate for the full workspace run.