### PR TITLE
decrating: dogfood Shipper for the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,14 @@
 # Release workflow for shipper
-# Creates GitHub releases with binaries for multiple platforms
-# and publishes to crates.io
+#
+# Dogfoods Shipper itself: the crates.io publish train is driven by
+# `shipper plan` -> `shipper preflight` -> `shipper publish`, with
+# `shipper resume` available for recovery. The binary-artifact + GitHub
+# Release steps are only finalized AFTER crates.io publishes succeed.
+#
+# Triggers:
+#   - push of a `v*.*.*` tag  -> full release (build + publish + release)
+#   - workflow_dispatch "rehearse" -> plan + preflight dry-run only
+#   - workflow_dispatch "resume"   -> download .shipper/ artifact and resume
 
 name: Release
 
@@ -8,6 +16,24 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Release mode'
+        required: true
+        default: 'rehearse'
+        type: choice
+        options:
+          - rehearse
+          - resume
+      ref:
+        description: 'Git ref to check out (tag/branch/SHA). Defaults to the workflow ref.'
+        required: false
+        default: ''
+      artifact_run_id:
+        description: 'For resume mode: workflow run ID to download the .shipper artifact from.'
+        required: false
+        default: ''
 
 env:
   CARGO_TERM_COLOR: always
@@ -16,8 +42,13 @@ permissions:
   contents: write
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Build per-platform release binaries. These are published as GitHub Release
+  # assets AFTER crates.io publish succeeds. (On tag pushes only.)
+  # ---------------------------------------------------------------------------
   build-binaries:
     name: Build ${{ matrix.target }}
+    if: github.event_name == 'push'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -35,7 +66,6 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             archive: zip
-
     steps:
       - uses: actions/checkout@v6
 
@@ -55,7 +85,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.target }}-release-
 
       - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }} -p shipper-cli
 
       - name: Package binary (Unix)
         if: matrix.os != 'windows-latest'
@@ -76,36 +106,77 @@ jobs:
         with:
           name: shipper-${{ matrix.target }}
           path: shipper-${{ matrix.target }}.*
-          retention-days: 1
+          retention-days: 7
 
-  create-release:
-    name: Create GitHub Release
+  # ---------------------------------------------------------------------------
+  # MSRV sanity check gates the publish train. The published crates declare
+  # rust-version = 1.92; the publish job should not run if MSRV is broken.
+  # ---------------------------------------------------------------------------
+  msrv-gate:
+    name: MSRV gate (1.92)
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    needs: build-binaries
     steps:
       - uses: actions/checkout@v6
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@v8
+      - name: Install Rust (MSRV)
+        uses: dtolnay/rust-toolchain@stable
         with:
-          path: artifacts
-
-      - name: Display structure of downloaded files
-        run: ls -la artifacts/
-
-      - name: Create release
-        uses: softprops/action-gh-release@v2
+          toolchain: 1.92.0
+      - name: Cache Cargo
+        uses: actions/cache@v5
         with:
-          files: artifacts/**/*
-          generate_release_notes: true
-          draft: false
-          prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-alpha') || contains(github.ref, '-beta') }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-msrv-
+      - name: Check with MSRV
+        run: cargo check --workspace
 
