### PR TITLE
ci: include .shipper/ hidden dir in release workflow artifact uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,6 +219,7 @@ jobs:
         with:
           name: shipper-state-plan
           path: .shipper/
+          include-hidden-files: true
           retention-days: 30
 
       # --- Step 4: preflight ------------------------------------------------
@@ -238,6 +239,7 @@ jobs:
         with:
           name: shipper-state-preflight
           path: .shipper/
+          include-hidden-files: true
           retention-days: 30
 
       - name: Fail fast if preflight failed
@@ -302,6 +304,7 @@ jobs:
         with:
           name: shipper-state-final
           path: .shipper/
+          include-hidden-files: true
           retention-days: 90
 
   # ---------------------------------------------------------------------------
@@ -415,6 +418,7 @@ jobs:
         with:
           name: shipper-rehearse-${{ github.run_id }}
           path: .shipper/
+          include-hidden-files: true
           retention-days: 30
 
   # ---------------------------------------------------------------------------
@@ -499,4 +503,5 @@ jobs:
         with:
           name: shipper-state-resume-${{ github.run_id }}
           path: .shipper/
+          include-hidden-files: true
           retention-days: 90


### PR DESCRIPTION
## Summary

Adds \`include-hidden-files: true\` to every \`actions/upload-artifact@v7\` step in \`release.yml\` that uploads \`.shipper/\`. Five upload steps affected:

| Step | Used by |
|---|---|
| \`shipper-state-plan\` | \`publish-crates-io\` (pre-publish evidence) |
| \`shipper-state-preflight\` | \`publish-crates-io\` (pre-publish evidence) |
| \`shipper-state-final\` | \`publish-crates-io\` (post-publish evidence) |
| \`shipper-rehearse-<run>\` | \`release-rehearse\` |
| \`shipper-state-resume-<run>\` | \`release-resume\` |

The binary upload at line 104 (\`shipper-\${{ matrix.target }}.*\`) is unaffected — it uploads non-hidden files.

## Root cause

\`actions/upload-artifact@v7\` defaults to \`include-hidden-files: false\`, which causes it to skip any dot-prefixed directory and its contents. \`.shipper/\` is hidden by convention, so every upload from that path silently dropped its contents.

## Observed symptom

Rehearsal run on \`main\` ([#24500573949](https://github.com/EffortlessMetrics/shipper/actions/runs/24500573949)) logged:
\`\`\`
##[warning]No files were found with the provided path: .shipper/.
No artifacts will be uploaded.
\`\`\`

Despite this, the preflight step succeeded functionally — the plan_id matched the local-rehearsal plan_id exactly (\`23ff8f854218ce1fef53dea51d9a0fcfccd87a55281052ea9eb843b6657238a0\`), 12 packages reported, \`Dry-run passed: 12\`. Files were on disk; only the upload filter dropped them.

Reproduced locally: the same \`shipper preflight\` invocation writes \`.shipper/events.jsonl\` (27 events, ~8.5 KB). The CI-vs-local difference is entirely the artifact-upload filter, not the CLI.

## Why this matters before tagging

The \`shipper-state-plan\` and \`shipper-state-preflight\` artifacts upload *before* any crates.io upload happens. If they silently drop their contents:

- A runner death between preflight and publish would leave no recoverable pre-publish evidence.
- A resume-via-artifact-download flow (\`release-resume\`, which pulls \`shipper-state-final\`) would have less state to work with.

\`shipper publish\` itself writes state aggressively, so \`shipper-state-final\` would at least contain state.json and receipt.json even without the fix. But the train is safer with the full evidence chain intact.

## Plan ID stability

This change only touches \`.github/workflows/release.yml\`. Plan ID is derived from workspace package identity + dependency graph, not workflow files. Re-rehearsal from this branch will confirm plan ID still matches \`23ff8f85…7238a0\`.

## Test plan

- [ ] Dispatch \`release.yml mode=rehearse\` against \`ci/fix-rehearse-artifact-upload\`.
- [ ] Confirm \`shipper-rehearse-<run>\` artifact is produced and contains \`plan.txt\` + \`events.jsonl\`.
- [ ] Confirm plan_id in the uploaded plan.txt matches \`23ff8f854218ce1fef53dea51d9a0fcfccd87a55281052ea9eb843b6657238a0\`.