### PR TITLE
ci: isolate CARGO_HOME in preflight snapshot test

### DIFF
--- a/crates/shipper-cli/tests/e2e_expanded.rs
+++ b/crates/shipper-cli/tests/e2e_expanded.rs
@@ -2210,6 +2210,11 @@ fn preflight_allow_dirty_snapshot() {
     // check_new_crate (which calls crate_exists under the hood).
     let registry = spawn_registry_not_found(2);
 
+    // Isolate CARGO_HOME to the empty tempdir so the token-resolution
+    // fallback (credentials.toml) can't pick up ambient credentials from
+    // the host. Without this, the snapshot varies between developer
+    // machines (which have a real credentials.toml) and CI runners
+    // (which don't), causing a Token Detected: ✓/✗ drift.
     let output = shipper_cmd()
         .arg("--manifest-path")
         .arg(td.path().join("Cargo.toml"))
@@ -2218,6 +2223,7 @@ fn preflight_allow_dirty_snapshot() {
         .arg("--allow-dirty")
         .arg("--skip-ownership-check")
         .arg("preflight")
+        .env("CARGO_HOME", td.path())
         .env_remove("CARGO_REGISTRY_TOKEN")
         .env_remove("CARGO_REGISTRIES_CRATES_IO_TOKEN")
         .output()

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__preflight_allow_dirty.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__preflight_allow_dirty.snap
@@ -9,7 +9,7 @@ Preflight Report
 plan_id: <PLAN_ID>
 Timestamp: <TIMESTAMP>
 
-Token Detected: ✓
+Token Detected: ✗
 
 Finishability: NOT PROVEN
 
@@ -17,7 +17,7 @@ Packages:
 ┌─────────────────────┬─────────┬──────────┬──────────┬───────────────┬─────────────┬─────────────┐
 │ Package             │ Version │ Published│ New Crate │ Auth Type     │ Ownership   │ Dry-run     │
 ├─────────────────────┼─────────┼──────────┼──────────┼───────────────┼─────────────┼─────────────┤
-│ demo                │ 0.1.0   │ No       │ Yes      │ Token         │ ✗           │ ✓           │
+│ demo                │ 0.1.0   │ No       │ Yes      │ -             │ ✗           │ ✓           │
 └─────────────────────┴─────────┴──────────┴──────────┴───────────────┴─────────────┴─────────────┘
 
 Summary:


### PR DESCRIPTION
## Summary
The `preflight_allow_dirty_snapshot` test passed on `nextest` / PR lanes but **failed on the Coverage (llvm-cov) lane**, flipping `main` red even after PR #82 merged.

Root cause is not the test harness — it's the test env setup:

- Shipper's token resolution chain is `CARGO_REGISTRY_TOKEN` → `CARGO_REGISTRIES_<NAME>_TOKEN` → `$CARGO_HOME/credentials.toml`.
- The test removed the first two env vars but said nothing about `CARGO_HOME`.
- On developer machines, `~/.cargo/credentials.toml` exists and contains a real token, so the snapshot was recorded with `Token Detected: ✓` / `Auth Type: Token`.
- On CI runners, that file doesn't exist, so preflight reports `Token Detected: ✗` / `Auth Type: -`. The diff flipped red.

Fix: set `CARGO_HOME` to the test's tempdir so the `credentials.toml` lookup can't find anything. Re-recorded the snapshot under the isolated env — now deterministic regardless of ambient credentials.

## Verification
- `cargo test -p shipper-cli --test e2e_expanded preflight_allow_dirty_snapshot -- --exact` — passes locally with the isolated env.
- Snapshot now shows `Token Detected: ✗` / `Auth Type: -`, matching what every clean CI runner produces.

## Test plan
- [ ] Coverage (llvm-cov) lane green on main after merge
- [ ] Tests (nextest) still green on all three OSes