### PR TITLE
ci: reduce PR proptest cost, add Ubuntu-only full-strength crypto lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,9 @@ jobs:
         env:
           # Keep snapshots from updating in CI
           INSTA_UPDATE: "no"
-          # Keep property tests productive but bounded
-          PROPTEST_CASES: "256"
+          # PR/push: fast-path proptests (Argon2-heavy crypto cases dominate wall clock).
+          # Nightly schedule + manual dispatch: full strength.
+          PROPTEST_CASES: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '256' || '16' }}
 
       - name: Run doc tests
         run: cargo test --workspace --doc
@@ -188,6 +189,11 @@ jobs:
 
       - name: Generate coverage (lcov)
         run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+        env:
+          INSTA_UPDATE: "no"
+          # llvm-cov instrumentation + Argon2 proptests is a bad combination.
+          # Coverage signal does not need max-strength property exploration.
+          PROPTEST_CASES: "16"
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,11 @@ jobs:
         env:
           # Keep snapshots from updating in CI
           INSTA_UPDATE: "no"
-          # PR/push: fast-path proptests (Argon2-heavy crypto cases dominate wall clock).
-          # Nightly schedule + manual dispatch: full strength.
-          PROPTEST_CASES: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '256' || '16' }}
+          # Matrix lane runs reduced proptest intensity on every trigger.
+          # Full-strength crypto proving lives in the `crypto-proptests-heavy`
+          # job below (Ubuntu-only, schedule + push-main + dispatch).
+          PROPTEST_CASES: "16"
+          PROPTEST_MAX_SHRINK_ITERS: "1000"
 
       - name: Run doc tests
         run: cargo test --workspace --doc
@@ -94,6 +96,55 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: junit-${{ matrix.os }}
+          path: target/nextest/ci/junit.xml
+          retention-days: 14
+
+  crypto-proptests-heavy:
+    name: Crypto Proptests (full strength, ubuntu)
+    # Deep crypto proving lane. The PR matrix above runs proptests with
+    # reduced intensity (PROPTEST_CASES=16) so that `shipper-encrypt`'s
+    # Argon2-bound property tests don't dominate wall clock on every PR.
+    # This job restores full-strength coverage on:
+    #   - nightly schedule (0 3 * * *)
+    #   - direct pushes to main
+    #   - manual workflow_dispatch
+    # It intentionally does NOT run on pull_request to keep developer
+    # feedback fast; if you want a specific PR to exercise it, use the
+    # workflow_dispatch trigger on the PR's branch.
+    if: github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - name: Cache Cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-crypto-heavy-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-crypto-heavy-
+
+      - name: Run shipper-encrypt proptests at full strength
+        run: cargo nextest run -p shipper-encrypt --all-features --profile ci
+        env:
+          INSTA_UPDATE: "no"
+          PROPTEST_CASES: "256"
+
+      - name: Upload JUnit
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: junit-crypto-heavy
           path: target/nextest/ci/junit.xml
           retention-days: 14
 


### PR DESCRIPTION
## Summary

Split the `shipper-encrypt` proptest load into two lanes:

- **PR matrix** (`test`, 3 OSes, every trigger): `PROPTEST_CASES=16` + `PROPTEST_MAX_SHRINK_ITERS=1000`. No Argon2 tax on developer round-trips.
- **New `crypto-proptests-heavy` job** (Ubuntu-only): runs just `shipper-encrypt` with `PROPTEST_CASES=256`. Triggers on `schedule` (nightly 03:00 UTC cron), `push` to main, and `workflow_dispatch`. Not on pull_request — opt in per-branch via dispatch if you want to exercise it against a PR.

Also:
- `coverage` job pinned to `PROPTEST_CASES=16` (llvm-cov instrumentation + Argon2 is worst-of-both; coverage signal doesn't need max-strength exploration).

## Why

The Argon2-heavy crypto proptests in `shipper-encrypt` (`derive_key_deterministic_prop`, `decrypt_truncated_ciphertext_always_fails_prop`, `double_encrypt_roundtrip_prop`, `each_encrypt_produces_unique_ciphertext`, etc.) were costing 10–20 min per platform at `PROPTEST_CASES=256` on every PR — paying the same proof three times on every round-trip, without proportional signal.

This PR gives you:
- **fast PR confidence** (three OSes, reduced intensity)
- **deep crypto confidence** (Ubuntu, full strength, on main push + nightly + dispatch)

which is the shape the repo wants at this stage of closeout.

## Scope discipline

- No proptest code changes.
- No nextest.toml change — the stale `profile.ci.junit.report-successful` key is already gone (removed in #82); verified against current main.
- Heavy lane is Ubuntu-only by design: the Rust-level crypto paths we exercise are platform-independent, and triplicating the full-strength run across Ubuntu/Windows/macOS on schedule would cost 30–60 min of cumulative wall time without proportional signal.

## Follow-ups (not this PR)

- Branch protection: if you want `crypto-proptests-heavy` to be a required check on main, configure it in repo settings — the workflow change alone doesn't make it required.

## Test plan

- [ ] This PR's own CI run completes materially faster on the three-OS `test` matrix than recent PRs (#82–#86).
- [ ] `coverage` job wall-clock drops.
- [ ] `crypto-proptests-heavy` does **not** run on this PR (it's pull_request-excluded by design).
- [ ] After merge to main, the next push-to-main run executes `crypto-proptests-heavy` at `PROPTEST_CASES=256` — verify via workflow log.
- [ ] Next nightly cron (0 3 * * *) executes `crypto-proptests-heavy` — verify via workflow log.
- [ ] Manual `workflow_dispatch` on any branch executes `crypto-proptests-heavy` at full strength — verify via workflow log.