### PR TITLE
release: fix rustls-webpki audit blocker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,9 +1995,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
- Bump `rustls-webpki` from 0.103.11 to 0.103.12 via `cargo update -p rustls-webpki`.
- Resolves RUSTSEC-2026-0098 and RUSTSEC-2026-0099 flagged through the `reqwest` / `rustls-platform-verifier` / `rustls` chain.
- Lockfile-only change; no manifest edits required (the advisories had a patched floor already reachable through the existing dependency constraints).

## Verification
- `cargo tree -i rustls-webpki` — confirmed single path through `rustls v0.23.38`.
- `cargo audit` — exit 0 (previously red on the two advisories above).
- `cargo check --workspace` — clean, 12 crates compiled.

## Test plan
- [ ] Security audit CI lane green
- [ ] `cargo check --workspace` green in CI
- [ ] No downstream breakage in nextest / fuzz lanes attributable to this bump

This is PR 1 in the release-hardening sprint (audit → nextest → fuzz → package-truth → rehearsal → publish).