### PR TITLE
ci(deps): bump actions/upload-artifact to v7 and actions/download-artifact to v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload JUnit
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: junit-${{ matrix.os }}
           path: target/nextest/ci/junit.xml
@@ -190,7 +190,7 @@ jobs:
         run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: lcov
           path: lcov.info
@@ -340,7 +340,7 @@ jobs:
         run: cargo build --release
 
       - name: Upload release binary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: shipper-linux-x86_64
           path: target/release/shipper

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Upload crashers
         if: steps.check_crashers.outputs.crashers_found == 'true'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: fuzz-crashers-${{ matrix.target }}
           path: artifacts/
@@ -109,7 +109,7 @@ jobs:
 
       - name: Upload corpus
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: fuzz-corpus-${{ matrix.target }}
           path: fuzz/corpus/${{ matrix.target }}/

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload mutation report
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: mutation-report
           path: mutants.out/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
           cd -
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: shipper-${{ matrix.target }}
           path: shipper-${{ matrix.target }}.*
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 


### PR DESCRIPTION
Summary

Updates GitHub Actions artifact actions:
- actions/upload-artifact -> v7
- actions/download-artifact -> v8

Scope

- workflow files only
- no Rust source or dependency changes