### PR TITLE
decrating: Phase 7 — path+version deps + workspace.dependencies + default-members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,9 @@ members = [
   "crates/shipper-sparse-index",
   "crates/shipper-cargo-failure",
   "crates/shipper-webhook",
-    "crates/shipper-output-sanitizer",
+  "crates/shipper-output-sanitizer",
 ]
+default-members = ["crates/shipper-cli", "crates/shipper"]
 exclude = ["fuzz"]
 resolver = "3"
 
@@ -26,6 +27,21 @@ rust-version = "1.92"
 unsafe_code = "forbid"
 
 [workspace.dependencies]
+# Intra-workspace crates (path + version for publish-readiness).
+shipper = { path = "crates/shipper", version = "0.3.0-rc.1" }
+shipper-cli = { path = "crates/shipper-cli", version = "0.3.0-rc.1" }
+shipper-config = { path = "crates/shipper-config", version = "0.3.0-rc.1" }
+shipper-types = { path = "crates/shipper-types", version = "0.3.0-rc.1" }
+shipper-duration = { path = "crates/shipper-duration", version = "0.3.0-rc.1" }
+shipper-retry = { path = "crates/shipper-retry", version = "0.3.0-rc.1" }
+shipper-encrypt = { path = "crates/shipper-encrypt", version = "0.3.0-rc.1" }
+shipper-webhook = { path = "crates/shipper-webhook", version = "0.3.0-rc.1" }
+shipper-registry = { path = "crates/shipper-registry", version = "0.3.0-rc.1" }
+shipper-sparse-index = { path = "crates/shipper-sparse-index", version = "0.3.0-rc.1" }
+shipper-cargo-failure = { path = "crates/shipper-cargo-failure", version = "0.3.0-rc.1" }
+shipper-output-sanitizer = { path = "crates/shipper-output-sanitizer", version = "0.3.0-rc.1" }
+
+# External crates.
 serde = { version = "1.0.228", features = ["derive"] }
 proptest = "1.11.0"
 insta = { version = "1.47.2", features = ["yaml"] }

--- a/crates/shipper-cli/Cargo.toml
+++ b/crates/shipper-cli/Cargo.toml
@@ -17,8 +17,8 @@ name = "shipper"
 path = "src/main.rs"
 
 [dependencies]
-shipper = { path = "../shipper", version = "0.3.0-rc.1" }
-shipper-duration = { path = "../shipper-duration" }
+shipper.workspace = true
+shipper-duration.workspace = true
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"

--- a/crates/shipper-config/Cargo.toml
+++ b/crates/shipper-config/Cargo.toml
@@ -15,10 +15,10 @@ serde.workspace = true
 anyhow = "1.0"
 toml = "1.0"
 serde_with = "3.17.0"
-shipper-types = { path = "../shipper-types" }
-shipper-encrypt = { path = "../shipper-encrypt" }
-shipper-webhook = { path = "../shipper-webhook" }
-shipper-retry = { path = "../shipper-retry" }
+shipper-types.workspace = true
+shipper-encrypt.workspace = true
+shipper-webhook.workspace = true
+shipper-retry.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/shipper-registry/Cargo.toml
+++ b/crates/shipper-registry/Cargo.toml
@@ -17,8 +17,8 @@ serde_json = "1.0"
 reqwest = { version = "0.13", features = ["blocking", "json", "rustls"] }
 chrono = { version = "0.4", features = ["serde"] }
 rand = { version = "0.10", features = ["std"] }
-shipper-sparse-index = { path = "../shipper-sparse-index" }
-shipper-types = { path = "../shipper-types" }
+shipper-sparse-index.workspace = true
+shipper-types.workspace = true
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/shipper-types/Cargo.toml
+++ b/crates/shipper-types/Cargo.toml
@@ -15,10 +15,10 @@ serde.workspace = true
 anyhow = "1.0"
 chrono = { version = "0.4.44", features = ["serde"] }
 serde_with = "3.17.0"
-shipper-encrypt = { path = "../shipper-encrypt" }
-shipper-webhook = { path = "../shipper-webhook" }
-shipper-retry = { path = "../shipper-retry" }
-shipper-duration = { path = "../shipper-duration" }
+shipper-encrypt.workspace = true
+shipper-webhook.workspace = true
+shipper-retry.workspace = true
+shipper-duration.workspace = true
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/crates/shipper/Cargo.toml
+++ b/crates/shipper/Cargo.toml
@@ -14,16 +14,16 @@ categories = ["development-tools", "development-tools::build-utils"]
 
 [dependencies]
 # Workspace microcrates
-shipper-retry = { path = "../shipper-retry" }
-shipper-encrypt = { path = "../shipper-encrypt" }
-shipper-registry = { path = "../shipper-registry" }
-shipper-webhook = { path = "../shipper-webhook" }
-shipper-types = { path = "../shipper-types" }
-shipper-config = { path = "../shipper-config" }
-shipper-duration = { path = "../shipper-duration" }
-shipper-cargo-failure = { path = "../shipper-cargo-failure" }
-shipper-sparse-index = { path = "../shipper-sparse-index" }
-shipper-output-sanitizer = { path = "../shipper-output-sanitizer" }
+shipper-retry.workspace = true
+shipper-encrypt.workspace = true
+shipper-registry.workspace = true
+shipper-webhook.workspace = true
+shipper-types.workspace = true
+shipper-config.workspace = true
+shipper-duration.workspace = true
+shipper-cargo-failure.workspace = true
+shipper-sparse-index.workspace = true
+shipper-output-sanitizer.workspace = true
 
 anyhow = "1.0.102"
 thiserror = "2.0.18"


### PR DESCRIPTION
## Summary

Phase 7 of the Shipper decrating effort. Converts the workspace to publish-shaped form so every crate can actually be packaged and published.

### Changes

- **Root `Cargo.toml`**: Adds `[workspace.dependencies]` with all 12 intra-workspace crates declared as `path + version = "0.3.0-rc.1"`. Adds `default-members = ["crates/shipper-cli", "crates/shipper"]` so root-level `cargo build` / `cargo test` target the two product crates. Also normalizes the stray indentation on `shipper-output-sanitizer`.
- **Each member `Cargo.toml`** (`shipper`, `shipper-cli`, `shipper-config`, `shipper-types`, `shipper-registry`): all sibling deps now use `dep.workspace = true` instead of `{ path = "../foo" }`.

### Why

Cargo rule: published crates cannot have `path`-only dependencies. Before this change, `cargo package --no-verify -p shipper-types` failed with:

> all dependencies must have a version requirement specified when packaging.
> dependency `shipper-duration` does not specify a version

After this change, `cargo package --list` succeeds for every public crate.

### Validation

- **Before**: 21 path-only intra-workspace deps across 5 crates (`shipper`, `shipper-cli`, `shipper-config`, `shipper-types`, `shipper-registry`).
- **After**: 0 path-only intra-workspace deps.
- `cargo check --workspace --all-targets` clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- `cargo fmt --all -- --check` clean.
- `cargo package --list -p <crate>` exits 0 for all 12 crates.

Per `docs/decrating-plan.md` §6 Phase 7.

## Test plan

- [ ] CI: workspace check, clippy, fmt, tests all green
- [ ] Manual: `cargo package --list` succeeds for every publishable crate
- [ ] Manual: root-level `cargo build` only builds `shipper` + `shipper-cli` (default-members)