+  # ---------------------------------------------------------------------------
+  # The dogfood publish train.
+  #
+  # Execution order:
+  #   1.  Build shipper-cli (release profile) and install it to PATH.
+  #   2.  `shipper plan`  — persist plan to .shipper/, also dump JSON to
+  #       .shipper/plan.json for artifact review.
+  #   3.  Upload .shipper/ as an artifact BEFORE preflight runs (belt-and-
+  #       braces: even if the runner dies mid-preflight the plan is preserved).
+  #   4.  `shipper preflight` — git-clean check, registry reachability,
+  #       version-not-taken check, workspace dry-run build.
+  #   5.  `shipper publish` — the real train. Shipper's engine handles retry
+  #       with exponential backoff on HTTP 429, post-publish readiness
+  #       verification via sparse-index or API before advancing, and
+  #       .shipper/state.json persistence after every step.
+  #   6.  Final post-publish verification: `cargo search` each published crate
+  #       at the tag's version to confirm registry visibility from a fresh
+  #       resolver.
+  #   7.  Upload the final .shipper/ state as an artifact regardless of outcome.
+  #
+  # Rate-limit handling for the first-publish train (12 brand-new crates):
+  #   crates.io allows a 5-crate burst, then 1 new crate per 10 minutes.
+  #   `shipper publish` handles this natively:
+  #     - --policy safe enables post-publish readiness verification before the
+  #       next crate starts, so rate-limit 429s surface as retryable backoff
+  #       rather than cascade failures.
+  #     - --max-attempts 12 + --max-delay 15m gives the retry loop enough
+  #       budget to ride through the 10-minute-between-new-crate limit.
+  #     - --verify-timeout 10m and --readiness-timeout 15m allow for sparse-
+  #       index propagation.
+  #   If the runner's 6-hour job timeout is insufficient for the ~80 minute
+  #   train, the run can time out; in that case trigger the `resume`
+  #   workflow_dispatch with this run's ID to pick up from .shipper/state.json.
+  # ---------------------------------------------------------------------------
   publish-crates-io:
-    name: Publish to crates.io
+    name: Publish to crates.io (via shipper)
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    needs: create-release
+    needs: [msrv-gate]
     environment: release
