### PR TITLE
ci: fix pre-existing coverage and nextest failures

### DIFF
--- a/crates/shipper-cli/tests/e2e_expanded.rs
+++ b/crates/shipper-cli/tests/e2e_expanded.rs
@@ -113,7 +113,21 @@ fn normalize_stderr(raw: &str) -> String {
     // Also strip common GitHub Actions workspace prefixes.
     let mut normalized = stripped
         .replace("/home/runner/work/shipper/shipper/", "")
-        .replace("../", "");
+        .replace('\\', "/");
+
+    // Iteratively strip leading `../` components and any residual `..`
+    // fragments that remain after absolute-path replacement. Cargo reports
+    // paths relative to CWD in some CI environments, which yields prefixes
+    // like `../../../tmp/...`. The tempdir replacement performed by the
+    // caller can leave a stray `..` behind (e.g. `..<TMPDIR>/foo`); strip
+    // it so snapshots are stable across platforms.
+    loop {
+        let before = normalized.clone();
+        normalized = normalized.replace("../", "").replace("..<", "<");
+        if normalized == before {
+            break;
+        }
+    }
 
     normalized = normalized
         .replace("\r\n", "\n")

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__publish_invalid_manifest_content.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__publish_invalid_manifest_content.snap
@@ -6,7 +6,7 @@ Error: failed to execute cargo metadata
 
 Caused by:
     `cargo metadata` exited with an error: error: key with no value, expected `=`
-     --> <TMPDIR>\Cargo.toml:1:6
+     --> <TMPDIR>/Cargo.toml:1:6
       |
     1 | this is not valid toml {{{{
       |      ^

--- a/crates/shipper-storage/src/lib.rs
+++ b/crates/shipper-storage/src/lib.rs
@@ -293,8 +293,25 @@ impl StorageBackend for FileStorage {
                 .with_context(|| format!("failed to create directory: {}", parent.display()))?;
         }
 
-        // Write to a temp file first, then rename for atomicity
-        let tmp_path = full_path.with_extension("tmp");
+        // Write to a unique temp file first, then rename for atomicity.
+        // The temp filename must be unique per-call so concurrent writes to
+        // the same destination do not race: with a shared temp name, one
+        // thread's rename can move the file away before another thread's
+        // rename runs, causing spurious ENOENT.
+        let tid = std::thread::current().id();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos())
+            .unwrap_or(0);
+        let pid = std::process::id();
+        let tmp_name = format!(
+            "{}.{pid}.{tid:?}.{nanos}.tmp",
+            full_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("shipper-storage")
+        );
+        let tmp_path = full_path.with_file_name(tmp_name);
         std::fs::write(&tmp_path, data)
             .with_context(|| format!("failed to write file: {}", tmp_path.display()))?;
 
@@ -773,10 +790,16 @@ mod tests {
 
         storage.write("atomic.txt", b"content").expect("write");
 
-        let tmp_path = td.path().join("atomic.tmp");
+        // No files with a `.tmp` extension should remain after successful write.
+        let leftover: Vec<_> = std::fs::read_dir(td.path())
+            .expect("read_dir")
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().map(|x| x == "tmp").unwrap_or(false))
+            .collect();
         assert!(
-            !tmp_path.exists(),
-            ".tmp file should not remain after successful write"
+            leftover.is_empty(),
+            ".tmp file should not remain after successful write: {leftover:?}"
         );
         assert!(td.path().join("atomic.txt").exists());
     }
@@ -1061,13 +1084,13 @@ mod tests {
         let td = tempdir().expect("tempdir");
         let storage = FileStorage::new(td.path().to_path_buf());
 
-        // Simulate a stale .tmp from a prior crash
+        // Simulate a stale .tmp from a prior crash. Writes now use a unique
+        // temp name per-call, so they do not collide with (and do not rely
+        // on cleaning up) any pre-existing stale temp file from a prior run.
         std::fs::write(td.path().join("state.tmp"), b"stale").unwrap();
 
         storage.write("state.json", b"fresh").expect("write");
         assert_eq!(storage.read("state.json").unwrap(), b"fresh");
-        // .tmp for "state.json" is "state.tmp" — it should be gone after rename
-        assert!(!td.path().join("state.tmp").exists());
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix two distinct pre-existing failures that keep CI red on `main` and block every open decrating PR (#48-#58). These failures exist independently of any code change — they fail on doc-only PRs too.

## Root cause analysis

### 1. `Coverage (llvm-cov)` — snapshot mismatch on Linux

Failing test: `publish_invalid_manifest_content_snapshot` in `crates/shipper-cli/tests/e2e_expanded.rs`.

On GitHub's Ubuntu runners, `cargo metadata` reports the invalid manifest using a path *relative* to the workspace CWD (`/home/runner/work/shipper/shipper/`), producing something like:

```
--> ../../../tmp/.tmpXXX/Cargo.toml:1:6
```

The test's tempdir replacement (`/tmp/.tmpXXX` → `<TMPDIR>`) consumed the leading `/`, leaving `../../..<TMPDIR>/...`. The old single-pass `.replace("../", "")` could only strip the first two `../`, leaving behind `..<TMPDIR>/Cargo.toml` — which did not match the snapshot (`<TMPDIR>\Cargo.toml`, committed from a Windows-side run).

### 2. `Tests (nextest)` on ubuntu-latest / macos-latest — concurrency race

Failing test: `tests::concurrent_reads_and_writes_same_file` in `crates/shipper-storage/src/lib.rs` (already `#[cfg_attr(target_os = "windows", ignore)]`).

Error:
```
write: failed to rename file to: /tmp/.tmpXXX/shared.txt
Caused by: No such file or directory (os error 2)
```

`FileStorage::write` built its scratch tmp path with `full_path.with_extension("tmp")`, so every concurrent write to `shared.txt` reused the single path `shared.tmp`. The interleaving

```
T1: write(shared.tmp)
T2: write(shared.tmp)   // overwrites
T1: rename(shared.tmp → shared.txt)  // removes tmp
T2: rename(shared.tmp → shared.txt)  // ENOENT
```

is a legitimate bug, not a test artifact — concurrent callers of the public `write` API can race on macOS/Linux (Windows's rename-into-existing semantics masked it).

## Fixes

### `crates/shipper-cli/tests/e2e_expanded.rs`
`normalize_stderr` now:
- converts backslashes to forward slashes so path separators are platform-independent in snapshots; and
- iteratively strips `../` prefixes and residual `..<TMPDIR>` fragments until stable.

### `crates/shipper-cli/tests/snapshots/e2e_expanded__publish_invalid_manifest_content.snap`
Committed snapshot updated to the canonical forward-slash form (`<TMPDIR>/Cargo.toml`).

### `crates/shipper-storage/src/lib.rs`
Each `write` call builds a unique scratch filename from `pid + thread id + subsecond nanos`, so concurrent writes never collide on the tmp path. Two local tests that asserted the old fixed `.tmp` name were adapted to the more general invariant ("no `.tmp` extension files remain after a successful write"); `atomic_write_overwrites_stale_tmp_from_prior_crash` now only asserts the new write succeeds (the new impl intentionally does not clobber unrelated stale `.tmp` files).

## Validation

Locally on Windows:
- `cargo test -p shipper-storage -- --include-ignored` → **93 lib + 33 integration + 1 doctest pass**, including `concurrent_reads_and_writes_same_file` which can now be un-`#[cfg_attr(..., ignore)]`'d in a follow-up (kept ignored on Windows for this minimal PR).
- `cargo test -p shipper-cli --test e2e_expanded` → **126/126 pass**.
- `cargo fmt --all -- --check` clean.
- `cargo clippy -p shipper-storage -p shipper-cli --all-targets --all-features -- -D warnings` clean.

Coverage-job-specific validation (`cargo llvm-cov`) is deferred to CI since it requires the coverage tool.

## Impact

Unblocks green CI for the decrating PR queue (#48-#58) and restores `main` to a publishable state.

## Test plan

- [ ] `Coverage (llvm-cov)` job turns green
- [ ] `Tests (nextest) (ubuntu-latest)` turns green
- [ ] `Tests (nextest) (macos-latest)` turns green
- [ ] `Tests (nextest) (windows-latest)` remains green
- [ ] All other CI jobs remain green