### PR TITLE
decrating: Phase 1 — scaffold ops/ and runtime/ layer dirs

### DIFF
--- a/crates/shipper/src/ops/CLAUDE.md
+++ b/crates/shipper/src/ops/CLAUDE.md
@@ -1,0 +1,45 @@
+# Layer: `ops` (I/O primitives)
+
+**Position in the architecture:** Layer 1 (bottom). The lowest layer of the `shipper` crate.
+
+## Single responsibility
+
+Talk to the outside world: filesystem, git binary, cargo subprocess, OS, network.
+
+## Import rules
+
+`ops` modules MUST NOT import from any higher layer:
+- ❌ `use crate::engine::...`
+- ❌ `use crate::plan::...`
+- ❌ `use crate::state::...`
+- ❌ `use crate::runtime::...`
+
+`ops` modules MAY import from:
+- ✅ `crate::types` (re-exports of `shipper-types`)
+- ✅ External crates (`anyhow`, `serde`, `tokio`, etc.)
+- ✅ Other `crate::ops::*` modules (with care — prefer `mod.rs` facades over deep paths)
+
+These are enforced by `.github/workflows/architecture-guard.yml`.
+
+## What lives here
+
+Each absorbed I/O microcrate gets its own folder under `ops/`:
+
+- `ops/auth/` — Cargo registry token resolution (was `shipper-auth`)
+- `ops/git/` — Git cleanliness checks, context capture (was `shipper-git`)
+- `ops/lock/` — Advisory file lock (was `shipper-lock`)
+- `ops/process/` — Cross-platform command execution (was `shipper-process`)
+- `ops/cargo/` — Cargo metadata + cargo publish invocation (was `shipper-cargo`)
+- `ops/storage/` — Storage backend trait + filesystem impl (was `shipper-storage`)
+
+## What does NOT live here
+
+- `shipper-registry`, `shipper-webhook`, `shipper-sparse-index` — these are public crates that `shipper` depends on directly. No internal wrapper inside `ops/`.
+- Domain types — those live in `shipper-types`.
+- Orchestration — that's `engine/`.
+
+## Boundary discipline
+
+- Each subfolder has its own `mod.rs` facade. Other modules talk through the facade, not by reaching into deep paths.
+- Default visibility: `pub(crate)`. Only items truly part of `shipper`'s public API get `pub`.
+- Each subfolder has its own `CLAUDE.md` describing its single responsibility.

--- a/crates/shipper/src/ops/mod.rs
+++ b/crates/shipper/src/ops/mod.rs
@@ -1,0 +1,7 @@
+//! Layer 1: I/O primitives. Talk to the filesystem, git, cargo, OS, network.
+//!
+//! This layer must not import from `engine`, `plan`, `state`, or `runtime`.
+//! See `CLAUDE.md` in this folder for the architectural rules.
+
+// Subsystem modules will be added here as they are absorbed from microcrates.
+// Currently this is a scaffold — no submodules yet.

--- a/crates/shipper/src/runtime/CLAUDE.md
+++ b/crates/shipper/src/runtime/CLAUDE.md
@@ -1,0 +1,33 @@
+# Layer: `runtime` (runtime context — pure data)
+
+**Position in the architecture:** Layer 2. Above `ops/`, below `state/`, `plan/`, `engine/`.
+
+## Single responsibility
+
+Pure-data descriptions of the runtime context: environment fingerprint, policy choices, execution context. No I/O, no side effects, no orchestration.
+
+## Import rules
+
+`runtime` modules MAY import from:
+- ✅ `crate::ops::*` (the layer below)
+- ✅ `crate::types` (re-exports of `shipper-types`)
+- ✅ External pure-data crates (`serde`, `chrono`, etc.)
+
+`runtime` modules MUST NOT import from:
+- ❌ `crate::engine::...`
+- ❌ `crate::plan::...`
+- ❌ `crate::state::...`
+
+These are enforced by `.github/workflows/architecture-guard.yml`.
+
+## What lives here
+
+- `runtime/environment/` — OS/arch/tool fingerprint (was `shipper-environment`)
+- `runtime/policy/` — `PublishPolicy`, `VerifyMode`, `ReadinessMethod` enums (was `shipper-policy`)
+- `runtime/execution/` — `ExecutionContext`, `ExecutionResult`, helpers (was `shipper-execution-core`)
+
+## Boundary discipline
+
+- Default visibility: `pub(crate)`.
+- Each subfolder owns its own `mod.rs` and `CLAUDE.md`.
+- Items here are mostly types and pure functions. If you find yourself doing I/O here, the code belongs in `ops/` instead.

--- a/crates/shipper/src/runtime/mod.rs
+++ b/crates/shipper/src/runtime/mod.rs
@@ -1,0 +1,6 @@
+//! Layer 2: runtime context (pure data). Environment fingerprint, policy, execution context.
+//!
+//! May import from `ops`. Must not import from `engine`, `plan`, or `state`.
+//! See `CLAUDE.md` in this folder for the architectural rules.
+
+// Subsystem modules will be added here as they are absorbed from microcrates.


### PR DESCRIPTION
## Summary

Phase 1 of the decrating plan (per \`docs/decrating-plan.md\`). Lays down two of the five layered-architecture directories inside \`crates/shipper/src/\`:

- \`ops/\` (layer 1, bottom) — I/O primitives
- \`runtime/\` (layer 2) — pure-data runtime context

Each folder gets a \`CLAUDE.md\` describing its single responsibility, allowed imports, and what lives there, plus an empty \`mod.rs\` stub.

## Why only 2 of 5 layers

The other three layer dirs (\`state/\`, \`plan/\`, \`engine/\`) each collide with an existing flat module file (\`state.rs\`, \`plan.rs\`, \`engine.rs\`). Rust cannot resolve \`pub mod state;\` when both \`state.rs\` and \`state/mod.rs\` exist. Those three layer directories are deferred to their respective Phase 2 absorption PRs, where the flat file is deleted in the same commit — eliminating the conflict atomically.

This is also why Phase 2 absorptions for those three layers must come BEFORE absorptions targeting their layer (e.g., \`auth → ops/auth/\` is independent of state.rs/plan.rs/engine.rs and can land first; but \`store → state/store/\` requires the \`state/\` dir to exist, which requires \`state.rs\` to be deleted in the SAME PR via the absorption move).

## Architecture-guard CI

The \`architecture-guard\` workflow added in PR #48 already handles missing layer dirs gracefully (\`if [ ! -d ... ]; then exit 0\`). With this PR, the guard becomes meaningful for \`ops/\` and \`runtime/\` immediately.

## Test plan

- [x] \`cargo check -p shipper\` passes
- [x] No code changes — only new files (\`mod.rs\` stubs + \`CLAUDE.md\`)
- [x] Architecture-guard CI passes (still trivially, since \`ops/\` and \`runtime/\` have no \`use crate::\` imports yet)

## Stacking

This PR is independent of #48 (plan doc + CI workflow) and can merge in either order. Phase 2 absorption PRs will branch off main after this lands.