+    timeout-minutes: 180
+    outputs:
+      publish_succeeded: ${{ steps.publish.outcome == 'success' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -119,24 +190,313 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-publish-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-publish-
+          key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-publish-
 
-      # NOTE: Publish order will be finalized in Phase 8 of the decrating plan.
-      # During Phase 2 absorption, only the still-public crates (shipper and
-      # shipper-cli) are published from here; individual absorption PRs remove
-      # any references to crates being folded in. Full topological publish
-      # order for remaining public crates (shipper-types,
-      # shipper-duration, shipper-retry, shipper-encrypt, shipper-webhook,
-      # shipper-registry, shipper-sparse-index, shipper-cargo-failure,
-      # shipper-output-sanitizer, shipper-config, plus shipper and shipper-cli)
-      # will be codified once the module layout settles.
-      - name: Publish shipper crate
-        run: cargo publish -p shipper --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        continue-on-error: true  # May already be published
+      # --- Step 1: build and install shipper-cli ----------------------------
+      - name: Build shipper-cli (release)
+        run: cargo build --release -p shipper-cli
 
-      - name: Wait for index update
-        run: sleep 30
+      - name: Install shipper to PATH
+        run: |
+          sudo install -m 0755 target/release/shipper /usr/local/bin/shipper
+          shipper --version
 
-      - name: Publish shipper-cli crate
-        run: cargo publish -p shipper-cli --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      # --- Step 2: plan -----------------------------------------------------
+      - name: shipper plan
+        run: |
+          mkdir -p .shipper
+          shipper plan \
+            --registry crates-io \
+            --state-dir .shipper \
+            --format json \
+            | tee .shipper/plan.txt
+
+      # --- Step 3: upload plan artifact BEFORE anything destructive --------
+      - name: Upload .shipper/ (plan stage)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: shipper-state-plan
+          path: .shipper/
+          retention-days: 30
+
+      # --- Step 4: preflight ------------------------------------------------
+      - name: shipper preflight
+        id: preflight
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          shipper preflight \
+            --registry crates-io \
+            --state-dir .shipper \
+            --policy safe
+
+      - name: Upload .shipper/ (preflight stage)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: shipper-state-preflight
+          path: .shipper/
+          retention-days: 30
+
+      - name: Fail fast if preflight failed
+        if: steps.preflight.outcome != 'success'
+        run: |
+          echo "::error::shipper preflight failed — aborting before publish."
+          echo "Download the shipper-state-preflight artifact for details."
+          exit 1
+
+      # --- Step 5: publish --------------------------------------------------
+      # `shipper publish` is idempotent: if .shipper/state.json already has
+      # published entries, it skips them and resumes. That means a re-run of
+      # this job (or the dedicated `resume` job below) naturally picks up.
+      - name: shipper publish
+        id: publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          shipper publish \
+            --registry crates-io \
+            --state-dir .shipper \
+            --policy safe \
+            --verify-mode package \
+            --readiness-method both \
+            --readiness-timeout 15m \
+            --verify-timeout 10m \
+            --max-attempts 12 \
+            --base-delay 10s \
+            --max-delay 15m \
+            --retry-strategy exponential
+
+      # --- Step 6: final verification --------------------------------------
+      - name: Verify crates on crates.io
+        if: steps.publish.outcome == 'success'
+        run: |
+          # Ask cargo to resolve each published crate from a fresh cache.
+          set -euo pipefail
+          CRATES=(
+            shipper-duration
+            shipper-retry
+            shipper-encrypt
+            shipper-output-sanitizer
+            shipper-cargo-failure
+            shipper-sparse-index
+            shipper-webhook
+            shipper-types
+            shipper-registry
+            shipper-config
+            shipper
+            shipper-cli
+          )
+          for c in "${CRATES[@]}"; do
+            echo "::group::cargo search $c"
+            cargo search "$c" --limit 1
+            echo "::endgroup::"
+          done
+
+      # --- Step 7: always persist final .shipper/ state --------------------
+      - name: Upload .shipper/ (final state)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: shipper-state-final
+          path: .shipper/
+          retention-days: 90
+
+  # ---------------------------------------------------------------------------
+  # Create the GitHub Release. ONLY runs after crates.io publish succeeds.
+  # Attaches platform binaries + final .shipper/ state as evidence.
+  # ---------------------------------------------------------------------------
+  create-release:
+    name: Create GitHub Release
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: [build-binaries, publish-crates-io]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download binary artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+          pattern: shipper-*
+
+      - name: Download final shipper state
+        uses: actions/download-artifact@v8
+        with:
+          name: shipper-state-final
+          path: artifacts/shipper-state-final
+
+      - name: Bundle final shipper state
+        run: |
+          cd artifacts
+          tar czvf shipper-release-state.tar.gz shipper-state-final
+          rm -rf shipper-state-final
+
+      - name: List release assets
+        run: ls -la artifacts/ artifacts/*/ 2>/dev/null || true
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            artifacts/**/shipper-*.tar.gz
+            artifacts/**/shipper-*.zip
+            artifacts/shipper-release-state.tar.gz
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-alpha') || contains(github.ref, '-beta') }}
+
+  # ---------------------------------------------------------------------------
+  # Rehearsal: plan + preflight only. No publishing.
+  #
+  # Use this before cutting a tag. It surfaces missing metadata, dirty trees,
+  # ownership issues, and missing registry tokens in a safe sandbox. Output
+  # artifact is the .shipper/ directory showing exactly what would happen.
+  # ---------------------------------------------------------------------------
+  release-rehearse:
+    name: Release rehearse (plan + preflight dry-run)
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'rehearse'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-rehearse-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-rehearse-
+
+      - name: Build shipper-cli (release)
+        run: cargo build --release -p shipper-cli
+
+      - name: Install shipper to PATH
+        run: |
+          sudo install -m 0755 target/release/shipper /usr/local/bin/shipper
+          shipper --version
+
+      - name: shipper plan (verbose)
+        run: |
+          mkdir -p .shipper
+          shipper plan \
+            --registry crates-io \
+            --state-dir .shipper \
+            --format json \
+            --verbose \
+            | tee .shipper/plan.txt
+
+      # Preflight against crates.io without publishing. A token isn't strictly
+      # required here (ownership checks are best-effort), but supply it if the
+      # `release` environment is available for a deeper check.
+      - name: shipper preflight (dry-run)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          shipper preflight \
+            --registry crates-io \
+            --state-dir .shipper \
+            --policy safe \
+            --skip-ownership-check
+
+      - name: Upload rehearsal state
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: shipper-rehearse-${{ github.run_id }}
+          path: .shipper/
+          retention-days: 30
+
+  # ---------------------------------------------------------------------------
+  # Resume a previously-interrupted publish run.
+  #
+  # Inputs:
+  #   mode            = "resume"
+  #   artifact_run_id = the workflow run ID that uploaded shipper-state-final
+  #                     or shipper-state-preflight from a failed attempt
+  #   ref             = the exact tag/SHA that failed (MUST match the plan ID
+  #                     in state.json or shipper will refuse to resume)
+  #
+  # The plan-ID check is intentional: if the workspace has changed between
+  # runs, resume aborts. This is the guardrail that keeps partial publishes
+  # from desyncing with the ledger.
+  # ---------------------------------------------------------------------------
+  release-resume:
+    name: Release resume
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'resume'
+    runs-on: ubuntu-latest
+    environment: release
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-publish-
+
+      - name: Build shipper-cli (release)
+        run: cargo build --release -p shipper-cli
+
+      - name: Install shipper to PATH
+        run: |
+          sudo install -m 0755 target/release/shipper /usr/local/bin/shipper
+          shipper --version
+
+      - name: Download prior .shipper/ state
+        uses: actions/download-artifact@v8
+        with:
+          name: shipper-state-final
+          path: .shipper/
+          run-id: ${{ github.event.inputs.artifact_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Inspect recovered state
+        run: |
+          ls -la .shipper/
+          [ -f .shipper/state.json ] || { echo "::error::.shipper/state.json missing from recovered artifact"; exit 1; }
+
+      - name: shipper resume
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          shipper resume \
+            --registry crates-io \
+            --state-dir .shipper \
+            --policy safe \
+            --verify-mode package \
+            --readiness-method both \
+            --readiness-timeout 15m \
+            --verify-timeout 10m \
+            --max-attempts 12 \
+            --base-delay 10s \
+            --max-delay 15m \
+            --retry-strategy exponential
+
+      - name: Upload .shipper/ (post-resume state)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: shipper-state-resume-${{ github.run_id }}
+          path: .shipper/
+          retention-days: 90

--- a/RELEASE_CHECKLIST_v0.3.0.md
+++ b/RELEASE_CHECKLIST_v0.3.0.md
@@ -26,49 +26,56 @@
 
 ## Release Execution
 
-- [ ] Commit all changes with message "release: v0.3.0-rc.1"
-- [ ] Tag the commit: `git tag -a v0.3.0-rc.1 -m "Release v0.3.0-rc.1"`
-- [ ] Push commit and tag: `git push origin main --tags`
-- [ ] Publish to crates.io (dry-run first):
-  ```bash
-  # Layer 0 — no workspace dependencies
-  # (shipper-schema folded into shipper-types::schema in Phase 6)
-  cargo publish -p shipper-duration --dry-run
-  cargo publish -p shipper-retry --dry-run
-  cargo publish -p shipper-output-sanitizer --dry-run
-  cargo publish -p shipper-sparse-index --dry-run
-  cargo publish -p shipper-encrypt --dry-run
-  cargo publish -p shipper-cargo-failure --dry-run
-  cargo publish -p shipper-webhook --dry-run
-  cargo publish -p shipper-git --dry-run
+The release is driven by `.github/workflows/release.yml`, which dogfoods
+Shipper itself (`shipper plan` → `shipper preflight` → `shipper publish`).
 
-  # Layer 1 — depend only on Layer 0
-  cargo publish -p shipper-types --dry-run
-  cargo publish -p shipper-cargo --dry-run
-  cargo publish -p shipper-registry --dry-run
+### Pre-tag rehearsal
 
-  # Layer 2
-  cargo publish -p shipper-config --dry-run
+- [ ] Trigger the `release-rehearse` workflow_dispatch job from the ref that
+      is about to be tagged. It runs `shipper plan --verbose` and
+      `shipper preflight` with no publishing.
+- [ ] Download the `shipper-rehearse-<run_id>` artifact and review
+      `.shipper/plan.txt`. Confirm the topological order matches
+      `docs/release-v0.3.0-rc.1-manifest.md`:
+      `shipper-duration, shipper-retry, shipper-encrypt,
+      shipper-output-sanitizer, shipper-cargo-failure, shipper-sparse-index,
+      shipper-webhook, shipper-types, shipper-registry, shipper-config,
+      shipper, shipper-cli`.
 
-  # Layer 5 (engine-parallel was absorbed into shipper::engine::parallel)
+### Tag & release
 
-  # Layer 6
-  cargo publish -p shipper --dry-run
+- [ ] Commit all changes with message `release: v0.3.0-rc.1`.
+- [ ] Tag the commit: `git tag -a v0.3.0-rc.1 -m "Release v0.3.0-rc.1"`.
+- [ ] Push commit and tag: `git push origin main --tags`.
+- [ ] The `v*.*.*` tag push triggers `.github/workflows/release.yml`:
+    - `msrv-gate` + `build-binaries` run in parallel.
+    - `publish-crates-io` runs after `msrv-gate`:
+      `shipper plan` → upload `.shipper/` → `shipper preflight`
+      → upload `.shipper/` → `shipper publish` → `cargo search` verification
+      → upload final `.shipper/` state.
+    - `create-release` runs only after `publish-crates-io` succeeds and
+      attaches platform binaries + the final `.shipper/` state tarball.
+- [ ] Do **not** run `cargo publish` by hand. The engine handles rate-limit
+      backoff, readiness checks, and state persistence; manual publishes
+      desync the ledger.
 
-  # Layer 7
-  cargo publish -p shipper-cli --dry-run
-  ```
+### If the publish train is interrupted
 
-  _Removed during decrating: `shipper-lock`, `shipper-process`,
-  `shipper-levels`, `shipper-chunking`, `shipper-policy`,
-  `shipper-config-runtime`, `shipper-plan`, `shipper-store`,
-  `shipper-events`, `shipper-state`, `shipper-execution-core`,
-  `shipper-environment`, `shipper-progress`, `shipper-storage`._
-  The remaining order is provisional and will be finalized in Phase 8 once
-  in-flight absorptions settle.
+- [ ] Identify the failed run ID (GitHub Actions UI).
+- [ ] Confirm the `shipper-state-final` (or `shipper-state-preflight`)
+      artifact was uploaded by that run.
+- [ ] Trigger the `release-resume` workflow_dispatch job with:
+    - `mode = resume`
+    - `ref = <the tag that failed>` (MUST be identical; plan-ID check
+       guards against workspace drift)
+    - `artifact_run_id = <failed run ID>`
+- [ ] Shipper skips already-published crates and continues from the first
+      pending/failed entry.
 
 ## Post-Release
 
-- [ ] Create GitHub release with release notes
-- [ ] Verify `cargo install shipper-cli` works
-- [ ] Monitor for issues
+- [ ] GitHub Release is created automatically after publish succeeds; verify
+      it lists all platform binaries and the `shipper-release-state.tar.gz`
+      evidence bundle.
+- [ ] Verify `cargo install shipper-cli` works from the published crate.
+- [ ] Monitor for issues.

--- a/docs/decrating-plan.md
+++ b/docs/decrating-plan.md
@@ -670,6 +670,14 @@ Each member's `Cargo.toml` uses `dep.workspace = true`.
 - Run `cargo publish --dry-run` for all 13 crates in topo order
 - Update `RELEASE_CHECKLIST_v0.3.0.md` with the new publish sequence
 - Cargo 1.90 multi-package publish is available (`cargo publish --workspace`) but is **non-atomic** — partial publish failures must be recoverable. Document the recovery procedure in the release checklist.
+- **Release workflow (done):** `.github/workflows/release.yml` now dogfoods
+  Shipper itself. The tag-push path runs `shipper plan` → `shipper preflight`
+  → `shipper publish` instead of raw `cargo publish`, persists `.shipper/`
+  as an artifact at every stage, and gates the GitHub Release on crates.io
+  publish success. Two `workflow_dispatch` jobs complement the main path:
+  `release-rehearse` (plan + preflight only — use before tagging) and
+  `release-resume` (downloads a prior `.shipper/` artifact and runs
+  `shipper resume`). See §6 of `release-v0.3.0-rc.1-manifest.md`.
 
 **Topological publish order:**
 ```

--- a/docs/release-v0.3.0-rc.1-manifest.md
+++ b/docs/release-v0.3.0-rc.1-manifest.md
@@ -177,6 +177,69 @@ resume rules apply:
 4. `Ambiguous` errors (upload may have succeeded) require an out-of-band check
    of the registry before deciding to retry or skip.
 
+## How the workflow executes the train
+
+The release workflow at `.github/workflows/release.yml` dogfoods Shipper:
+the crates.io publish train is driven by `shipper plan` → `shipper preflight`
+→ `shipper publish`, not raw `cargo publish`.
+
+### `publish-crates-io` job (tag push, `v*.*.*`)
+
+1. Install Rust stable and cache `~/.cargo`.
+2. `cargo build --release -p shipper-cli`, then install `target/release/shipper`
+   to `/usr/local/bin/shipper` (the binary that will drive the train is the
+   one we just built from this tag).
+3. `shipper plan --registry crates-io --state-dir .shipper --format json`
+   writes the plan summary into `.shipper/plan.txt` (and the engine also
+   persists its internal plan artefacts under `.shipper/`).
+4. `.shipper/` is uploaded as an artifact (`shipper-state-plan`) **before**
+   preflight runs, so the plan survives catastrophic job failure.
+5. `shipper preflight --registry crates-io --state-dir .shipper --policy safe`
+   runs git-clean / registry-reachability / version-not-taken checks.
+   `.shipper/` is uploaded again (`shipper-state-preflight`). On failure the
+   workflow fails fast before any publish happens.
+6. `shipper publish` runs the real train with these flags:
+    - `--policy safe`  (verify + strict)
+    - `--verify-mode package`  (per-crate post-publish verify)
+    - `--readiness-method both`  (sparse-index **and** API)
+    - `--readiness-timeout 15m`, `--verify-timeout 10m`
+    - `--max-attempts 12`, `--base-delay 10s`, `--max-delay 15m`,
+      `--retry-strategy exponential`
+7. On success, `cargo search <crate>` is run against every published crate
+   to confirm visibility from a fresh resolver.
+8. `.shipper/` is uploaded a final time as `shipper-state-final` (retention
+   90 days). The GitHub Release is then created, attaching platform binaries
+   plus a tarball of the final `.shipper/` state as publish evidence.
+
+### Rate-limit handling for the first-publish train
+
+crates.io allows a 5-crate burst for new crates and then 1 new crate per
+10 minutes (see §"Rate-limit plan" above). The workflow does **not** hard-code
+tier batching or sleeps; the shipper engine handles rate-limit 429s as
+retryable errors with exponential backoff, and the post-publish readiness
+check (both sparse-index **and** API because `--readiness-method both`) blocks
+the next publish until the previous crate is visible. `--max-delay 15m` gives
+the backoff loop enough headroom to wait out the 10-minute new-crate window.
+The whole train completes in roughly 70–90 minutes inside the single runner.
+
+If the job hits the 180-minute timeout (or the runner dies), the `.shipper/`
+artifact is still uploaded and the dedicated `release-resume` workflow_dispatch
+job downloads it and runs `shipper resume`.
+
+### `release-rehearse` (workflow_dispatch)
+
+Runs `shipper plan --verbose` + `shipper preflight --skip-ownership-check`
+against the requested ref and uploads `.shipper/`. Use this before tagging
+to verify nothing is broken. No publishing happens.
+
+### `release-resume` (workflow_dispatch)
+
+Accepts an `artifact_run_id` input, downloads the prior `shipper-state-final`
+artifact into `.shipper/`, and runs `shipper resume` with the same policy
+flags as `publish`. The plan-ID check in `shipper resume` is the guardrail:
+if the workspace changed between runs, resume aborts rather than produce
+a desynced ledger.
+
 ## Known deferred work
 
 - **Non-leaf `cargo publish --dry-run`**: will not pass until Tier 1 is live on


### PR DESCRIPTION
## Summary

Rewrites `.github/workflows/release.yml` to drive the crates.io publish
train with Shipper itself (`shipper plan` -> `shipper preflight` ->
`shipper publish`) instead of raw `cargo publish`. Closes the credibility
gap between the product's promise and the repo's release path, and is the
Phase 8 follow-up called out in `docs/release-v0.3.0-rc.1-manifest.md` and
`docs/decrating-plan.md`.

### Workflow shape

Triggered on `v*.*.*` tag push:

- `msrv-gate` — `cargo check --workspace` against Rust 1.92 before anything publishes.
- `build-binaries` — cross-platform binary artifacts (Linux/macOS/Windows). Uploaded but NOT attached to a release yet.
- `publish-crates-io` — builds and installs `shipper`, then runs:
  1. `shipper plan --format json` (upload `.shipper/` as `shipper-state-plan`)
  2. `shipper preflight` (upload `.shipper/` as `shipper-state-preflight`; fail fast on error)
  3. `shipper publish` with `--policy safe --verify-mode package --readiness-method both --readiness-timeout 15m --verify-timeout 10m --max-attempts 12 --base-delay 10s --max-delay 15m --retry-strategy exponential`
  4. `cargo search` each of the 12 crates to confirm registry visibility
  5. Upload final `.shipper/` as `shipper-state-final` (90-day retention) — always, even on failure.
- `create-release` — runs ONLY after `publish-crates-io` succeeds. Creates the GitHub Release and attaches the platform binaries plus a tarball of the final `.shipper/` state as publish evidence.

Triggered via `workflow_dispatch`:

- `release-rehearse` — plan + preflight against a chosen ref, no publishing. Use this before cutting a tag.
- `release-resume` — downloads a prior failed run's `.shipper/` artifact (`artifact_run_id` input) and runs `shipper resume`. The plan-ID check inside shipper is the guardrail against workspace drift between runs.

### First-publish rate-limit handling

12 brand-new crates; crates.io allows a 5-crate burst, then 1 new crate per 10 minutes. The workflow does NOT hard-code tier batching or sleeps — `shipper publish`'s retry loop handles HTTP 429 as retryable with exponential backoff (`--max-delay 15m` is larger than the 10-minute window), and `--readiness-method both` blocks the next publish on sparse-index AND API visibility of the previous one. Full train ~70-90 minutes; job timeout is 180 minutes; on overrun, `release-resume` picks up from `.shipper/state.json`.

### Preserved vs rewritten

- Preserved: `build-binaries` job and platform matrix, softprops/action-gh-release usage, environment-gated `release` job.
- Rewritten: the `publish-crates-io` job now drives shipper, not `cargo publish`. The `create-release` job now depends on successful publish and bundles the `.shipper/` state as release evidence.
- Other workflows (`ci.yml`, `architecture-guard.yml`, `fuzz.yml`, `mutation.yml`) are untouched.

### Docs updates

- `RELEASE_CHECKLIST_v0.3.0.md` — replaces the hand-rolled `cargo publish --dry-run` list with workflow-driven steps (rehearse first, then tag, then resume if needed).
- `docs/release-v0.3.0-rc.1-manifest.md` — new section explaining how the workflow executes the train.
- `docs/decrating-plan.md` — Phase 8 note marking the release-workflow work complete.

## Test plan

- [ ] `cargo check --workspace` passes locally (verified)
- [ ] `cargo build -p shipper-cli --release` produces a working binary (verified)
- [ ] YAML is well-formed (verified with `python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] All `uses:` action pins match the rest of the repo (verified — same versions as `ci.yml`)
- [ ] Trigger `release-rehearse` via workflow_dispatch against this branch (manual step after merge) and confirm plan + preflight complete against crates.io without publishing
- [ ] Dry-run the first real release (e.g. v0.3.0-rc.1) end-to-end only once confidence is high; resume via the `release-resume` job if interrupted