### PR TITLE
fix(engine/parallel): restore imports after PR #64 absorption drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2278,6 +2278,7 @@ dependencies = [
  "base64",
  "cargo_metadata",
  "chrono",
+ "dirs",
  "gethostname",
  "hex",
  "hmac 0.13.0",
@@ -2292,12 +2293,10 @@ dependencies = [
  "serde_with",
  "serial_test",
  "sha2 0.11.0",
- "shipper-auth",
  "shipper-cargo",
  "shipper-cargo-failure",
  "shipper-chunking",
  "shipper-config",
- "shipper-config-runtime",
  "shipper-duration",
  "shipper-encrypt",
  "shipper-environment",
@@ -2305,18 +2304,14 @@ dependencies = [
  "shipper-execution-core",
  "shipper-git",
  "shipper-levels",
- "shipper-lock",
  "shipper-output-sanitizer",
  "shipper-plan",
- "shipper-policy",
- "shipper-process",
  "shipper-registry",
  "shipper-retry",
  "shipper-schema",
  "shipper-sparse-index",
  "shipper-state",
  "shipper-storage",
- "shipper-store",
  "shipper-types",
  "shipper-webhook",
  "temp-env",
@@ -2325,21 +2320,7 @@ dependencies = [
  "tiny_http",
  "tokio",
  "toml",
-]
-
-[[package]]
-name = "shipper-auth"
-version = "0.3.0-rc.1"
-dependencies = [
- "anyhow",
- "dirs",
- "insta",
- "proptest",
- "serde",
- "serde_json",
- "temp-env",
- "tempfile",
- "toml",
+ "which",
 ]
 
 [[package]]
@@ -2414,18 +2395,6 @@ dependencies = [
  "shipper-types",
  "shipper-webhook",
  "tempfile",
- "toml",
-]
-
-[[package]]
-name = "shipper-config-runtime"
-version = "0.3.0-rc.1"
-dependencies = [
- "insta",
- "proptest",
- "shipper-config",
- "shipper-retry",
- "shipper-types",
  "toml",
 ]
 
@@ -2526,20 +2495,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shipper-lock"
-version = "0.3.0-rc.1"
-dependencies = [
- "anyhow",
- "chrono",
- "gethostname",
- "insta",
- "proptest",
- "serde",
- "serde_json",
- "tempfile",
-]
-
-[[package]]
 name = "shipper-output-sanitizer"
 version = "0.3.0-rc.1"
 dependencies = [
@@ -2567,32 +2522,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shipper-policy"
-version = "0.3.0-rc.1"
-dependencies = [
- "insta",
- "proptest",
- "serde",
- "shipper-retry",
- "shipper-types",
-]
-
-[[package]]
-name = "shipper-process"
-version = "0.3.0-rc.1"
-dependencies = [
- "anyhow",
- "humantime",
- "insta",
- "proptest",
- "serde",
- "serde_json",
- "temp-env",
- "tempfile",
- "which",
-]
-
-[[package]]
 name = "shipper-progress"
 version = "0.3.0-rc.1"
 dependencies = [
@@ -2606,12 +2535,15 @@ name = "shipper-registry"
 version = "0.3.0-rc.1"
 dependencies = [
  "anyhow",
+ "chrono",
  "insta",
  "proptest",
+ "rand 0.10.1",
  "reqwest",
  "serde",
  "serde_json",
  "shipper-sparse-index",
+ "shipper-types",
  "tempfile",
  "tiny_http",
 ]
@@ -2673,23 +2605,6 @@ dependencies = [
  "serde",
  "serde_json",
  "temp-env",
- "tempfile",
-]
-
-[[package]]
-name = "shipper-store"
-version = "0.3.0-rc.1"
-dependencies = [
- "anyhow",
- "chrono",
- "insta",
- "proptest",
- "serde",
- "serde_json",
- "shipper-events",
- "shipper-schema",
- "shipper-state",
- "shipper-types",
  "tempfile",
 ]
 

--- a/crates/shipper/src/engine/parallel/mod.rs
+++ b/crates/shipper/src/engine/parallel/mod.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 
 use shipper_events as events;
 use shipper_plan::PlannedWorkspace;
-use shipper_registry::RegistryClient;
+use shipper_registry::HttpRegistryClient as RegistryClient;
 use shipper_types::{
     ExecutionResult, ExecutionState, PackageEvidence, PackageReceipt, PackageState, RuntimeOptions,
 };
@@ -74,7 +74,7 @@ pub fn run_publish_parallel(
     reporter: &mut dyn crate::engine::Reporter,
 ) -> Result<Vec<PackageReceipt>> {
     let api_base = reg.registry().api_base.trim_end_matches('/');
-    let reg_inner = shipper_registry::RegistryClient::new(api_base);
+    let reg_inner = shipper_registry::HttpRegistryClient::new(api_base);
     let ws_inner = shipper_plan::PlannedWorkspace {
         workspace_root: ws.workspace_root.clone(),
         plan: ws.plan.clone(),

--- a/crates/shipper/src/engine/parallel/policy.rs
+++ b/crates/shipper/src/engine/parallel/policy.rs
@@ -5,14 +5,14 @@
 
 use shipper_types::RuntimeOptions;
 
-pub(super) fn policy_effects(opts: &RuntimeOptions) -> shipper_policy::PolicyEffects {
+pub(super) fn policy_effects(opts: &RuntimeOptions) -> crate::runtime::policy::PolicyEffects {
     let policy = match opts.policy {
-        shipper_types::PublishPolicy::Safe => shipper_policy::PolicyKind::Safe,
-        shipper_types::PublishPolicy::Balanced => shipper_policy::PolicyKind::Balanced,
-        shipper_types::PublishPolicy::Fast => shipper_policy::PolicyKind::Fast,
+        shipper_types::PublishPolicy::Safe => crate::runtime::policy::PolicyKind::Safe,
+        shipper_types::PublishPolicy::Balanced => crate::runtime::policy::PolicyKind::Balanced,
+        shipper_types::PublishPolicy::Fast => crate::runtime::policy::PolicyKind::Fast,
     };
 
-    shipper_policy::evaluate(
+    crate::runtime::policy::evaluate(
         policy,
         opts.no_verify,
         opts.skip_ownership_check,

--- a/crates/shipper/src/engine/parallel/publish.rs
+++ b/crates/shipper/src/engine/parallel/publish.rs
@@ -17,7 +17,7 @@ use shipper_cargo as cargo;
 use shipper_events as events;
 use shipper_execution_core::{backoff_delay, classify_cargo_failure, pkg_key, update_state_locked};
 use shipper_plan::PlannedWorkspace;
-use shipper_registry::RegistryClient;
+use shipper_registry::HttpRegistryClient as RegistryClient;
 use shipper_state as state;
 use shipper_types::{
     AttemptEvidence, ErrorClass, EventType, ExecutionState, PackageEvidence, PackageReceipt,

--- a/crates/shipper/src/engine/parallel/readiness.rs
+++ b/crates/shipper/src/engine/parallel/readiness.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use chrono::Utc;
 
-use shipper_registry::RegistryClient;
+use shipper_registry::HttpRegistryClient as RegistryClient;
 use shipper_types::{ReadinessConfig, ReadinessEvidence, ReadinessMethod};
 
 /// Check readiness visibility with exponential backoff and optional sparse-index fallback.

--- a/crates/shipper/src/engine/parallel/tests.rs
+++ b/crates/shipper/src/engine/parallel/tests.rs
@@ -16,7 +16,7 @@ use super::*;
 use shipper_events as events;
 use shipper_execution_core::{pkg_key, update_state_locked};
 use shipper_plan::PlannedWorkspace;
-use shipper_registry::RegistryClient;
+use shipper_registry::HttpRegistryClient as RegistryClient;
 use shipper_types::{
     ErrorClass, ExecutionState, PackageEvidence, PackageProgress, PackageReceipt, PackageState,
     PlannedPackage, PublishLevel, ReadinessConfig, Registry, ReleasePlan, RuntimeOptions,


### PR DESCRIPTION
## Summary

PR #64 merged with stale imports that assumed the pre-absorption `shipper_policy` crate and the pre-split `shipper_registry::RegistryClient` API. After merge, `cargo check -p shipper` on main fails with `E0433` (unresolved `shipper_policy`) and `E0599` (missing `base_url` / `fetch_sparse_index_file`).

Two drift corrections:

- `engine/parallel/policy.rs`: `shipper_policy::*` -> `crate::runtime::policy::*` (policy was absorbed in main before PR #64's branch).
- `engine/parallel/{mod,publish,readiness,tests}.rs`: `shipper_registry::RegistryClient` -> `shipper_registry::HttpRegistryClient as RegistryClient`. The parallel engine operates on a bare base-URL and calls `base_url()` / `fetch_sparse_index_file()`, which now live on `HttpRegistryClient`. The full Registry-aware client in `shipper_registry::RegistryClient` takes a `Registry` struct and returns `Result<Self>`, which is not what this call path needs.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test -p shipper --lib engine::parallel` — 65 tests pass