### PR TITLE
ci: repair fuzz smoke after decrating absorptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,6 @@ jobs:
           cargo fuzz run load_state --target x86_64-unknown-linux-gnu -- -max_total_time=60
           cargo fuzz run resolve_token --target x86_64-unknown-linux-gnu -- -max_total_time=60
           cargo fuzz run schema_version --target x86_64-unknown-linux-gnu -- -max_total_time=60
-          cargo fuzz run policy_effects --target x86_64-unknown-linux-gnu -- -max_total_time=60
           cargo fuzz run release_levels --target x86_64-unknown-linux-gnu -- -max_total_time=60
           cargo fuzz run redact_output --target x86_64-unknown-linux-gnu -- -max_total_time=60
 

--- a/fuzz/fuzz_targets/engine_parallel_chunks.rs
+++ b/fuzz/fuzz_targets/engine_parallel_chunks.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use shipper_engine_parallel::chunk_by_max_concurrent;
+use shipper::engine::parallel::chunk_by_max_concurrent;
 
 fuzz_target!(|data: (u8, Vec<u8>)| {
     let (max_hint, payload) = data;
@@ -13,7 +13,7 @@ fuzz_target!(|data: (u8, Vec<u8>)| {
         .map(|(index, byte)| format!("{index}:{byte}"))
         .collect();
 
-    let chunks = chunk_by_max_concurrent(&items, max_concurrent);
+    let chunks: Vec<Vec<String>> = chunk_by_max_concurrent(&items, max_concurrent);
 
     assert!(chunks.iter().all(|chunk| chunk.len() <= max_concurrent));
     assert_eq!(

--- a/fuzz/fuzz_targets/load_state.rs
+++ b/fuzz/fuzz_targets/load_state.rs
@@ -3,7 +3,7 @@
 use std::fs;
 
 use libfuzzer_sys::fuzz_target;
-use shipper::state::load_state;
+use shipper::state::execution_state::load_state;
 use tempfile::tempdir;
 
 fuzz_target!(|data: &[u8]| {


### PR DESCRIPTION
## Summary
Two fuzz targets still referenced the pre-decrating module layout, and the Fuzz Smoke CI step still invoked a target that no longer exists:

- `fuzz_targets/load_state.rs` imported `shipper::state::load_state`, but the function moved to `shipper::state::execution_state::load_state` when the state module was split into sub-modules.
- `fuzz_targets/engine_parallel_chunks.rs` imported the standalone `shipper_engine_parallel` crate, which was absorbed into `shipper::engine::parallel`. Added the explicit `Vec<Vec<String>>` return-type annotation that the absorbed signature now requires for the fuzz input to type-check.
- `.github/workflows/ci.yml` still ran `cargo fuzz run policy_effects`, but that target was deleted when `shipper-policy` was absorbed into `shipper::runtime::policy` (54dbadf). Dropped the stale invocation.

## Verification
- `cargo check --bins` against a cleaned `fuzz/target/` — all 29 fuzz binaries compile from scratch in ~36s.
- Windows can't link the libfuzzer sanitizer runtime; real exercise happens in CI.

## Test plan
- [ ] Fuzz Smoke (PR) lane green
- [ ] No "fuzz target not found: policy_effects" failure

This is PR 3 in the release-hardening sprint (audit → nextest → fuzz → package-truth → rehearsal → publish).