### PR TITLE
ci: stabilize nextest across platforms

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,7 +9,7 @@ fail-fast = false
 retries = { count = 2, backoff = "exponential", delay = "1s" }
 
 # JUnit output for CI reporting
-junit = { path = "target/nextest/ci/junit.xml", report-successful = true }
+junit = { path = "target/nextest/ci/junit.xml" }
 
 # Timeout for individual tests
 test-threads = "num-cpus"

--- a/crates/shipper-cli/tests/e2e_expanded.rs
+++ b/crates/shipper-cli/tests/e2e_expanded.rs
@@ -33,6 +33,8 @@ fn normalize_output(raw: &str) -> String {
         .map(|line| {
             if line.starts_with("plan_id: ") || line.starts_with("Plan ID: ") {
                 "plan_id: <PLAN_ID>".to_string()
+            } else if line.starts_with("Timestamp: ") {
+                "Timestamp: <TIMESTAMP>".to_string()
             } else if line.starts_with("workspace_root: ") {
                 "workspace_root: <WORKSPACE_ROOT>".to_string()
             } else if line.starts_with("state_dir: ") {
@@ -2204,7 +2206,9 @@ fn preflight_allow_dirty_snapshot() {
     let td = tempdir().expect("tempdir");
     create_workspace(td.path());
 
-    let registry = spawn_registry_not_found(1);
+    // preflight issues two registry calls per crate: version_exists and
+    // check_new_crate (which calls crate_exists under the hood).
+    let registry = spawn_registry_not_found(2);
 
     let output = shipper_cmd()
         .arg("--manifest-path")

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__preflight_allow_dirty.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__preflight_allow_dirty.snap
@@ -3,8 +3,34 @@ source: crates/shipper-cli/tests/e2e_expanded.rs
 expression: normalize_output(&normalize_stderr(&combined))
 ---
 --- stdout ---
+Preflight Report
+===============
+
+plan_id: <PLAN_ID>
+Timestamp: <TIMESTAMP>
+
+Token Detected: ✓
+
+Finishability: NOT PROVEN
+
+Packages:
+┌─────────────────────┬─────────┬──────────┬──────────┬───────────────┬─────────────┬─────────────┐
+│ Package             │ Version │ Published│ New Crate │ Auth Type     │ Ownership   │ Dry-run     │
+├─────────────────────┼─────────┼──────────┼──────────┼───────────────┼─────────────┼─────────────┤
+│ demo                │ 0.1.0   │ No       │ Yes      │ Token         │ ✗           │ ✓           │
+└─────────────────────┴─────────┴──────────┴──────────┴───────────────┴─────────────┴─────────────┘
+
+Summary:
+  Total packages: 1
+  Already published: 0
+  New crates: 1
+  Ownership verified: 0
+  Dry-run passed: 1
+
+What to do next:
+-----------------
+⚠ Some checks could not be verified. You can still publish, but may encounter permission issues. Use `shipper publish --policy fast` to proceed.
 --- stderr ---
 [info] initializing registry client...
 [info] running workspace dry-run verification...
 [info] checking packages against registry...
-Error: unexpected status while checking crate existence: failed to send request to registry


### PR DESCRIPTION
## Summary
- **Root cause**: `preflight_allow_dirty_snapshot` used `spawn_registry_not_found(1)`, but preflight issues two registry calls per crate (`version_exists` + `check_new_crate`). The second call timed out against the exhausted mock, producing a reqwest error that embedded a non-deterministic port and "operation timed out" text — flaking on Linux/macOS/Windows.
- **Fix**: bump the mock to 2 expected requests so preflight completes cleanly. Regenerate the snapshot against the actual preflight report.
- Drop the unknown `profile.ci.junit.report-successful` key from `.config/nextest.toml` — it was the source of the `ignoring unknown configuration key` warning in every CI log.
- Add `Timestamp:` normalization to `e2e_expanded::normalize_output` (matching the helper already in `cli_e2e`) so the preflight report snapshot stays stable across runs.

## Verification
- `cargo nextest show-config` — no longer warns about the unknown key.
- `cargo test -p shipper-cli --test e2e_expanded` — 126/126 pass locally (previously 125 pass, 1 fail).
- New snapshot is deterministic: timestamps and plan IDs are normalized, no reqwest timeout text.

## Test plan
- [ ] Tests (nextest) (ubuntu-latest) green
- [ ] Tests (nextest) (windows-latest) green
- [ ] Tests (nextest) (macos-latest) green
- [ ] No remaining nextest config warnings in CI logs

This is PR 2 in the release-hardening sprint (audit → nextest → fuzz → package-truth → rehearsal → publish).