### PR TITLE
ci: fix broken intra-doc links (Documentation lane)

### DIFF
--- a/crates/shipper-types/src/lib.rs
+++ b/crates/shipper-types/src/lib.rs
@@ -33,7 +33,6 @@ pub use shipper_duration::{deserialize_duration, serialize_duration};
 use shipper_encrypt::EncryptionConfig as EncryptionSettings;
 use shipper_webhook::WebhookConfig;
 
-/// Storage backend configuration types (was `shipper-storage`, split).
 pub mod storage;
 
 /// Schema version parsing and compatibility validation for shipper state files.

--- a/crates/shipper/src/git.rs
+++ b/crates/shipper/src/git.rs
@@ -1,6 +1,6 @@
 //! Public façade for git operations.
 //!
-//! Re-exports the absorbed [`crate::ops::git`] module's public API so external
+//! Re-exports the absorbed `crate::ops::git` module's public API so external
 //! consumers (notably `shipper-cli`) keep using `shipper::git::*` after the
 //! `shipper-git` microcrate absorption.
 //!

--- a/crates/shipper/src/ops/auth/mod.rs
+++ b/crates/shipper/src/ops/auth/mod.rs
@@ -53,13 +53,12 @@ pub use resolver::{
 
 /// Resolve the authentication token for a registry.
 ///
-/// Wraps the lower-level [`resolver::resolve_token`] (which returns an
-/// [`AuthInfo`] diagnostic record) and adds:
+/// Wraps the lower-level resolver (which returns an [`AuthInfo`] diagnostic
+/// record) and adds:
 ///
 /// - Whitespace trimming; empty/whitespace-only tokens are treated as absent.
 /// - Fallback to the legacy `$CARGO_HOME/credentials` filename (in addition
-///   to `credentials.toml`) with crates.io alias handling
-///   ([`credentials::token_from_credentials_file_extended`]).
+///   to `credentials.toml`) with crates.io alias handling.
 ///
 /// This is the canonical public-crate API used by `engine.rs` and the CLI.
 pub fn resolve_token(registry_name: &str) -> Result<Option<String>> {

--- a/crates/shipper/src/ops/git/bin_override.rs
+++ b/crates/shipper/src/ops/git/bin_override.rs
@@ -1,11 +1,11 @@
 //! `SHIPPER_GIT_BIN` override support.
 //!
 //! These helpers replicate the commit/branch/tag/dirty queries that live in
-//! [`super::context`] but honor the `SHIPPER_GIT_BIN` environment variable so
+//! `super::context` but honor the `SHIPPER_GIT_BIN` environment variable so
 //! tests (and sandboxed environments) can substitute a fake git binary.
 //!
-//! The override is set up by [`collect_git_context`] (in [`super::mod`]) and
-//! [`local_is_git_clean`] (used by [`super::cleanliness::is_git_clean`]).
+//! The override is set up by `collect_git_context` (in `super`) and by
+//! `local_is_git_clean` (used by `super::cleanliness::is_git_clean`).
 //!
 //! Invariants:
 //!

--- a/crates/shipper/src/ops/git/cleanliness.rs
+++ b/crates/shipper/src/ops/git/cleanliness.rs
@@ -26,7 +26,7 @@ use super::bin_override;
 /// Check whether the git working tree is clean (no uncommitted changes).
 ///
 /// When `SHIPPER_GIT_BIN` is set, routes through the override implementation in
-/// [`super::bin_override::local_is_git_clean`]. Otherwise uses the default git
+/// `super::bin_override::local_is_git_clean`. Otherwise uses the default git
 /// invocation. In both cases, an untracked file counts as "dirty".
 pub fn is_git_clean(repo_root: &Path) -> Result<bool> {
     if let Ok(git_program) = env::var("SHIPPER_GIT_BIN") {

--- a/crates/shipper/src/ops/git/mod.rs
+++ b/crates/shipper/src/ops/git/mod.rs
@@ -31,8 +31,8 @@ use crate::types::GitContext;
 /// Returns `None` when the CWD is not inside a git repository.
 ///
 /// When `SHIPPER_GIT_BIN` is set, every sub-query is routed through the
-/// [`bin_override`] helpers — there is no silent fallback to the default
-/// `git` binary. Without the override, queries go through [`context`].
+/// `bin_override` helpers — there is no silent fallback to the default
+/// `git` binary. Without the override, queries go through `context`.
 pub fn collect_git_context() -> Option<GitContext> {
     let repo_root = std::env::current_dir().ok()?;
 


### PR DESCRIPTION
## Summary
Two classes of rustdoc failures were blocking the Documentation lane:

1. **Unresolved links in `shipper-types`.** The outer `///` doc comment on `pub mod storage` was being merged with the module's inner `//!` docs. Rustdoc then tried to resolve the inner block's `[CloudStorageConfig]` and `[StorageType]` links in the **parent crate scope**, where those items aren't visible. Removing the redundant outer doc lets the module's own `//!` docs resolve the links correctly.
2. **Private intra-doc links from public items.** Several facades in `shipper::git` and `shipper::auth` linked to `pub(crate)` items (`[super::bin_override::local_is_git_clean]`, `[credentials::token_from_credentials_file_extended]`, `[crate::ops::git]`, etc.). Those only resolved because CI runs with `--document-private-items`, and rustdoc warns under `-D warnings`. Downgraded them to plain backtick code spans so the prose reads the same but rustdoc is happy either way.

## Verification
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --no-deps --document-private-items` — exit 0 (was exit 101 with 9 errors).
- No public API changes — docs-only.

## Test plan
- [ ] Documentation lane green

This is PR 3b in the release-hardening sprint — a docs-only companion to PRs 1/2/3.