### PR TITLE
ci: architecture-guard .rs filter + drop stale fuzz target

### DIFF
--- a/.github/workflows/architecture-guard.yml
+++ b/.github/workflows/architecture-guard.yml
@@ -33,7 +33,7 @@ jobs:
             echo "ops/ layer not yet scaffolded — skipping (this is expected before Phase 3)."
             exit 0
           fi
-          if grep -rE 'use crate::(engine|plan|state|runtime)::' crates/shipper/src/ops/; then
+          if grep -rE --include='*.rs' 'use crate::(engine|plan|state|runtime)::' crates/shipper/src/ops/; then
             echo "::error::ops/ layer must not import from engine, plan, state, or runtime"
             exit 1
           fi
@@ -45,7 +45,7 @@ jobs:
             echo "runtime/ layer not yet scaffolded — skipping."
             exit 0
           fi
-          if grep -rE 'use crate::(engine|plan|state)::' crates/shipper/src/runtime/; then
+          if grep -rE --include='*.rs' 'use crate::(engine|plan|state)::' crates/shipper/src/runtime/; then
             echo "::error::runtime/ layer must not import from engine, plan, or state"
             exit 1
           fi
@@ -57,7 +57,7 @@ jobs:
             echo "state/ layer not yet scaffolded — skipping."
             exit 0
           fi
-          if grep -rE 'use crate::(engine|plan)::' crates/shipper/src/state/; then
+          if grep -rE --include='*.rs' 'use crate::(engine|plan)::' crates/shipper/src/state/; then
             echo "::error::state/ layer must not import from engine or plan"
             exit 1
           fi
@@ -69,7 +69,7 @@ jobs:
             echo "plan/ layer not yet scaffolded — skipping."
             exit 0
           fi
-          if grep -rE 'use crate::engine::' crates/shipper/src/plan/; then
+          if grep -rE --include='*.rs' 'use crate::engine::' crates/shipper/src/plan/; then
             echo "::error::plan/ layer must not import from engine"
             exit 1
           fi

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -38,7 +38,6 @@ jobs:
         target:
           - load_state
           - resolve_token
-          - policy_effects
           - encrypt_decrypt
           - retry_strategy
           - types_serialization


### PR DESCRIPTION
## Summary
Two latent CI hygiene issues that would keep main red or fail post-launch:

### 1. `architecture-guard` false positive on `CLAUDE.md`
The job uses `grep -rE` to assert lower layers don't import upward. Without `--include='*.rs'`, grep also scans the per-layer `CLAUDE.md` docs — which list the forbidden import patterns (`use crate::engine::...`, etc.) as examples of what NOT to do. That's enough to flip the guard red on every push.

Fix: add `--include='*.rs'` to each of the four layer greps (`ops`, `runtime`, `state`, `plan`).

### 2. Nightly `fuzz.yml` still lists deleted `policy_effects` target
Same class of stale reference as the PR `Fuzz Smoke` lane fixed in #83: `policy_effects` was deleted when `shipper-policy` was absorbed into `shipper::runtime::policy` (commit `54dbadf`). The nightly fuzz matrix still references it and would fail every scheduled run at 3 AM UTC.

## Verification
Per-layer local greps on `main` with the new filter:

| Layer | Pattern | Result |
|-------|---------|--------|
| `ops`     | `use crate::(engine\|plan\|state\|runtime)::` | clean |
| `runtime` | `use crate::(engine\|plan\|state)::`          | clean |
| `state`   | `use crate::(engine\|plan)::`                  | clean |
| `plan`    | `use crate::engine::`                           | clean |

## Test plan
- [ ] `architecture-guard / forbid upward layer imports` green on this PR
- [ ] Next scheduled `Fuzz` workflow run doesn't fail on missing `policy_effects`