### PR TITLE
docs: align roadmap, add mission/steering docs, Diátaxis reorg, tighten README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,10 +57,20 @@ The core flow is: **plan → preflight → publish → (resume if interrupted)**
 ### State Files
 
 Written to `.shipper/` (configurable via `--state-dir`):
-- `state.json` — resumable execution state (schema-versioned)
-- `receipt.json` — audit receipt with evidence (stdout/stderr, exit codes, git context, environment fingerprint)
-- `events.jsonl` — append-only event log
+- `state.json` — resumable execution state (schema-versioned). **Projection** of events.
+- `receipt.json` — audit receipt with evidence (stdout/stderr, exit codes, git context, environment fingerprint). **Summary** derived at end-of-run.
+- `events.jsonl` — append-only event log. **Authoritative truth.**
 - `lock` — distributed lock preventing concurrent publishes
+
+### Events-as-truth invariant
+
+`events.jsonl` is authoritative; `state.json` is a projection; `receipt.json` is a summary. See [docs/INVARIANTS.md](docs/INVARIANTS.md). When the three disagree, events win — and a drift is a bug. Tooling that needs ground truth should read events; tooling that needs fast "what's done" can read state.
+
+In `state.json`, package status is at `.packages[].state.state`, not `.packages[].status` — common source of misreads.
+
+## Product thesis (nine competencies)
+
+Cargo 1.90 stabilized multi-package workspace publishing. Shipper's value is what Cargo still doesn't do, organized as nine competencies: **Prove, Survive, Reconcile, Narrate, Remediate, Harden, Profile, Integrate, Ergonomics**. See [ROADMAP.md](ROADMAP.md) and master tracking issue [#109](https://github.com/EffortlessMetrics/shipper/issues/109). The biggest open gap is **Reconcile** ([#102](https://github.com/EffortlessMetrics/shipper/issues/102) / [#99](https://github.com/EffortlessMetrics/shipper/issues/99)): when `cargo publish` exits ambiguously, Shipper currently blind-retries instead of reconciling against the registry. Use this thesis as the north star when scoping work.
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Orientation
+
+- [**MISSION.md**](MISSION.md) — north star: mission, vision, audience, beliefs. Read before scoping non-trivial work.
+- [**ROADMAP.md**](ROADMAP.md) — nine-competency thesis, current status, now/next/later sequencing.
+- [**docs/product.md**](docs/product.md) — product overview at a glance.
+- [**docs/structure.md**](docs/structure.md) — repository and crate structure.
+- [**docs/tech.md**](docs/tech.md) — tech stack and conventions.
+- [**docs/INVARIANTS.md**](docs/INVARIANTS.md) — events-as-truth contract.
+
 ## Build & Test Commands
 
 ```bash
@@ -68,9 +77,11 @@ Written to `.shipper/` (configurable via `--state-dir`):
 
 In `state.json`, package status is at `.packages[].state.state`, not `.packages[].status` — common source of misreads.
 
-## Product thesis (nine competencies)
+## Product context
 
-Cargo 1.90 stabilized multi-package workspace publishing. Shipper's value is what Cargo still doesn't do, organized as nine competencies: **Prove, Survive, Reconcile, Narrate, Remediate, Harden, Profile, Integrate, Ergonomics**. See [ROADMAP.md](ROADMAP.md) and master tracking issue [#109](https://github.com/EffortlessMetrics/shipper/issues/109). The biggest open gap is **Reconcile** ([#102](https://github.com/EffortlessMetrics/shipper/issues/102) / [#99](https://github.com/EffortlessMetrics/shipper/issues/99)): when `cargo publish` exits ambiguously, Shipper currently blind-retries instead of reconciling against the registry. Use this thesis as the north star when scoping work.
+[**MISSION.md**](MISSION.md) is the north star — mission, vision, audience, and the nine convictions that produce every design decision. Read it before scoping non-trivial work.
+
+Cargo 1.90 stabilized multi-package workspace publishing. Shipper's value is what Cargo still doesn't do, organized as nine competencies: **Prove, Survive, Reconcile, Narrate, Remediate, Harden, Profile, Integrate, Ergonomics**. See [ROADMAP.md](ROADMAP.md) and master tracking issue [#109](https://github.com/EffortlessMetrics/shipper/issues/109). The biggest open gap is **Reconcile** ([#102](https://github.com/EffortlessMetrics/shipper/issues/102) / [#99](https://github.com/EffortlessMetrics/shipper/issues/99)): when `cargo publish` exits ambiguously, Shipper currently blind-retries instead of reconciling against the registry.
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Orientation
 
 - [**MISSION.md**](MISSION.md) — north star: mission, vision, audience, beliefs. Read before scoping non-trivial work.
-- [**ROADMAP.md**](ROADMAP.md) — nine-competency thesis, current status, now/next/later sequencing.
-- [**docs/product.md**](docs/product.md) — product overview at a glance.
-- [**docs/structure.md**](docs/structure.md) — repository and crate structure.
-- [**docs/tech.md**](docs/tech.md) — tech stack and conventions.
+- [**ROADMAP.md**](ROADMAP.md) — five pillars + nine-competency thesis, current status, now/next/later sequencing.
+- [**docs/README.md**](docs/README.md) — documentation index (Diátaxis: tutorials/how-to/reference/explanation).
+- [**docs/explanation/why-shipper.md**](docs/explanation/why-shipper.md) — the *why*, distilled.
+- [**docs/product.md**](docs/product.md), [**docs/structure.md**](docs/structure.md), [**docs/tech.md**](docs/tech.md) — steering docs.
 - [**docs/INVARIANTS.md**](docs/INVARIANTS.md) — events-as-truth contract.
 
 ## Build & Test Commands

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,7 +5,9 @@
 ## Orientation
 
 - `MISSION.md` — north star: mission, vision, audience, beliefs.
-- `ROADMAP.md` — nine-competency thesis and sequencing.
+- `ROADMAP.md` — five pillars + nine-competency thesis and sequencing.
+- `docs/README.md` — documentation index (Diátaxis: tutorials/how-to/reference/explanation).
+- `docs/explanation/why-shipper.md` — the *why*, distilled.
 - `docs/product.md`, `docs/structure.md`, `docs/tech.md` — product overview, code structure, tech stack.
 - `docs/INVARIANTS.md` — events-as-truth contract.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -2,6 +2,13 @@
 
 `shipper` is a **publishing reliability layer** for Rust workspaces. It is designed to make the process of publishing multiple crates safer, deterministic, and resumable, addressing common real-world failures like partial publishes, CI cancellations, and registry backpressure.
 
+## Orientation
+
+- `MISSION.md` — north star: mission, vision, audience, beliefs.
+- `ROADMAP.md` — nine-competency thesis and sequencing.
+- `docs/product.md`, `docs/structure.md`, `docs/tech.md` — product overview, code structure, tech stack.
+- `docs/INVARIANTS.md` — events-as-truth contract.
+
 ## Project Overview
 
 - **Core Purpose:** Enhances `cargo publish` by adding a reliability layer that handles planning, preflight checks, retries, and state persistence.
@@ -39,6 +46,7 @@
 - **State Management:** Execution state is persisted atomically as JSON. The `plan_id` is used to ensure that resumes match the intended plan.
 - **Events-as-Truth Invariant:** `events.jsonl` is the authoritative source of truth; `state.json` is a projection over events for fast resume; `receipt.json` is a summary at end-of-run. See `docs/INVARIANTS.md`.
 - **Product Thesis:** Shipper's value is organized as nine competencies (Prove, Survive, Reconcile, Narrate, Remediate, Harden, Profile, Integrate, Ergonomics). See `ROADMAP.md` and master tracking issue #109. The biggest open gap is Reconcile (#102 / #99).
+- **North Star:** `MISSION.md` is the canonical mission/vision/beliefs document. Read it before scoping non-trivial work.
 - **Testing Pattern:** 
     - Extensive use of `tempfile` for filesystem isolation.
     - Registry interactions are mocked in tests using a local `tiny_http` server.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -37,6 +37,8 @@
 - **Error Handling:** Uses `anyhow::Result` for flexible error reporting across the library and CLI.
 - **Reporting:** Uses a `Reporter` trait to abstract logging/output, allowing the CLI to provide formatted eprints while keeping the library agnostic.
 - **State Management:** Execution state is persisted atomically as JSON. The `plan_id` is used to ensure that resumes match the intended plan.
+- **Events-as-Truth Invariant:** `events.jsonl` is the authoritative source of truth; `state.json` is a projection over events for fast resume; `receipt.json` is a summary at end-of-run. See `docs/INVARIANTS.md`.
+- **Product Thesis:** Shipper's value is organized as nine competencies (Prove, Survive, Reconcile, Narrate, Remediate, Harden, Profile, Integrate, Ergonomics). See `ROADMAP.md` and master tracking issue #109. The biggest open gap is Reconcile (#102 / #99).
 - **Testing Pattern:** 
     - Extensive use of `tempfile` for filesystem isolation.
     - Registry interactions are mocked in tests using a local `tiny_http` server.

--- a/MISSION.md
+++ b/MISSION.md
@@ -1,0 +1,88 @@
+# Mission, Vision, and What We Believe
+
+This document is Shipper's north star. When the [roadmap](ROADMAP.md) ages or specific issues drift, this is what gets re-read. Everything else descends from here.
+
+## Mission
+
+Shipper makes publishing Rust crates to a registry **safe to start and safe to re-run**. We encode what Cargo doesn't: pre-flight proof, ambiguity reconciliation, mechanical recovery, and operator-grade observability — so a multi-crate workspace publish becomes a boring, auditable operation instead of a manual coordination dance.
+
+## Vision
+
+Five years from now, every Rust workspace maintainer treats `shipper publish` the way they treat `cargo test` — boring, trustworthy, and unsurprising. When releases go wrong, the tool that planned them is the tool that contains them. Trusted Publishing is the default; long-lived tokens are the exception. CI is publishing's natural environment, not its hostile one.
+
+## Audience
+
+Shipper is for workspace maintainers who:
+
+- Publish **multiple interdependent crates** as a coherent release
+- Treat publishing as a **serious, audited operation**
+- Run releases **through CI**, not from a developer laptop
+- Need to **recover correctly** when things go wrong, not heroically
+
+We are explicitly not optimizing for one-shot toy publishes or solo single-crate authors who are well-served by `cargo publish` directly. Their workflow is fine. Ours is what happens when the workflow has consequences.
+
+## What we believe
+
+These convictions produce every design decision. When in doubt, return here.
+
+### 1. Cargo is excellent at packaging and uploading. The workflow around it is where reliability breaks.
+Shipper does not replace cargo. It wraps the operations cargo treats as one-shot into something resumable, observable, and recoverable.
+
+### 2. Publishing is irreversible.
+Once a version is on crates.io, you cannot delete it (yank is containment, not undo). This asymmetry should shape every default. Defaults err toward verifying, logging, and providing evidence — not toward speed. Faster paths are explicit opt-ins.
+
+### 3. CI dies. Networks partition. Runners cancel. Rate limits exist.
+A publishing tool that pretends these don't happen is one that loses data the first time they do. State persists after every step. Resume works without operator heroics.
+
+### 4. Registries can lie about state.
+Cargo's upload-then-poll model means the command can fail while the upload succeeded. Stdout is a hint; the registry itself is the truth. Ambiguity is reconciled against the registry, never blind-retried.
+
+### 5. Operators must trust the tool.
+Trust comes from **legibility** ("what is it doing right now?") and **reconciliation** ("what actually happened?"). Silent retry loops corrode both. Receipts and evidence are how we prove what happened, after the fact, to anyone — including ourselves.
+
+### 6. The engine is a library; the CLI is a frontend.
+Both exist. Neither contains the other. The library does not depend on the CLI. Other frontends — IDP plugins, dashboards, automation — consume the library directly.
+
+### 7. Events are truth. State is projection.
+`events.jsonl` is the authoritative record of what happened. `state.json` is a derived projection over events for resume convenience. `receipt.json` is a summary at end-of-run. When they disagree, events win. See [docs/INVARIANTS.md](docs/INVARIANTS.md).
+
+### 8. Determinism is a feature.
+The same workspace state always produces the same `plan_id`. Plans are reproducible across environments and time. This is the foundation that makes resume safe and audit possible.
+
+### 9. We forbid `unsafe`.
+`unsafe_code = "forbid"` is enforced workspace-wide. A tool whose pitch is safety should not opt out of Rust's.
+
+## What we are not
+
+Shipper is not:
+
+| Not this | Use instead |
+|---|---|
+| A release orchestrator | [cargo-release](https://github.com/crate-ci/cargo-release), [release-plz](https://github.com/MarcoIeni/release-plz) |
+| A version-decision tool | cargo-release / release-plz |
+| A changelog generator | [git-cliff](https://github.com/orhun/git-cliff), release-plz |
+| A git-tag / GitHub-release creator | `gh` CLI, GitHub Actions |
+| A multi-ecosystem publishing tool | Specialized tools per ecosystem |
+| A general-purpose CI framework | GitHub Actions, GitLab CI, etc. |
+
+Rust → crates.io is the focus. Alternative cargo-protocol registries (Cloudsmith, kellnr, self-hosted) are supported as they appear; other ecosystems are out of scope.
+
+## How we measure success
+
+The product thesis — the **nine competencies** in [ROADMAP.md](ROADMAP.md) — is the structured measure. Each competency is graded Done / Partial / Missing against engine behavior. We close gaps in the order set by ROADMAP's *Now / Next / Later*.
+
+A short definition of *good enough for v0.3.0 stable*:
+
+> When an operator can push a tag, walk away for an hour, come back to a complete release with evidence, and have the tool recover automatically when things go wrong — without external monitoring — Shipper has earned the trust its mission claims.
+
+The longer definition lives in [ROADMAP.md](ROADMAP.md) under *Now*.
+
+## How to read this repo
+
+| If you are… | Start here |
+|---|---|
+| A new user | [README.md](README.md) → install, quick start, examples |
+| An operator setting up CI | [docs/release-runbook.md](docs/release-runbook.md), [docs/configuration.md](docs/configuration.md) |
+| A contributor | This document → [ROADMAP.md](ROADMAP.md) → [CONTRIBUTING.md](CONTRIBUTING.md) → an issue from #100–#109 |
+| Auditing receipts or events | [docs/INVARIANTS.md](docs/INVARIANTS.md) |
+| An AI assistant | [CLAUDE.md](CLAUDE.md) or [GEMINI.md](GEMINI.md), then this document |

--- a/MISSION.md
+++ b/MISSION.md
@@ -4,7 +4,13 @@ This document is Shipper's north star. When the [roadmap](ROADMAP.md) ages or sp
 
 ## Mission
 
-Shipper makes publishing Rust crates to a registry **safe to start and safe to re-run**. We encode what Cargo doesn't: pre-flight proof, ambiguity reconciliation, mechanical recovery, and operator-grade observability — so a multi-crate workspace publish becomes a boring, auditable operation instead of a manual coordination dance.
+Shipper makes publishing Rust crates to a registry **safe to start and safe to re-run**. We encode what Cargo doesn't — pre-flight proof, ambiguity reconciliation, mechanical recovery, and operator-grade observability — so a multi-crate workspace publish becomes a boring, auditable operation instead of a manual coordination dance.
+
+The single-sentence test of whether we are succeeding:
+
+> **You can start a release train, stop staring at the terminal, and still trust the outcome.**
+
+If that's true, we've done our job. If it isn't, no amount of mechanism makes us valuable.
 
 ## Vision
 

--- a/README.md
+++ b/README.md
@@ -2,47 +2,23 @@
 
 `shipper` is a **publishing reliability layer** for Rust workspaces.
 
-Cargo already knows how to package and upload crates. What tends to break in real life is the workflow around it:
+Cargo packages and uploads. The workflow around it — planning a multi-crate release, surviving rate limits, recovering when CI dies, knowing what actually shipped when the upload was ambiguous — is where things tend to break. Shipper makes a workspace publish **safe to start** and **safe to re-run**.
 
-- publishing is **irreversible** (versions can't be overwritten)
-- multi-crate publishing can be **non-atomic** (partial publishes)
-- CI runs get cancelled or time out
-- registries apply **backpressure** (HTTP 429)
-- some failures are **ambiguous** (upload may have succeeded even when the client errors)
-
-Shipper is intentionally narrow: it focuses on making publishing **safe to start** and **safe to re-run**.
+> **Why this exists:** see [MISSION.md](MISSION.md) for mission, vision, audience, and the convictions that shape every default.
 
 ## Status
 
-**v0.3.0-rc.1 shipped 2026-04-16** — first real-world crates.io publish, 12 crates live, driven by Shipper itself. See [ROADMAP.md](ROADMAP.md) for the post-rc.1 product thesis (nine competencies) and master tracking issue [#109](https://github.com/EffortlessMetrics/shipper/issues/109).
+**v0.3.0-rc.1 shipped 2026-04-16** — first real-world crates.io publish, 12 crates live, driven by Shipper itself. The publish absorbed 41 retries silently across a 69-minute run. See [ROADMAP.md](ROADMAP.md) for the post-rc.1 product thesis (nine competencies) and master tracking issue [#109](https://github.com/EffortlessMetrics/shipper/issues/109).
 
-## Workspace crates
+| Audience | Start here |
+|---|---|
+| New user | This README → [docs/release-runbook.md](docs/release-runbook.md) |
+| Operator | [docs/release-runbook.md](docs/release-runbook.md), [docs/configuration.md](docs/configuration.md) |
+| Contributor | [MISSION.md](MISSION.md) → [ROADMAP.md](ROADMAP.md) → [CONTRIBUTING.md](CONTRIBUTING.md) → an issue from #100–#109 |
+| AI assistant | [CLAUDE.md](CLAUDE.md) or [GEMINI.md](GEMINI.md) |
+| Auditing receipts/events | [docs/INVARIANTS.md](docs/INVARIANTS.md) |
 
-- [`shipper-cli`](crates/shipper-cli/README.md) — installs the `shipper` binary and exposes the command-line workflow.
-- [`shipper`](crates/shipper/README.md) — reusable library for planning, preflight checks, publish execution, resume, and receipts.
-
-## What shipper does
-
-- Builds a deterministic **publish plan** for workspace crates (dependency-first ordering).
-- Runs **preflight checks** (git cleanliness, publishability, registry reachability, version existence).
-- Optionally verifies **crate ownership/permissions** up front (when a token is available).
-- Publishes **one crate at a time** using `cargo publish -p <crate>`.
-- Applies retry/backoff for retryable failures.
-- Verifies publish completion via the registry API before declaring success.
-- Persists progress to disk so you can **resume** after interruption.
-- Captures **evidence** for each operation (stdout, stderr, exit codes).
-- Maintains an **event log** for complete audit trails.
-- Performs **readiness checks** to ensure registry visibility before publishing dependent crates.
-- Supports **parallel publishing** for independent packages within the dependency graph.
-- Supports configurable **publish policies** for different safety levels.
-
-## What shipper does not do (yet)
-
-- It does not bump versions, generate changelogs, create git tags, or create GitHub releases.
-  Use `cargo-release`, `release-plz`, or your own workflow to decide *what* version to publish.
-  Shipper focuses on *getting those versions published reliably*.
-
-## Build / install
+## Install
 
 From crates.io:
 
@@ -50,12 +26,11 @@ From crates.io:
 cargo install shipper-cli --locked
 ```
 
-> Note: the binary is named `shipper` but the crate is `shipper-cli`. Tracking [#95](https://github.com/EffortlessMetrics/shipper/issues/95) to make `cargo install shipper` work.
+> The binary is named `shipper` but the published crate is `shipper-cli`. [#95](https://github.com/EffortlessMetrics/shipper/issues/95) tracks making `cargo install shipper` work.
 
 From this repository:
 
 ```bash
-cargo build --release
 cargo install --path crates/shipper-cli --locked
 ```
 
@@ -65,275 +40,145 @@ cargo install --path crates/shipper-cli --locked
 shipper plan        # preview the publish order
 shipper preflight   # verify everything is ready
 shipper publish     # execute the plan
+shipper resume      # if interrupted, continue from the last state
 ```
 
-If the publish is interrupted (CI cancellation, network issues):
+`shipper --help` and `shipper <subcommand> --help` are the canonical command/flag reference.
 
-```bash
-shipper resume
-```
+## How it works
+
+The core flow is **plan → preflight → publish → (resume if interrupted)**.
+
+1. **Plan.** Reads the workspace via `cargo_metadata`, filters publishable crates, topologically sorts them by intra-workspace dependencies, and computes a SHA256-based `plan_id`. Same workspace state always produces the same `plan_id`.
+2. **Preflight.** Validates git cleanliness, registry reachability, performs a workspace dry-run, checks version-not-taken, optionally verifies ownership. Produces a `Finishability` assessment (Proven / NotProven / Failed).
+3. **Publish.** Executes the plan one crate at a time with retry/backoff. After each `cargo publish`, verifies registry visibility (sparse index and/or API) before advancing to a dependent crate. Persists state to disk after every step.
+4. **Resume.** Reloads `.shipper/state.json`, validates the `plan_id` matches the current workspace, skips already-published packages, continues from the first pending crate.
+
+State lives in `.shipper/`:
+
+- **`events.jsonl`** — append-only event stream. **The authoritative record.**
+- **`state.json`** — projection over events for fast resume.
+- **`receipt.json`** — end-of-run summary with evidence.
+- **`lock`** — concurrent-publish guard.
+
+The truth/projection/summary contract is documented in [docs/INVARIANTS.md](docs/INVARIANTS.md). Use `--state-dir <path>` to redirect (e.g. into a CI artifacts directory).
+
+## What shipper does
+
+- Deterministic, dependency-ordered publish plan.
+- Pre-flight checks (git, registry, dry-run, version, ownership).
+- Per-crate publish with retry/backoff for retryable failures.
+- Post-publish readiness verification before advancing to dependents.
+- Resumable state after every step.
+- Append-only audit event log + machine-readable receipt with evidence (stdout/stderr, exit codes, git context, environment fingerprint).
+- Multi-registry orchestration in a single run (state segregated per registry).
+- Parallel publishing for independent crates within the dependency graph.
+- Configurable safety/speed tradeoff via publish policies (`safe`, `balanced`, `fast`).
+
+## What shipper does not do
+
+- Bump versions, generate changelogs, create git tags, or write release notes. Use [cargo-release](https://github.com/crate-ci/cargo-release) or [release-plz](https://github.com/MarcoIeni/release-plz) for those. Shipper picks up *after* the version is decided.
 
 ## Authentication
 
-Publishing itself is performed by Cargo.
+Publishing itself is performed by Cargo. Shipper resolves a registry token from the same places Cargo does:
 
-Shipper's registry API checks (version existence, optional owners preflight) resolve a token using the same places people already use for Cargo:
+1. `CARGO_REGISTRY_TOKEN` (crates.io)
+2. `CARGO_REGISTRIES_<NAME>_TOKEN` (alternative registries; `<NAME>` uppercased, `-` replaced with `_`)
+3. `$CARGO_HOME/credentials.toml`
 
-- `CARGO_REGISTRY_TOKEN` (crates.io)
-- `CARGO_REGISTRIES_<NAME>_TOKEN` (other registries; `<NAME>` uppercased, `-` replaced with `_`)
-- `$CARGO_HOME/credentials.toml` (created by `cargo login`)
+The token is opaque, never logged, sanitized from receipts.
 
-The token is treated as an **opaque string** and sent as the value of the `Authorization` header, matching Cargo's registry web API model.
+`shipper doctor` reports `auth_type`:
 
-`shipper doctor` reports both `token_detected` and an `auth_type` value:
-- `token` (Cargo token found)
-- `trusted` (GitHub OIDC trusted publishing env detected)
-- `unknown` (partial auth env detected)
-- `-` (no known auth detected)
+- `token` — Cargo token detected
+- `trusted` — GitHub OIDC trusted-publishing env detected
+- `unknown` — partial auth env detected
+- `-` — none
 
-## State + receipts
+> Trusted Publishing detection exists today; making it the default (with OIDC token exchange) is tracked at [#96](https://github.com/EffortlessMetrics/shipper/issues/96).
 
-By default Shipper writes:
+## Configuration
 
-- `.shipper/state.json` — resumable execution state
-- `.shipper/receipt.json` — machine-readable receipt for CI/auditing
-- `.shipper/events.jsonl` — detailed event log for debugging
-
-Use `--state-dir <path>` to redirect these elsewhere (for example, a CI artifacts directory).
-
-## Commands
-
-### Core commands
-
-- `shipper plan` — print the publish order and what will be skipped
-- `shipper preflight` — run checks without publishing
-- `shipper publish` — execute the plan (writes state + receipt + events)
-- `shipper resume` — continue from the last state
-- `shipper status` — compare local versions to the registry
-- `shipper doctor` — environment and auth diagnostics
-
-### Inspection commands
-
-- `shipper inspect-events` — view detailed event log with timestamps and evidence
-- `shipper inspect-receipt` — view detailed receipt with captured evidence
-- `shipper clean` — clean state files (state.json, receipt.json, events.jsonl)
-
-### CI commands
-
-- `shipper ci github-actions` — print GitHub Actions workflow snippet
-- `shipper ci gitlab` — print GitLab CI workflow snippet
-- `shipper ci circleci` — print CircleCI configuration snippet
-- `shipper ci azure-devops` — print Azure DevOps pipeline snippet
-
-### Utility commands
-
-- `shipper completion <shell>` — generate shell completion scripts (bash, zsh, fish, powershell, elvish)
-- `shipper config init` — generate a default `.shipper.toml` configuration file
-- `shipper config validate` — validate a configuration file
-
-## Options
-
-### Global options
-
-- `--config <path>` — Path to a custom `.shipper.toml` configuration file
-- `--manifest-path <path>` — Path to the workspace Cargo.toml (default: Cargo.toml)
-- `--registry <name>` — Cargo registry name (default: crates-io)
-- `--api-base <url>` — Registry API base URL (default: https://crates.io)
-- `--package <name>` — Restrict to specific packages (repeatable)
-- `--format <format>` — Output format: text (default) or json
-- `--verbose` — Show detailed output (e.g., dependency analysis for plan)
-- `-q` / `--quiet` — Suppress informational output
-
-### State options
-
-- `--state-dir <path>` — Directory for shipper state and receipts (default: .shipper)
-- `--force` — Force override of existing locks (use with caution)
-- `--lock-timeout <duration>` — Lock timeout duration (default: 1h)
-
-### Verification options
-
-- `--policy <policy>` — Publish policy: safe (verify+strict), balanced (verify when needed), fast (no verify) (default: safe)
-- `--verify-mode <mode>` — Verify mode: workspace (default), package (per-crate), none (no verify)
-- `--no-verify` — Pass --no-verify to cargo publish
-
-### Readiness options
-
-- `--readiness-method <method>` — Readiness check method: api (default, fast), index (slower, more accurate), both (slowest, most reliable)
-- `--readiness-timeout <duration>` — How long to wait for registry visibility during readiness checks (default: 5m)
-- `--readiness-poll <duration>` — Poll interval for readiness checks (default: 2s)
-- `--no-readiness` — Disable readiness checks (for advanced users)
-
-### Preflight options
-
-- `--allow-dirty` — Allow publishing from a dirty git working tree
-- `--skip-ownership-check` — Skip owners/permissions preflight
-- `--strict-ownership` — Fail preflight if ownership checks fail or if no token is available
-
-### Retry options
-
-- `--max-attempts <number>` — Max attempts per crate publish step (default: 6)
-- `--base-delay <duration>` — Base backoff delay (default: 2s)
-- `--max-delay <duration>` — Max backoff delay (default: 2m)
-- `--retry-strategy <strategy>` — Retry strategy: immediate, exponential (default), linear, constant
-- `--retry-jitter <factor>` — Jitter factor for retry delays (0.0 = no jitter, 1.0 = full jitter; default: 0.5)
-- `--verify-timeout <duration>` — How long to wait for registry visibility after a successful publish (default: 2m)
-- `--verify-poll <duration>` — Poll interval for checking registry visibility (default: 5s)
-
-### Evidence options
-
-- `--output-lines <number>` — Number of output lines to capture for evidence (default: 50)
-
-### Parallel options
-
-- `--parallel` — Enable parallel publishing (packages at the same dependency level published concurrently)
-- `--max-concurrent <number>` — Maximum concurrent publish operations (default: 4, implies --parallel)
-- `--per-package-timeout <duration>` — Timeout per package in parallel mode (default: 30m)
-
-### Resume options
-
-- `--force-resume` — Force resume even if the computed plan differs from the state file
-
-## Configuration file
-
-Shipper supports project-specific configuration via a `.shipper.toml` file in your workspace root. CLI flags always take precedence over configuration file values.
+Project-specific configuration via `.shipper.toml` in the workspace root. CLI flags always take precedence.
 
 ```bash
 shipper config init       # generate a default config file
-shipper config validate   # validate an existing config file
+shipper config validate   # validate a configuration file
 ```
 
 See [docs/configuration.md](docs/configuration.md) for the full reference.
 
+## CI integration
+
+Generate a workflow snippet for your platform:
+
+```bash
+shipper ci github-actions
+shipper ci gitlab
+shipper ci circleci
+shipper ci azure-devops
+```
+
+Or browse `templates/` for reference workflows.
+
 ## Examples
 
-### Basic publish workflow
+### Choosing a publish policy
 
 ```bash
-shipper plan
-shipper preflight
-shipper publish
+shipper publish --policy safe       # default: verify every step
+shipper publish --policy balanced   # verify when needed
+shipper publish --policy fast       # skip verification (with caution)
 ```
 
-### Publish policies
+### Choosing a readiness method
 
 ```bash
-# Safe mode (default): verify every publish with strict checks
-shipper publish --policy safe
-
-# Balanced mode: verify only when needed
-shipper publish --policy balanced
-
-# Fast mode: skip verification (use with caution)
-shipper publish --policy fast
+shipper publish --readiness-method api    # fast (default)
+shipper publish --readiness-method index  # more accurate
+shipper publish --readiness-method both   # most reliable
 ```
 
-### Readiness checks
+### Multi-registry publishing
 
 ```bash
-# API-based readiness (fast, default)
-shipper publish --readiness-method api
-
-# Index-based readiness (slower but more accurate)
-shipper publish --readiness-method index
-
-# Both methods (slowest but most reliable)
-shipper publish --readiness-method both
-
-# Custom timeout and poll interval
-shipper publish --readiness-timeout 10m --readiness-poll 5s
-
-# Disable readiness checks (advanced users only)
-shipper publish --no-readiness
+shipper publish --registries crates-io,internal-mirror
+shipper publish --all-registries
 ```
 
-### Verify modes
+### Inspecting state and receipts
 
 ```bash
-# Verify at workspace level (default)
-shipper publish --verify-mode workspace
-
-# Verify each package individually
-shipper publish --verify-mode package
-
-# Skip verification
-shipper publish --verify-mode none
-```
-
-### Inspecting events and receipts
-
-```bash
-# View the event log
-shipper inspect-events
-
-# View the detailed receipt with evidence
-shipper inspect-receipt
-
-# Get JSON output for CI integration
-shipper inspect-receipt --format json
+shipper inspect-events                  # human-readable event log
+shipper inspect-receipt --format json   # JSON receipt for CI consumption
+shipper status                          # compare local versions to the registry
 ```
 
 ### Resuming after interruption
 
 ```bash
-# Resume normally from where it left off
 shipper resume
-
-# Force resume if plan has changed
-shipper resume --force-resume
-
-# Resume from a specific package (skipping previous ones)
-shipper publish --resume-from my-crate
+shipper resume --force-resume           # if the workspace plan has changed
+shipper publish --resume-from my-crate  # restart from a specific crate
 ```
 
-### Multi-registry publishing
+## Workspace crates
 
-Shipper can publish to multiple registries in a single run. State and receipts are segregated by registry name.
+- [`shipper-cli`](crates/shipper-cli/README.md) — installs the `shipper` binary.
+- [`shipper`](crates/shipper/README.md) — reusable library: planning, preflight, publish, resume, receipts.
 
-```bash
-# Publish to all registries defined in .shipper.toml
-shipper publish --all-registries
-
-# Publish to specific registries
-shipper publish --registries crates-io,internal-mirror
-```
-
-### Parallel publishing
-
-```bash
-# Publish independent packages concurrently
-shipper publish --parallel
-
-# Limit to 2 concurrent operations
-shipper publish --parallel --max-concurrent 2
-
-# With per-package timeout
-shipper publish --parallel --per-package-timeout 10m
-```
-
-### Cleaning state files
-
-```bash
-# Clean all state files
-shipper clean
-
-# Keep the receipt but clean state and events
-shipper clean --keep-receipt
-```
-
-## CI templates
-
-See `templates/` for example workflows, or generate snippets:
-
-```bash
-shipper ci github-actions
-shipper ci gitlab
-```
+The full crate map is in [docs/structure.md](docs/structure.md).
 
 ## Documentation
 
+- [MISSION.md](MISSION.md) — mission, vision, audience, and what we believe
 - [ROADMAP.md](ROADMAP.md) — product thesis, nine-competency scorecard, now/next/later
+- [docs/product.md](docs/product.md) — product overview at a glance
+- [docs/structure.md](docs/structure.md) — repository and crate structure
+- [docs/tech.md](docs/tech.md) — tech stack and conventions
 - [docs/INVARIANTS.md](docs/INVARIANTS.md) — events-as-truth / state-as-projection contract
-- [docs/configuration.md](docs/configuration.md) — configuration file reference
+- [docs/configuration.md](docs/configuration.md) — `.shipper.toml` reference
 - [docs/preflight.md](docs/preflight.md) — pre-flight verification guide
 - [docs/readiness.md](docs/readiness.md) — readiness verification guide
 - [docs/failure-modes.md](docs/failure-modes.md) — common failure scenarios and solutions

--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@ Cargo already knows how to package and upload crates. What tends to break in rea
 
 Shipper is intentionally narrow: it focuses on making publishing **safe to start** and **safe to re-run**.
 
+## Status
+
+**v0.3.0-rc.1 shipped 2026-04-16** — first real-world crates.io publish, 12 crates live, driven by Shipper itself. See [ROADMAP.md](ROADMAP.md) for the post-rc.1 product thesis (nine competencies) and master tracking issue [#109](https://github.com/EffortlessMetrics/shipper/issues/109).
+
 ## Workspace crates
 
-- [`shipper-cli`](crates/shipper-cli/README.md) - installs the `shipper` binary and exposes the command-line workflow.
-- [`shipper`](crates/shipper/README.md) - reusable library for planning, preflight checks, publish execution, resume, and receipts.
+- [`shipper-cli`](crates/shipper-cli/README.md) — installs the `shipper` binary and exposes the command-line workflow.
+- [`shipper`](crates/shipper/README.md) — reusable library for planning, preflight checks, publish execution, resume, and receipts.
 
 ## What shipper does
 
@@ -39,6 +43,14 @@ Shipper is intentionally narrow: it focuses on making publishing **safe to start
   Shipper focuses on *getting those versions published reliably*.
 
 ## Build / install
+
+From crates.io:
+
+```bash
+cargo install shipper-cli --locked
+```
+
+> Note: the binary is named `shipper` but the crate is `shipper-cli`. Tracking [#95](https://github.com/EffortlessMetrics/shipper/issues/95) to make `cargo install shipper` work.
 
 From this repository:
 
@@ -319,10 +331,13 @@ shipper ci gitlab
 
 ## Documentation
 
-- [Configuration](docs/configuration.md) - Configuration file reference
-- [Preflight Verification](docs/preflight.md) - Pre-flight verification guide
-- [Readiness Checking](docs/readiness.md) - Readiness verification guide
-- [Failure Modes](docs/failure-modes.md) - Common failure scenarios and solutions
+- [ROADMAP.md](ROADMAP.md) — product thesis, nine-competency scorecard, now/next/later
+- [docs/INVARIANTS.md](docs/INVARIANTS.md) — events-as-truth / state-as-projection contract
+- [docs/configuration.md](docs/configuration.md) — configuration file reference
+- [docs/preflight.md](docs/preflight.md) — pre-flight verification guide
+- [docs/readiness.md](docs/readiness.md) — readiness verification guide
+- [docs/failure-modes.md](docs/failure-modes.md) — common failure scenarios and solutions
+- [docs/release-runbook.md](docs/release-runbook.md) — operator release runbook
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ shipper resume      # if interrupted, continue from the last state
 
 `shipper --help` and `shipper <subcommand> --help` are the canonical command/flag reference.
 
+For a walkthrough, see the [first-publish tutorial](docs/tutorials/first-publish.md). For the full docs tree (tutorials / how-to / reference / explanation), see [docs/README.md](docs/README.md).
+
 ## How it works
 
 The core flow is **plan → preflight → publish → (resume if interrupted)**.
@@ -174,17 +176,20 @@ The full crate map is in [docs/structure.md](docs/structure.md).
 
 ## Documentation
 
-- [MISSION.md](MISSION.md) — mission, vision, audience, and what we believe
-- [ROADMAP.md](ROADMAP.md) — product thesis, nine-competency scorecard, now/next/later
-- [docs/product.md](docs/product.md) — product overview at a glance
-- [docs/structure.md](docs/structure.md) — repository and crate structure
-- [docs/tech.md](docs/tech.md) — tech stack and conventions
-- [docs/INVARIANTS.md](docs/INVARIANTS.md) — events-as-truth / state-as-projection contract
-- [docs/configuration.md](docs/configuration.md) — `.shipper.toml` reference
-- [docs/preflight.md](docs/preflight.md) — pre-flight verification guide
-- [docs/readiness.md](docs/readiness.md) — readiness verification guide
-- [docs/failure-modes.md](docs/failure-modes.md) — common failure scenarios and solutions
-- [docs/release-runbook.md](docs/release-runbook.md) — operator release runbook
+The full docs tree is organized by reader purpose ([Diátaxis](https://diataxis.fr/)): tutorials, how-to guides, reference, explanation. Start at **[docs/README.md](docs/README.md)**.
+
+Top of the repo:
+
+- [MISSION.md](MISSION.md) — mission, vision, audience, beliefs
+- [ROADMAP.md](ROADMAP.md) — five pillars, nine-competency scorecard, now/next/later
+- [docs/README.md](docs/README.md) — documentation index
+
+Quick links:
+
+- **Learn:** [First publish tutorial](docs/tutorials/first-publish.md) • [Recover from interruption](docs/tutorials/recover-from-interruption.md)
+- **Do:** [Run in GitHub Actions](docs/how-to/run-in-github-actions.md) • [Inspect state & receipts](docs/how-to/inspect-state-and-receipts.md)
+- **Look up:** [CLI reference](docs/reference/cli.md) • [`.shipper.toml`](docs/configuration.md) • [Failure modes](docs/failure-modes.md)
+- **Understand:** [Why Shipper](docs/explanation/why-shipper.md) • [Architecture](docs/architecture.md) • [Invariants](docs/INVARIANTS.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Cargo packages and uploads. The workflow around it — planning a multi-crate release, surviving rate limits, recovering when CI dies, knowing what actually shipped when the upload was ambiguous — is where things tend to break. Shipper makes a workspace publish **safe to start** and **safe to re-run**.
 
+> **The single test:** you can start a release train, stop staring at the terminal, and still trust the outcome.
+
 > **Why this exists:** see [MISSION.md](MISSION.md) for mission, vision, audience, and the convictions that shape every default.
 
 ## Status

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,9 +8,23 @@
 
 The post-release retrospective produced a product thesis organized around nine competencies. This document is structured around them. Each competency has a tracking issue (#100–#108); the master roadmap is **#109**.
 
-## Product thesis: nine competencies
+## Five existential pillars (the safety claim)
 
-Cargo 1.90 stabilized multi-package workspace publishing, so "publish several crates at once" is no longer Shipper's differentiator. Shipper exists to do what Cargo still doesn't:
+Cargo 1.90 stabilized multi-package workspace publishing. "Publish several crates at once" is no longer a differentiator. Shipper is only worth existing if it owns five guarantees Cargo still does not give you — together they are the **release-closure system** that the engine is moving toward:
+
+| Pillar | Question it answers | Status |
+|---|---|---|
+| **Prove** | Can I show this release is safe *before* the irreversible step? | Partial — workspace dry-run + ownership; rehearsal-registry pending ([#97](https://github.com/EffortlessMetrics/shipper/issues/97)) |
+| **Dispatch** | Is the publish executed in a registry-aware, paced way? | Partial — generic exponential backoff; documented-constraint + Retry-After layering pending ([#94](https://github.com/EffortlessMetrics/shipper/issues/94)) |
+| **Reconcile** | When the result is ambiguous, do I check registry truth before retrying? | **Missing** ([#99](https://github.com/EffortlessMetrics/shipper/issues/99) / [#102](https://github.com/EffortlessMetrics/shipper/issues/102)) — biggest open gap |
+| **Recover** | If the runner dies mid-train, can I converge from durable state without losing or duplicating work? | Partial — implemented; verification under real interruption pending ([#90](https://github.com/EffortlessMetrics/shipper/issues/90)) |
+| **Remediate** | If a partial release goes bad, can I contain or fix-forward it mechanically? | **Missing** ([#98](https://github.com/EffortlessMetrics/shipper/issues/98) / [#104](https://github.com/EffortlessMetrics/shipper/issues/104)) |
+
+These five are the existential pillars: a publishing tool that doesn't own them is a publishing tool that asks too much trust from the operator. Today Shipper is two-thirds of the way through pillars 1, 2, and 4; pillars 3 and 5 are the work that turns "useful release executor" into "trustworthy release-closure system."
+
+## Nine competencies (the full scorecard)
+
+The five pillars cover the safety story. Four more competencies — narrate, harden, integrate, ergonomics — make the tool legible, securable, embeddable, and approachable. Together they form the full scorecard each tracking issue maps to:
 
 | # | Competency | Definition | Status | Issue |
 |---|---|---|---|---|

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,578 +1,100 @@
 # Shipper Roadmap
 
-This document outlines the planned development trajectory for Shipper, a reliability layer around `cargo publish` for workspace publishing. It provides detailed feature specifications, technical implementation considerations, and guidance for contributors and users.
+## Where we are
 
-## Table of Contents
+**v0.3.0-rc.1 shipped 2026-04-16.** Twelve crates went live on crates.io: `shipper`, `shipper-cli`, `shipper-config`, `shipper-types`, `shipper-registry`, `shipper-duration`, `shipper-retry`, `shipper-encrypt`, `shipper-output-sanitizer`, `shipper-cargo-failure`, `shipper-sparse-index`, `shipper-webhook`. The publish train was driven by Shipper itself — first real-world dogfooding under crates.io rate limits, with 41 retries silently absorbed across a 69-minute run.
 
-1. [Current Release: v0.2.0](#current-release-v020)
-2. [Design Principles](#design-principles)
-3. [Technical Debt to Address](#technical-debt-to-address)
-4. [Performance Goals](#performance-goals)
-5. [Ecosystem Integration](#ecosystem-integration)
-6. [Version Roadmap](#version-roadmap)
-   - [v0.3.0 - User Experience](#v030---user-experience)
-   - [v0.4.0 - Extensibility](#v040---extensibility)
-   - [v0.5.0 - Multi-Registry](#v050---multi-registry)
-   - [v1.0.0 - Stability](#v100---stability)
-7. [Feature Specifications](#feature-specifications)
-8. [Explicit Non-Goals](#explicit-non-goals)
-9. [Contributing to the Roadmap](#contributing-to-the-roadmap)
+The post-release retrospective produced a product thesis organized around nine competencies. This document is structured around them. Each competency has a tracking issue (#100–#108); the master roadmap is **#109**.
 
----
+## Product thesis: nine competencies
 
-## Current Release: v0.3.0-rc.1
+Cargo 1.90 stabilized multi-package workspace publishing, so "publish several crates at once" is no longer Shipper's differentiator. Shipper exists to do what Cargo still doesn't:
 
-Shipper v0.3.0-rc.1 is a major milestone focusing on User Experience, multi-registry support, and performance optimizations. It provides:
+| # | Competency | Definition | Status | Issue |
+|---|---|---|---|---|
+| 1 | **Prove** | Establish before the irreversible step that the publish can succeed | Partial | [#100](https://github.com/EffortlessMetrics/shipper/issues/100) |
+| 2 | **Survive** | Recover from interruption without losing or duplicating work | Partial | [#101](https://github.com/EffortlessMetrics/shipper/issues/101) |
+| 3 | **Reconcile** | Close ambiguous outcomes against registry truth | **Missing** | [#102](https://github.com/EffortlessMetrics/shipper/issues/102) |
+| 4 | **Narrate** | Tell the operator what's happening live, not just after the fact | Partial | [#103](https://github.com/EffortlessMetrics/shipper/issues/103) |
+| 5 | **Remediate** | Mechanically recover from bad partial outcomes (yank, fix-forward) | **Missing** | [#104](https://github.com/EffortlessMetrics/shipper/issues/104) |
+| 6 | **Harden** | Default to safe auth posture; minimize long-lived secret blast radius | Partial | [#105](https://github.com/EffortlessMetrics/shipper/issues/105) |
+| 7 | **Profile** | Encode what we know about each registry (rate limits, regimes) | Partial | [#106](https://github.com/EffortlessMetrics/shipper/issues/106) |
+| 8 | **Integrate** | Consumable from IDP platforms and CI orchestration tooling | Partial | [#107](https://github.com/EffortlessMetrics/shipper/issues/107) |
+| 9 | **Ergonomics** | First-impression friction is low; defaults are sensible | Partial | [#108](https://github.com/EffortlessMetrics/shipper/issues/108) |
 
-- **Multi-registry publishing** - Orchestrate publishes across multiple registries in one run
-- **Sparse index caching** - ETag-based disk caching for faster readiness verification
-- **Selective resumability** - Start publishing from any package in the plan with `--resume-from`
-- **Shell completions** - Built-in support for generating shell completion scripts
-- **Enhanced diagnostics** - Deep `doctor` command for environment health checks
-- **Improved locking** - Workspace-aware hashing to prevent global lock collisions
+**Master tracking issue: [#109](https://github.com/EffortlessMetrics/shipper/issues/109)**
 
-See the [CHANGELOG.md](CHANGELOG.md) for complete details.
+The biggest single gap is **#3 Reconcile**: when `cargo publish` returns ambiguously (it uploads first, then polls the index, and the poll can time out without affecting the upload), Shipper today retries blindly. Without ambiguity reconciliation against registry truth, the safety pitch has a hole at the worst possible spot.
 
----
+## Design principles
 
-## Design Principles
+These guide all Shipper development.
 
-These principles guide all Shipper development decisions:
+### Reliability over speed
+Default behaviors verify, log, and provide evidence. Faster paths are explicit opt-ins. The default publish policy (`safe`) includes all verification.
 
-### 1. Reliability Over Speed
+### Determinism
+Publish order is reproducible. Plan IDs are SHA256 of the workspace plan and stable across environments. The same workspace state always produces the same `plan_id`.
 
-Shipper prioritizes correct behavior and data integrity over fast execution. When in doubt, Shipper verifies, logs, and provides evidence rather than assuming success.
+### Events are truth, state is a projection
+Per [docs/INVARIANTS.md](docs/INVARIANTS.md): `events.jsonl` is authoritative and append-only. `state.json` is a projection over events for resume convenience. `receipt.json` is a summary derived from events at end-of-run. The relationship is contractual; see [#93](https://github.com/EffortlessMetrics/shipper/issues/93) for enforcement.
 
-- **Default to safe behavior**: The default publish policy (`safe`) includes all verification steps
-- **Evidence over assumptions**: Every operation captures evidence for debugging and auditing
-- **Explicit over implicit**: Users must opt-in to faster but riskier behaviors
+### Engine is library; CLI is thin
+All domain logic lives in `crates/shipper`. `crates/shipper-cli` parses args and calls into the library. Other frontends (IDP plugins, dashboards, automation) consume the library directly.
 
-### 2. Determinism
+### Forbid unsafe; respect MSRV
+`unsafe_code = "forbid"` workspace-wide. Edition 2024, MSRV 1.92.
 
-Publishing should be reproducible across environments and time:
+## Now / Next / Later
 
-- **Deterministic ordering**: Publish order is computed from dependency graph with stable sorting
-- **Plan IDs**: Every publish plan has a SHA256-based ID for resume validation
-- **State versioning**: State and receipt files include schema versions for compatibility
+Sequencing follows the master roadmap ([#109](https://github.com/EffortlessMetrics/shipper/issues/109)).
 
-### 3. Transparency
+### Now — gates v0.3.0 stable
+1. **[#102](https://github.com/EffortlessMetrics/shipper/issues/102) Reconcile** — implement the ambiguous-outcome state machine ([#99](https://github.com/EffortlessMetrics/shipper/issues/99)). Without this, Shipper cannot truthfully claim to be safer than naive `cargo publish`.
+2. **[#105](https://github.com/EffortlessMetrics/shipper/issues/105) Harden** — make Trusted Publishing the default ([#96](https://github.com/EffortlessMetrics/shipper/issues/96)). Most of the wiring exists.
+3. **[#103](https://github.com/EffortlessMetrics/shipper/issues/103) Narrate** — surface retry/backoff state ([#91](https://github.com/EffortlessMetrics/shipper/issues/91)). Operators currently fly blind for ~60 minutes during rate-limited publishes.
+4. **[#101](https://github.com/EffortlessMetrics/shipper/issues/101) Survive** — execute the rehearsal procedure ([#90](https://github.com/EffortlessMetrics/shipper/issues/90)) and document the events-as-truth invariant ([#93](https://github.com/EffortlessMetrics/shipper/issues/93)). Resume is currently unverified under real interruption.
+5. **[#108](https://github.com/EffortlessMetrics/shipper/issues/108) Ergonomics** — `cargo install shipper` should work ([#95](https://github.com/EffortlessMetrics/shipper/issues/95)).
 
-Users should understand what Shipper is doing and why:
+### Next — past stable
+6. **[#106](https://github.com/EffortlessMetrics/shipper/issues/106) Profile** — registry-aware backoff layered on the regime tag preflight already detects ([#94](https://github.com/EffortlessMetrics/shipper/issues/94)). Preflight discovers `is_new_crate`; publish discards it. Threading the tag through is the entire mechanism.
+7. **[#104](https://github.com/EffortlessMetrics/shipper/issues/104) Remediate** — receipt-driven yank/fix-forward for compromised releases ([#98](https://github.com/EffortlessMetrics/shipper/issues/98)).
+8. **[#100](https://github.com/EffortlessMetrics/shipper/issues/100) Prove tier 2** — rehearsal registry as the next preflight strength ([#97](https://github.com/EffortlessMetrics/shipper/issues/97)). Promotes preflight from "we believe" to "we proved against a registry-shaped target".
 
-- **Clear progress indication**: Each step's purpose and status is visible
-- **Detailed logging**: Event log captures every operation with context
-- **Evidence preservation**: Failed operations retain stdout/stderr for debugging
+### Later — once the engine is closure-complete
+9. **[#107](https://github.com/EffortlessMetrics/shipper/issues/107) Integrate** — IDP plugin examples (Backstage / Port / Cortex), HTTP query API, webhook reliability semantics, library consumer guide. Best done after the engine offers a stable closure story to integrate against.
 
-### 4. Composability
+## Explicit non-goals
 
-Shipper should integrate well with existing workflows:
-
-- **Thin CLI layer**: Core logic lives in the library crate, CLI is minimal
-- **Trait-based abstractions**: `StateStore`, `RegistryClient`, and `Reporter` allow customization
-- **Configuration flexibility**: CLI flags, environment variables, and config files with clear precedence
-
-### 5. Minimal External Dependencies
-
-Shipper should be lightweight and easy to audit:
-
-- **Few runtime dependencies**: Prefer standard library and well-audited crates
-- **No runtime reflection**: All types are statically known for binary size and security
-- **Explicit feature flags**: Users can disable unused functionality
-
----
-
-## Technical Debt to Address
-
-### High Priority
-
-| Issue | Description | Impact | Approach |
-|-------|-------------|--------|----------|
-| Error categorization | Some errors aren't properly classified as retryable vs permanent | Unnecessary retries or premature failures | Expand `ErrorClass` enum and classification logic |
-| Test coverage gaps | Some error paths lack test coverage | Potential bugs in edge cases | Add integration tests for error scenarios |
-| Lock granularity | File-level locking prevents parallel workspace publishes | Limited CI parallelism | Implement directory-based locking per workspace |
-
-### Medium Priority
-
-| Issue | Description | Impact | Approach |
-|-------|-------------|--------|----------|
-| Config migration | No automatic config file migration between versions | User friction on upgrades | Add schema version checking with migration hints |
-| Sparse index caching | Index is re-fetched for each readiness check | Slow readiness verification | Implement configurable caching with TTL |
-| Verbose output | CLI output can be overwhelming in CI | Difficult to parse | Add machine-readable output modes |
-
-### Lower Priority
-
-| Issue | Description | Impact | Approach |
-|-------|-------------|--------|----------|
-| Documentation examples | Some edge cases lack examples | User confusion | Expand docs with scenario-based guides |
-| Error messages | Some errors could be more actionable | Debugging difficulty | Review and improve error message clarity |
-
----
-
-## Performance Goals
-
-Shipper aims to balance reliability with reasonable performance:
-
-| Metric | Current | Target | Version |
-|--------|---------|--------|---------|
-| Publish overhead (single crate) | ~2-5s | <3s | v0.3.0 |
-| Parallel publish efficiency | ~70% | >85% | v0.4.0 |
-| Readiness check latency (API) | ~500ms | <200ms | v0.3.0 |
-| Memory usage (100 crates) | ~50MB | <30MB | v0.4.0 |
-| Cold start time | ~1s | <500ms | v0.3.0 |
-| State file size (per crate) | ~1KB | <500B | v0.5.0 |
-
-### Optimization Priorities
-
-1. **Parallel publishing efficiency**: Reduce coordination overhead between parallel tasks
-2. **Readiness check caching**: Cache API responses to avoid redundant network calls
-3. **Lazy initialization**: Defer expensive operations until needed
-4. **Streaming state updates**: Write state incrementally instead of full rewrites
-
----
-
-## Ecosystem Integration
-
-### Package Manager Integration
-
-| Manager | Status | Notes |
-|---------|--------|-------|
-| Cargo | **Primary** | Shipper wraps cargo publish |
-| crates.io | **Supported** | Default registry |
-| GitHub crates.io index | **Supported** | Via sparse protocol |
-| Alternative registries | **Planned** | See v0.5.0 |
-
-### CI/CD Integration
-
-| Platform | Status | Template |
-|----------|--------|----------|
-| GitHub Actions | **Available** | `shipper ci github-actions` |
-| GitLab CI | **Available** | `shipper ci gitlab` |
-| Azure DevOps | **Planned** | See v0.3.0 |
-| CircleCI | **Planned** | See v0.3.0 |
-
-### Release Tooling Integration
-
-Shipper explicitly does NOT replace release orchestration tools. Integration points:
-
-- **cargo-release**: Use for version bumping, changelog generation, git tags
-- **release-plz**: Use for automated PR-based releases
-- **GitHub CLI**: Use for GitHub release creation
-- **custom scripts**: Shipper emits JSON output for programmatic consumption
-
----
-
-## Version Roadmap
-
-### v0.3.0 - User Experience
-
-**Theme**: Improve CLI usability and developer experience
-
-**Estimated Timeline**: Q2 2026
-
-**Focus Areas**:
-- Shell completions for bash, zsh, fish, PowerShell
-- Progress bars and TTY enhancement
-- Enhanced dry-run output
-- Additional CI templates
-
-**Breaking Changes**: Minimal expected
-
----
-
-### v0.4.0 - Extensibility
-
-**Theme**: Enable customization and advanced use cases
-
-**Estimated Timeline**: Q3-Q4 2026
-
-**Focus Areas**:
-- Plugin system for custom verification steps
-- Cloud storage backends for StateStore
-- Custom retry strategies per error type
-- Webhook notifications
-
-**Breaking Changes**: Possible config format additions
-
----
-
-### v0.5.0 - Multi-Registry
-
-**Theme**: Support multiple registries
-
-**Estimated Timeline**: Q4 2026 - Q1 2027
-
-**Focus Areas**:
-- Multi-registry publishing in one run
-- Alternative registry priority configuration
-- Custom registry token management
-- Registry-specific retry strategies
-
-**Breaking Changes**: State format may need migration
-
----
-
-### v1.0.0 - Stability
-
-**Theme**: Stabilize for production use
-
-**Estimated Timeline**: 2027
-
-**Focus Areas**:
-- Stable public API guarantees
-- Comprehensive docs.rs coverage
-- Formal deprecation policy
-- State file format stabilization
-- Receipt format versioning guarantees
-
-**Breaking Changes**: Final breaking change window before stability
-
----
-
-## Feature Specifications
-
-### Shell Completions
-
-| Attribute | Details |
-|-----------|---------|
-| **Description** | Generate shell completion scripts for bash, zsh, fish, and PowerShell |
-| **User Benefit** | Enables tab completion for shipper commands and options |
-| **Technical Approach** | Use `clap` built-in completion generation; add `shipper completion <shell>` subcommand |
-| **Dependencies** | `clap_complete` crate (already dependency) |
-| **Complexity** | Small |
-| **Success Criteria** | All shipper flags complete correctly; documentation shows usage |
-
-```bash
-# Usage
-shipper completion bash > /etc/bash_completion.d/shipper
-shipper completion zsh > ~/.zsh/completions/_shipper
-shipper completion fish > ~/.config/fish/completions/shipper.fish
-```
-
----
-
-### Progress Bars
-
-| Attribute | Details |
-|-----------|---------|
-| **Description** | Visual progress indication for TTY environments with optional plain text fallback |
-| **User Benefit** | Better visibility into publish progress, especially for large workspaces |
-| **Technical Approach** | Use `indicatif` crate; detect TTY via `atty`; fallback to structured text for CI |
-| **Dependencies** | `indicatif`, `atty` crates |
-| **Complexity** | Small |
-| **Success Criteria** | Progress bar shows during publish; respects `--no-progress` flag; CI environments get text output |
-
-```bash
-# Example output
-Publishing my-crate v1.2.0 [=====>    ] 4/10 crates
-```
-
----
-
-### Enhanced Dry-Run
-
-| Attribute | Details |
-|-----------|---------|
-| **Description** | Detailed dependency analysis in dry-run mode showing which crates depend on which |
-| **User Benefit** | Better understanding of publish order and dependency relationships |
-| **Technical Approach** | Extend current dry-run output with dependency graph visualization |
-| **Dependencies** | None (reuse existing plan.rs logic) |
-| **Complexity** | Small |
-| **Success Criteria** | Shows complete dependency tree; highlights potential issues |
-
-```bash
-# Example output
-Publish order: [crate-a, crate-b, crate-c, crate-d]
-Dependency tree:
-  crate-a (no deps)
-  crate-b (depends on: crate-a)
-  crate-c (depends on: crate-a)
-  crate-d (depends on: crate-b, crate-c)
-```
-
----
-
-### Additional CI Templates
-
-| Attribute | Details |
-|-----------|---------|
-| **Description** | Generate workflow snippets for Azure DevOps, CircleCI, and other CI platforms |
-| **User Benefit** | Easier integration with existing CI infrastructure |
-| **Technical Approach** | Add new subcommands: `shipper ci azure`, `shipper ci circleci` |
-| **Dependencies** | None |
-| **Complexity** | Small |
-| **Success Criteria** | Templates generate valid CI configuration; include common options |
-
----
-
-### Webhook Notifications
-
-| Attribute | Details |
-|-----------|---------|
-| **Description** | HTTP callbacks on publish events (started, success, failure per crate) |
-| **User Benefit** | Integrate with external monitoring, Slack, custom automation |
-| **Technical Approach** | Add webhook configuration in `.shipper.toml`; async HTTP POST with retry |
-| **Dependencies** | `reqwest` or `ureq` for HTTP client |
-| **Complexity** | Medium |
-| **Success Criteria** | Webhooks fire on configured events; payload includes crate info; retry on failure |
-
-```toml
-[webhook]
-enabled = true
-url = "https://example.com/hooks/shipper"
-events = ["publish_started", "publish_success", "publish_failure"]
-retry = true
-```
-
----
-
-### Custom Retry Strategies
-
-| Attribute | Details |
-|-----------|---------|
-| **Description** | Configure retry behavior based on error type (rate limit, network, auth) |
-| **User Benefit** | More intelligent retries; faster recovery from known error patterns |
-| **Technical Approach** | Extend retry config with per-error-type settings; enhance error classification |
-| **Dependencies** | None (existing error handling) |
-| **Complexity** | Medium |
-| **Success Criteria** | Different backoff for 429 vs 5xx; auth errors don't retry; config validates properly |
-
-```toml
-[retry]
-max_attempts = 6
-base_delay = "1s"
-max_delay = "2m"
-
-[retry.strategy]
-http_429 = { base_delay = "5s", max_delay = "10m", max_attempts = 20 }
-network = { base_delay = "1s", max_delay = "1m", max_attempts = 5 }
-auth = { max_attempts = 1 }  # Don't retry auth errors
-```
-
----
-
-### State File Encryption
-
-| Attribute | Details |
-|-----------|---------|
-| **Description** | Encrypt sensitive state data at rest using AES-256-GCM |
-| **User Benefit** | Protect potentially sensitive publish metadata in shared environments |
-| **Technical Approach** | Add encryption layer to `StateStore`; key from environment or user input |
-| **Dependencies** | `ring` or `aes-gcm` crate |
-| **Complexity** | Medium |
-| **Success Criteria** | State files encrypted with user-provided key; graceful degradation if no key |
-
-```bash
-# Usage
-shipper publish --encrypt-state
-# Or via config
-[state]
-encrypt = true
-key_env = "SHIPPER_STATE_KEY"
-```
-
----
-
-### Cloud Storage Backends
-
-| Attribute | Details |
-|-----------|---------|
-| **Description** | Implement `StateStore` for S3, GCS, and Azure Blob storage |
-| **User Benefit** | Share state across CI runners; enable distributed publishing |
-| **Technical Approach** | Add trait implementations for cloud providers; support credentials via environment |
-| **Dependencies** | Cloud SDK crates (`aws-sdk-s3`, `google-cloud-storage`, `azure-storage-blob`) |
-| **Complexity** | Large |
-| **Success Criteria** | State persists to cloud; concurrent access handled; works with major providers |
-
-```toml
-[store]
-backend = "s3"
-bucket = "my-workspace-shipper"
-region = "us-east-1"
-prefix = "releases/"
-```
-
----
-
-### Plugin System
-
-| Attribute | Details |
-|-----------|---------|
-| **Description** | Extend Shipper with custom verification steps, pre/post hooks |
-| **User Benefit** | Custom checks (security scans, license verification) without modifying Shipper |
-| **Technical Approach** | Define plugin trait; support WASM or external process plugins; add `shipper plugin` subcommand |
-| **Dependencies** | `wasmtime` or process execution |
-| **Complexity** | Large |
-| **Success Criteria** | Plugin interface stable; example plugins demonstrate use cases; sandboxed execution |
-
-```toml
-[plugins]
-enabled = true
-
-[[plugins]]
-name = "security-scan"
-path = "./shipper-security-plugin.wasm"
-hooks = ["pre_publish", "post_publish"]
-```
-
----
-
-### Multi-Registry Publishing
-
-| Attribute | Details |
-|-----------|---------|
-| **Description** | Publish crates to multiple registries in a single run |
-| **User Benefit** | Support crate mirrors, enterprise registries, and redundancy |
-| **Technical Approach** | Extend publish pipeline with registry list; maintain per-registry state |
-| **Dependencies** | Alternative registry support in config |
-| **Complexity** | Large |
-| **Success Criteria** | Publish to crates.io + private registry; state tracks per-registry progress |
-
-```bash
-# Usage
-shipper publish --registries crates-io,my-crates
-
-# Config
-[[registries]]
-name = "crates-io"
-default = true
-
-[[registries]]
-name = "my-crates"
-url = "https://crates.mycompany.com"
-token = { env = "MY_CRATES_TOKEN" }
-```
-
----
-
-### Alternative Registry Support
-
-| Attribute | Details |
-|-----------|---------|
-| **Description** | Support publishing to registries other than crates.io |
-| **User Benefit** | Enterprise users can publish to private registries |
-| **Technical Approach** | Extend `RegistryClient` trait; support crates.io-compatible APIs |
-| **Dependencies** | Configuration for custom registry URLs |
-| **Complexity** | Medium |
-| **Success Criteria** | Works with common alternatives (GitHub, Cloudsmith, self-hosted) |
-
----
-
-### JSON/YAML Output Formats
-
-| Attribute | Details |
-|-----------|---------|
-| **Description** | Machine-readable output for all commands |
-| **User Benefit** | Parse Shipper output in scripts and tooling |
-| **Technical Approach** | Add `--format json|yaml` flag to relevant commands |
-| **Dependencies** | `serde_json`, `serde_yaml` crates |
-| **Complexity** | Small |
-| **Success Criteria** | All status commands support JSON/YAML; schema documented |
-
-```bash
-# Example output
-shipper status --format json
-{
-  "plan_id": "abc123",
-  "crates": [
-    {"name": "crate-a", "version": "1.0.0", "state": "Published"}
-  ]
-}
-```
-
----
-
-### Improved Error Categorization
-
-| Attribute | Details |
-|-----------|---------|
-| **Description** | Classify more errors as retryable or permanent with better detection |
-| **User Benefit** | Faster failure detection; fewer unnecessary retries |
-| **Technical Approach** | Enhance error parsing from cargo output; add more HTTP status code handling |
-| **Dependencies** | None |
-| **Complexity** | Medium |
-| **Success Criteria** | All known error types classified; ambiguous cases logged for improvement |
-
----
-
-### Lock File Improvements
-
-| Attribute | Details |
-|-----------|---------|
-| **Description** | Implement directory-based locking for parallel workspace publishes |
-| **User Benefit** | Run Shipper on multiple workspaces simultaneously |
-| **Technical Approach** | Use workspace path hash for lock file location instead of global `.shipper/lock` |
-| **Dependencies** | None |
-| **Complexity** | Small |
-| **Success Criteria** | Concurrent Shipper runs on different workspaces succeed |
-
----
-
-## Explicit Non-Goals
-
-Shipper intentionally does NOT plan to support:
+Shipper does NOT plan to support:
 
 | Feature | Alternative |
-|---------|-------------|
-| Version bumping | Use [cargo-release](https://github.com/crate-ci/cargo-release) |
-| Changelog generation | Use [release-plz](https://github.com/MarcoIeni/release-plz) |
-| Git tag creation | Use cargo-release |
-| GitHub release creation | Use `gh` CLI or GitHub Actions |
-| crate.io team management | Use `cargo owner` directly |
-| Dependency updates | Use cargo's built-in commands |
+|---|---|
+| Version bumping | [cargo-release](https://github.com/crate-ci/cargo-release) |
+| Changelog generation | [release-plz](https://github.com/MarcoIeni/release-plz) |
+| Git tag creation | cargo-release |
+| GitHub release creation | `gh` CLI or GitHub Actions |
+| crates.io team management | `cargo owner` |
+| Dependency updates | cargo's built-in commands |
 
 **Shipper focuses on reliable publishing, not release orchestration.**
 
----
+## Contributing
 
-## Contributing to the Roadmap
+How features are prioritized:
+1. Fit with the nine-competency thesis
+2. Whether it closes a gap blocking v0.3.0 stable
+3. Maintenance burden vs value
 
-### How Features Are Prioritized
+To contribute:
+1. Pick an issue from #100–#109 or one of the child issues #90–#99
+2. Comment to claim
+3. Open a draft PR with tests + documentation per [CONTRIBUTING.md](CONTRIBUTING.md)
 
-Roadmap items are prioritized based on:
+## Version history
 
-1. **Community feedback** - Feature requests and use cases from GitHub Issues
-2. **Ecosystem trends** - Changes to crates.io, Cargo, or Rust tooling
-3. **Maintenance burden** - Complexity vs. value trade-offs
-4. **Strategic alignment** - Fit with Shipper's design principles
-
-### Suggesting a Feature
-
-To suggest a feature:
-
-1. Check existing [GitHub Issues](https://github.com/effortlessmetrics/shipper/issues)
-2. Open a new issue with the `enhancement` label
-3. Describe your use case and expected behavior
-4. Include: User story, technical approach (if known), priority justification
-
-### Implementing a Feature
-
-If you'd like to implement a roadmap item:
-
-1. Comment on the GitHub issue to express interest
-2. Review the [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines
-3. Propose an implementation plan in a draft PR
-4. Ensure tests and documentation are included
-
----
-
-## Version History
-
-| Version | Status | Theme | Notes |
-|---------|--------|-------|-------|
-| v0.2.0 | **Current** | Evidence & Verification | Parallel publishing, configuration files, readiness verification |
-| v0.1.0 | Released | Core Functionality | Initial release with basic publish workflow |
-
----
-
-## Appendix: Complexity Guidelines
-
-| Rating | Description | Typical Effort |
-|--------|-------------|----------------|
-| **Small** | Can be implemented in < 1 week; affects single module | 2-5 days |
-| **Medium** | Requires architectural consideration; 1-2 weeks | 1-2 weeks |
-| **Large** | Major feature requiring design; 1+ months | Several weeks to months |
-
-Complexity estimates assume:
-- Familiarity with Shipper codebase
-- Code review and testing requirements
-- Documentation updates included
+| Version | Date | Theme |
+|---|---|---|
+| v0.3.0-rc.1 | 2026-04-16 | First crates.io publish; 12 crates live; deterministic plan, retry absorption (41 retries), evidence trail proven under real rate limits |
+| v0.2.0 | 2026-02-14 | Evidence + verification (event log, receipts, readiness checks, publish policies) |
+| v0.1.0 | — | Initial release |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,7 @@
 # Shipper Roadmap
 
+> See [MISSION.md](MISSION.md) for the mission, vision, audience, and beliefs that produce the priorities below.
+
 ## Where we are
 
 **v0.3.0-rc.1 shipped 2026-04-16.** Twelve crates went live on crates.io: `shipper`, `shipper-cli`, `shipper-config`, `shipper-types`, `shipper-registry`, `shipper-duration`, `shipper-retry`, `shipper-encrypt`, `shipper-output-sanitizer`, `shipper-cargo-failure`, `shipper-sparse-index`, `shipper-webhook`. The publish train was driven by Shipper itself — first real-world dogfooding under crates.io rate limits, with 41 retries silently absorbed across a 69-minute run.

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -1,0 +1,40 @@
+# Invariants
+
+## Truth, projection, summary
+
+Three files in `.shipper/` carry execution data. They have a strict ordering of authority.
+
+### `events.jsonl` — truth
+Append-only. Every state transition emits exactly one event with timestamp, package context, and event-type-specific payload. Never replayed-and-rewritten. Never compacted (events are bounded by package count × attempt count, both small).
+
+### `state.json` — projection
+A serialized view of the current `ExecutionState`, rewritten after every package state change. Equivalent to a fold over `events.jsonl` followed by snapshotting. Used by `shipper resume` for fast recovery without replaying the full event log.
+
+### `receipt.json` — summary
+Written once at end-of-run. Summarizes packages, plan, registry, environment, and event log location. Intended for CI artifacts and audit consumers.
+
+## The invariant
+
+> The set of `package_published` events in `events.jsonl` MUST equal the set of packages with `state.state == "published"` in `state.json`.
+
+Drift between events and state is a bug. Per [#93](https://github.com/EffortlessMetrics/shipper/issues/93), an end-of-run consistency check enforces this and emits `state_event_drift_detected` on mismatch.
+
+## Why it matters
+
+`shipper resume` reads `state.json` to decide which packages to skip. If state.json drifts from events, resume could either re-publish duplicates (state under-reports success) or refuse to continue valid work (state over-reports success).
+
+The contract guarantees: even if `state.json` is corrupted or deleted, the run can be reconstructed from `events.jsonl` alone (per [#101](https://github.com/EffortlessMetrics/shipper/issues/101)'s state-rebuild capability).
+
+## Field-name caveat
+
+In `state.json`, package status is at `.packages[].state.state`, not `.packages[].status`. The original v0.3.0-rc.1 retrospective briefly misread the file by querying the wrong path. The invariant above is what makes that ambiguity recoverable: events are the truth, the projection's exact field path is implementation detail.
+
+## Practical guidance for tooling
+
+If you are writing tooling that consumes Shipper output:
+
+- **For per-event audit / streaming**: read `events.jsonl`. Each line is one JSON object.
+- **For "what's the current state"**: read `state.json`. Treat it as a cache; reconcile against events if you suspect drift.
+- **For "did this release succeed and what was published"**: read `receipt.json`.
+
+Never derive critical decisions from CLI stdout alone. Stdout is a human-facing rendering of the events; structured consumers should always go to the JSON files.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,61 @@
+# Shipper Documentation
+
+Organized by reader purpose ([Diátaxis](https://diataxis.fr/)). Pick the column that matches what you need right now.
+
+| Need | Go to |
+|---|---|
+| **Learn** by doing a task end-to-end | [Tutorials](#tutorials) |
+| **Solve** a specific problem you already understand | [How-to guides](#how-to-guides) |
+| **Look up** exact command, flag, or schema | [Reference](#reference) |
+| **Understand** why Shipper works the way it does | [Explanation](#explanation) |
+
+---
+
+## Tutorials
+
+Step-by-step learning paths. Start here if you've never used Shipper before.
+
+- [First publish — from a toy workspace](tutorials/first-publish.md)
+- [Recover from an interrupted release](tutorials/recover-from-interruption.md)
+
+## How-to guides
+
+Task-oriented recipes. Each solves one focused problem.
+
+- [Run a release in GitHub Actions](how-to/run-in-github-actions.md)
+- [Inspect state, events, and receipts](how-to/inspect-state-and-receipts.md)
+
+Operator runbook (promotion to how-to pending): [release-runbook.md](release-runbook.md)
+
+## Reference
+
+Exhaustive, precise, stable specs.
+
+- [CLI reference](reference/cli.md) (canonical source: `shipper --help` / `shipper <cmd> --help`)
+- [`.shipper.toml` configuration](configuration.md)
+- [Preflight checks](preflight.md)
+- [Readiness verification](readiness.md)
+- [Failure modes](failure-modes.md)
+
+## Explanation
+
+Design decisions and reasoning. Read these to understand *why* things are the way they are.
+
+- [Why Shipper exists](explanation/why-shipper.md)
+- [Architecture](architecture.md)
+- [Events-as-truth invariant](INVARIANTS.md)
+- [Product overview](product.md)
+- [Repository structure](structure.md)
+- [Tech stack](tech.md)
+
+## Root-level orientation
+
+The following live at the repo root because they carry repo-wide authority:
+
+- [MISSION.md](../MISSION.md) — mission, vision, audience, beliefs
+- [ROADMAP.md](../ROADMAP.md) — five pillars, nine-competency scorecard, now/next/later
+- [README.md](../README.md) — product README
+- [CLAUDE.md](../CLAUDE.md) / [GEMINI.md](../GEMINI.md) — AI-assistant orientation
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — contribution guide
+- [SECURITY.md](../SECURITY.md) — security policy
+- [CHANGELOG.md](../CHANGELOG.md) — release history

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,375 +1,214 @@
 # Architecture
 
-Shipper is a **publishing reliability layer** for Rust workspaces. It wraps
-`cargo publish` with deterministic ordering, preflight checks, retry/backoff,
-state persistence, and audit evidence — making multi-crate publishes safe to
-start, safe to interrupt, and safe to re-run.
+Shipper is a **publishing reliability layer** for Rust workspaces. It wraps `cargo publish` with deterministic ordering, preflight checks, retry/backoff, ambiguity reconciliation, state persistence, and audit evidence — making multi-crate publishes safe to start, safe to interrupt, and safe to re-run.
+
+> See [MISSION.md](../MISSION.md) for the *why*. This doc is the *how*.
 
 ---
 
-## Workspace Structure
+## The architectural rule
 
-The repository is a Cargo workspace with **31 crates**: one facade library, one
-CLI binary, and 29 focused microcrates that each own a single responsibility.
+**Crates are semver promises. Folders are ownership boundaries.**
 
-### Facade & CLI
+Every published crate on crates.io is a public API surface that downstream users will pin and depend on. Every published crate is a versioning commitment we have to honor. So we do not split a crate every time we want a new ownership boundary — we use **modules** for that. We split a crate only when:
 
-| Crate | Kind | Purpose |
-|-------|------|---------|
-| `shipper` | lib | Facade — re-exports every microcrate as a public module |
-| `shipper-cli` | bin | Thin CLI that parses args via `clap` and delegates to the library |
+- it has a genuinely independent value as a library to other consumers, OR
+- it carries a stable contract that we want to commit to versioning separately
 
-### Microcrates
+Most of the time, an internal subsystem (auth, lock, planning, execution core, parallel engine, state store, events writer, etc.) is one of those things. It deserves an owner; it does not deserve a published crate.
 
-> **Note:** The project is consolidating many single-responsibility microcrates
-> into module folders under `shipper`, `shipper-config`, and `shipper-cli`
-> (the "decrating" effort). Entries below marked _Absorbed_ are no longer
-> published as standalone crates. A post-absorption refresh will rewrite this
-> section around the final module layout (`engine/`, `plan/`, `ops/`,
-> `runtime/`, `store/`).
+This rule produces three consequences we hold to:
+
+1. **The public crate count stays small.** Today: 12 crates. We don't grow that lightly.
+2. **`pub(crate)` is the default.** Crate roots are curated facades; subsystems stay crate-private unless externally consumed.
+3. **No deep lateral imports.** Subsystems talk through owner-facing module roots, not through each other's internal helpers. That preserves SRP without preserving every microcrate.
+
+---
+
+## Workspace layout
+
+The workspace has **12 crates**, all published. There is no separate "workspace-internal" tier. When a concern needs an owner that doesn't deserve a public crate, it lives as a module inside the relevant owner crate.
+
+### Primary surface
 
 | Crate | Purpose |
-|-------|---------|
-| `shipper-cargo` | Workspace metadata via `cargo_metadata` |
-| `shipper-cargo-failure` | Classify `cargo publish` stderr into typed failure categories |
-| `shipper-chunking` | _Absorbed — now `shipper::plan::chunking` module (PR #56)_ |
-| `shipper-config` | Load, merge, and validate `.shipper.toml` configuration files; `runtime` submodule converts `ShipperConfig` + CLI overrides into `RuntimeOptions` |
-| `shipper-config-runtime` | _Absorbed — now `shipper-config::runtime` module (PR #58)_ |
-| `shipper-duration` | Human-friendly duration parsing and serde codecs |
+|---|---|
+| `shipper` | Core library — engine, plan, state, runtime, ops |
+| `shipper-cli` | Thin CLI binary (`shipper` command) |
+| `shipper-config` | `.shipper.toml` parsing, validation, and CLI-overlay |
+| `shipper-types` | Shared domain types (Plan, ExecutionState, Receipt, events, schema) |
+| `shipper-registry` | Registry HTTP client (REST API: version-existence, owners) |
+
+### Published support crates
+
+These are leaf utilities with genuine standalone value to other consumers:
+
+| Crate | Purpose |
+|---|---|
+| `shipper-duration` | Human-friendly duration parsing + serde codecs |
+| `shipper-retry` | Retry/backoff strategies (exponential, linear, constant) with jitter |
 | `shipper-encrypt` | AES-256-GCM encryption for state files |
-| `shipper-environment` | _Absorbed — now `shipper::runtime::environment` module (PR #65)_ |
-| `shipper-events` | _Absorbed — now `shipper::state::events` module (PR #60)_ |
-| `shipper-execution-core` | _Absorbed — now `shipper::runtime::execution` module (PR #69)_ |
-| `shipper-git` | _Absorbed — now `shipper::ops::git` module (decrating Phase 2)_ |
-| `shipper-levels` | _Absorbed — now `shipper::plan::levels` module (PR #56)_ |
-| `shipper-lock` | _Absorbed — now `shipper::ops::lock` module (PR #52)_ |
-| `shipper-output-sanitizer` | Redact tokens and secrets from captured cargo output |
-| `shipper-plan` | _Absorbed — now `shipper::plan` module (PR #56)_ |
-| `shipper-policy` | _Absorbed — now `shipper::runtime::policy` module (PR #54)_ |
-| `shipper-process` | _Absorbed — now `shipper::ops::process` module (PR #55)_ |
-| `shipper-progress` | _Absorbed — now `shipper-cli::output::progress` module (PR #67)_ |
-| `shipper-registry` | HTTP client for registry REST API (version check, owners) |
-| `shipper-retry` | Configurable retry strategies (exponential, linear, constant) with jitter |
-| `shipper-schema` | _Folded into `shipper-types::schema` — schema-version parsing and validation now lives in `shipper-types` (Phase 6)_ |
-| `shipper-sparse-index` | Cargo sparse-index path derivation and version lookup |
-| `shipper-state` | _Absorbed — now `shipper::state::execution_state` module (PR #60)_ |
-| `shipper-storage` | _SPLIT — config types to `shipper-types::storage`, backend to `shipper::ops::storage` (PR #68)_ |
-| `shipper-store` | _Absorbed — now `shipper::state::store` module (PR #57)_ |
-| `shipper-types` | Core domain types (specs, plans, options, receipts, errors) |
 | `shipper-webhook` | Webhook notifications for publish lifecycle events |
+| `shipper-sparse-index` | Cargo sparse-index path derivation and version lookup |
+| `shipper-cargo-failure` | Classify `cargo publish` stderr into typed failure categories |
+| `shipper-output-sanitizer` | Redact tokens and secrets from captured cargo output |
+
+### Workspace internals — modules, not crates
+
+Many subsystems that started as crates have been consolidated into modules under `shipper`, `shipper-config`, or `shipper-cli`. Each of these has a clear owner module root and a `pub(crate)` boundary; they are not on crates.io.
+
+Examples (non-exhaustive — see [structure.md](structure.md) for the full module map):
+
+- `shipper::ops::auth` — token resolution + OIDC detection
+- `shipper::ops::lock` — file-based distributed locking
+- `shipper::ops::process` — subprocess invocation + capture
+- `shipper::plan` — workspace analysis, topo-sort, plan_id, levels, chunking
+- `shipper::engine` — preflight + parallel publish + readiness verification
+- `shipper::runtime::execution` — error classification, retry coordination
+- `shipper::runtime::policy` — publish/verify/readiness policy resolution
+- `shipper::runtime::environment` — environment fingerprinting
+- `shipper::state::execution_state` — `state.json` writer (atomic)
+- `shipper::state::events` — `events.jsonl` writer (append-only)
+- `shipper::state::store` — `StateStore` trait
+- `shipper-config::runtime` — config + CLI → `RuntimeOptions` conversion
+- `shipper-cli::output::progress` — progress bars and TTY rendering
 
 ---
 
-## Dependency Graph
+## Pipeline
 
-> **Note:** The graph below reflects the pre-decrating layout. Crates marked
-> _Absorbed_ above no longer exist as standalone nodes — their edges are now
-> intra-crate module edges inside `shipper`, `shipper-config`, or `shipper-cli`.
-> A full redraw is deferred to the post-Phase-2 doc refresh.
-
-Arrows read as "depends on". Only shipper-\* edges are shown.
+The core flow is **plan → preflight → publish → (resume if interrupted)**.
 
 ```
-shipper-cli
-  ├── shipper  (facade)
-  └── shipper-duration
-  (progress UI lives inline at shipper-cli::output::progress)
-
-shipper  (facade — re-exports all microcrates)
-  ├── shipper-types            (includes schema module, formerly `shipper-schema`)
-  ├── shipper-config           (runtime conversion helpers live in `shipper_config::runtime`)
-  ├── shipper-retry
-  ├── shipper-duration
-  ├── shipper-levels
-  ├── shipper-encrypt
-  ├── shipper-webhook
-  ├── shipper-cargo-failure
-  ├── shipper-output-sanitizer
-  ├── shipper-sparse-index
-  ├── shipper-cargo           (optional)
-  ├── shipper-registry
-  └── shipper-sparse-index
+                                  ┌─────────────────────────────┐
+shipper plan ──────────────────► │ ReleasePlan (plan_id stable) │
+                                  └─────────────────────────────┘
+                                                │
+                                                ▼
+                                  ┌─────────────────────────────┐
+shipper preflight ──────────────► │ Finishability assessment    │
+                                  │ (Proven / NotProven / Failed)│
+                                  └─────────────────────────────┘
+                                                │
+                                                ▼
+                                  ┌─────────────────────────────┐
+shipper publish ────────────────► │ ExecutionState              │
+                                  │ events.jsonl (append)       │
+                                  │ state.json (atomic update)  │
+                                  │ receipt.json (end-of-run)   │
+                                  └─────────────────────────────┘
+                                                │
+                                            ⚠ killed?
+                                                │
+                                                ▼
+                                  ┌─────────────────────────────┐
+shipper resume ─────────────────► │ Reload state, validate      │
+                                  │ plan_id, skip published     │
+                                  │ packages, continue          │
+                                  └─────────────────────────────┘
 ```
 
-### Microcrate internal edges
+### Plan
+Reads workspace via `cargo_metadata`, filters publishable crates, topologically sorts by intra-workspace dependencies (Kahn's algorithm with `BTreeSet` for determinism), computes a SHA256-based `plan_id` over (workspace identity × dependency graph × versions). Same workspace state always produces the same `plan_id`.
+
+### Preflight
+Validates git cleanliness, registry reachability, performs a workspace dry-run, checks version-not-taken, optionally verifies ownership. Produces a `Finishability` (Proven / NotProven / Failed). For first-publish runs of brand-new crates, `NotProven` is the correct outcome — see [#100](https://github.com/EffortlessMetrics/shipper/issues/100).
+
+### Publish
+Executes the plan one crate at a time with retry/backoff. After each `cargo publish`, verifies registry visibility (sparse index and/or API) before advancing to dependent crates. Persists `ExecutionState` to disk after every step.
+
+### Resume
+Reloads `.shipper/state.json`, validates the `plan_id` matches the current workspace plan, skips already-published packages, continues from the first pending crate. Plan-ID mismatch refuses resume unless `--force-resume`.
+
+---
+
+## Key abstractions
+
+| Trait / Type | Lives in | Purpose |
+|---|---|---|
+| `StateStore` | `shipper::state::store` | Persistence abstraction. Currently filesystem-backed; designed to host future cloud backends. |
+| `Reporter` | `shipper::engine` | Pluggable output handler for publish/preflight progress. |
+| `RegistryClient` | `shipper-registry` | Trait-based registry API access (mock-friendly). |
+| `ErrorClass` | `shipper-types` | `Retryable` (HTTP 429, network) / `Permanent` (auth, version conflict) / `Ambiguous` (upload may have succeeded despite client error). Only `Retryable` triggers backoff today; `Ambiguous` reconciliation is the largest open gap ([#99](https://github.com/EffortlessMetrics/shipper/issues/99)). |
+| `PublishPolicy` / `VerifyMode` / `ReadinessMethod` | `shipper-types` | Configuration enums controlling safety vs speed tradeoffs. |
+| `Finishability` | `shipper-types` | Preflight assessment outcome. |
+
+---
+
+## State files
+
+See [INVARIANTS.md](INVARIANTS.md) for the truth/projection/summary contract.
+
+| File | Authority | Purpose |
+|---|---|---|
+| `events.jsonl` | **Truth** (append-only) | Every state transition |
+| `state.json` | Projection | Serialized `ExecutionState` for resume |
+| `receipt.json` | Summary | End-of-run audit summary |
+| `lock` | — | Concurrent-publish guard |
+
+---
+
+## Dependency graph
+
+Arrows read as "depends on"; only `shipper-*` edges are shown.
 
 ```
-shipper-types
-  ├── shipper-encrypt
-  ├── shipper-webhook
-  ├── shipper-retry
-  ├── shipper-duration
-  └── shipper-levels
+shipper-cli ──► shipper
+shipper-cli ──► shipper-duration
 
-shipper-config  (contains `runtime` submodule for config→RuntimeOptions conversion)
-  ├── shipper-types            (for schema-version helpers + domain types)
-  ├── shipper-encrypt
-  ├── shipper-webhook
-  └── shipper-retry
+shipper ──► shipper-types
+shipper ──► shipper-config
+shipper ──► shipper-registry
+shipper ──► shipper-retry
+shipper ──► shipper-duration
+shipper ──► shipper-encrypt
+shipper ──► shipper-webhook
+shipper ──► shipper-cargo-failure
+shipper ──► shipper-output-sanitizer
+shipper ──► shipper-sparse-index
+
+shipper-config ──► shipper-types
+shipper-config ──► shipper-encrypt
+shipper-config ──► shipper-webhook
+shipper-config ──► shipper-retry
 
 shipper-registry ──► shipper-sparse-index
-shipper-cargo ──► shipper-output-sanitizer
+shipper-registry ──► shipper-output-sanitizer
 
-Leaf crates (zero shipper-* dependencies):
-  shipper-cargo-failure, shipper-chunking,
-  shipper-duration, shipper-encrypt, shipper-levels,
-  shipper-lock, shipper-output-sanitizer, shipper-process,
-  shipper-retry,
-  shipper-sparse-index, shipper-webhook
+shipper-types ──► shipper-encrypt
+shipper-types ──► shipper-webhook
+shipper-types ──► shipper-retry
+shipper-types ──► shipper-duration
+
+Leaf crates (no shipper-* dependencies):
+  shipper-cargo-failure, shipper-duration, shipper-encrypt,
+  shipper-output-sanitizer, shipper-retry, shipper-sparse-index,
+  shipper-webhook
 ```
 
 ---
 
-## Core Flow
+## Conventions
 
-Every publish operation follows the same pipeline:
-
-```
- ┌────────┐    ┌───────────┐    ┌─────────┐    ┌────────┐    ┌─────────┐
- │  Plan  │───►│ Preflight │───►│ Publish │───►│ Verify │───►│ Receipt │
- └────────┘    └───────────┘    └─────────┘    └────────┘    └─────────┘
-                                     │              ▲
-                                     │  per crate   │
-                                     └──────────────┘
-```
-
-### 1. Plan (`shipper plan`)
-
-`plan::build_plan` reads the workspace manifest via `cargo_metadata`, filters
-out `publish = false` crates and crates whose current version already exists on
-the registry, then produces a **topologically sorted** `ReleasePlan`. The plan
-is identified by a deterministic SHA-256 hash (`plan_id`) so that resume
-operations can verify they match the original intent.
-
-### 2. Preflight (`shipper preflight`)
-
-`engine::run_preflight` runs all safety checks **without publishing**:
-
-- **Git cleanliness** — working tree must be clean (unless `--allow-dirty`).
-- **Dry-run compilation** — `cargo publish --dry-run` for each crate.
-- **Version existence** — confirm the version is not already on the registry.
-- **Ownership** — optionally verify the current user is an owner (best-effort).
-- **Registry reachability** — verify the API endpoint responds.
-
-The result is a `PreflightReport` with a `Finishability` verdict (all-good,
-warnings-only, or blocking issues).
-
-### 3. Publish (`shipper publish`)
-
-`engine::run_publish` executes the plan crate-by-crate (or wave-by-wave in
-parallel mode via `engine::parallel`):
-
-- Runs `cargo publish -p <crate>` with `--no-verify` passthrough if requested.
-- On failure, classifies the error (`cargo_failure`) and applies retry with
-  configurable backoff (`retry`).
-- Persists state to `.shipper/state.json` after every step so the run is
-  resumable.
-- Fires webhook events and appends to the JSONL event log.
-
-### 4. Verify (readiness checks)
-
-After each successful `cargo publish`, shipper polls the registry to confirm
-the newly published version is visible:
-
-- **API check** — HTTP GET to the registry REST API.
-- **Index check** — sparse-index lookup for the version string.
-- Configurable timeout, poll interval, and method (`api`, `index`, or `both`).
-
-This prevents dependent crates from attempting to publish before their
-dependencies are actually resolvable.
-
-### 5. Receipt
-
-On completion (or partial completion), shipper writes:
-
-- `.shipper/state.json` — resumable execution state.
-- `.shipper/receipt.json` — machine-readable audit receipt with per-crate
-  evidence (attempt counts, durations, error classifications, timestamps).
-- `.shipper/events.jsonl` — append-only structured event log.
-
-### Resume (`shipper resume`)
-
-`engine::run_resume` reloads persisted state, verifies the `plan_id` matches
-(unless `--force-resume`), and continues from the first pending or failed
-package. This makes shipper safe to use in CI where jobs may be cancelled and
-restarted.
+- `unsafe_code = "forbid"` workspace-wide. No `unsafe` blocks anywhere.
+- Edition 2024, MSRV 1.92, resolver v3.
+- Tests touching env vars or filesystem use `#[serial]` from `serial_test` for isolation.
+- Registry interactions in tests use `tiny_http` mock servers — never real registries.
+- Snapshot tests use `insta`. Property-based tests use `proptest`.
+- Token resolution follows Cargo conventions: `CARGO_REGISTRY_TOKEN` → `CARGO_REGISTRIES_<NAME>_TOKEN` → `$CARGO_HOME/credentials.toml`. Tokens are opaque strings, never logged.
+- Atomic file writes everywhere (write-temp + fsync + rename + fsync-parent).
+- `BTreeSet`/`BTreeMap` over `HashSet`/`HashMap` where iteration order is observable.
 
 ---
 
-## Key Design Decisions
+## See also
 
-### SRP microcrate architecture
-
-Each concern lives in its own crate with a minimal public API. This provides:
-
-- **Fast incremental builds** — changing `shipper-retry` does not recompile
-  unrelated microcrates like `shipper-webhook`.
-- **Independent testability** — each crate has its own unit tests with no
-  reliance on the full workspace.
-- **Stable public surface** — the 13-crate target (achieved via the
-  decrating effort) keeps semver promises and docs.rs pages small while
-  preserving SRP at the module level inside the facade crate.
-
-Several of the remaining microcrates are **leaf crates** with zero internal
-dependencies, enforcing loose coupling.
-
-### Facade pattern
-
-The `shipper` crate does not contain significant logic of its own. It
-re-exports each microcrate as a module (e.g., `shipper::auth`, `shipper::plan`)
-and provides `cfg`-gated module declarations that swap between local
-implementations and microcrate re-exports based on the active feature set.
-The CLI depends only on `shipper`, never on individual microcrates directly
-(except `shipper-duration`). Progress-bar UI lives inside `shipper-cli` itself
-at `shipper-cli::output::progress`.
-
-### State persistence for resumability
-
-Execution state is serialised to `.shipper/state.json` after every crate
-publish step. The state file records:
-
-- The `plan_id` (SHA-256) to match against the current plan.
-- Per-package status (`Pending`, `Publishing`, `Published`, `Failed`).
-- Attempt counts and error history.
-- Optional AES-256-GCM encryption (via `--encrypt`).
-
-Resume verifies the plan hash before continuing, preventing accidental
-cross-plan confusion. A pluggable `StorageBackend` trait allows state files to
-be persisted to cloud storage (S3, GCS, Azure) for distributed CI.
-
-### Registry verification with backoff
-
-After each `cargo publish`, shipper does **not** assume the version is
-immediately available. It actively polls the registry API and/or sparse index,
-using configurable timeouts and intervals. This eliminates the most common
-multi-crate publish failure: a dependent crate trying to resolve a dependency
-that the registry has not yet indexed.
-
-The retry layer (`shipper-retry`) provides exponential, linear, and constant
-backoff strategies with configurable jitter, applied both to publish retries
-and readiness polling.
-
----
-
-## Module Responsibilities
-
-> **Note:** Entries for _Absorbed_ crates (see the Microcrates table above)
-> describe their pre-decrating roles. Those responsibilities now live in
-> modules inside `shipper`, `shipper-config`, or `shipper-cli`. A full
-> rewrite of this section is deferred to the post-Phase-2 doc refresh.
-
-### Configuration layer
-
-| Crate | Role |
-|-------|------|
-| `shipper-config` | Parse `.shipper.toml`, merge sections, validate constraints; `runtime` submodule converts `ShipperConfig` + `CliOverrides` → `RuntimeOptions` |
-| `shipper-types::schema` | Parse and validate schema version identifiers in state files (formerly the standalone `shipper-schema` crate, folded in during Phase 6) |
-
-Configuration flows: CLI flags → `CliOverrides` → merged with `ShipperConfig`
-from disk → produces `RuntimeOptions` consumed by the engine.
-
-### Execution layer
-
-| Crate | Role |
-|-------|------|
-| `shipper-cargo` | Run `cargo metadata` / `cargo publish` via subprocess |
-| `shipper-cargo-failure` | Pattern-match `cargo publish` stderr into failure categories |
-| `shipper-process` | Cross-platform process spawning with timeout support |
-| `shipper-output-sanitizer` | Strip tokens and secrets from captured subprocess output |
-
-The `engine` module inside the `shipper` facade implements the sequential
-publish loop; `engine::parallel` (absorbed from the former
-`shipper-engine-parallel` microcrate) extends this with dependency-level
-wave concurrency.
-
-### Planning layer
-
-| Crate | Role |
-|-------|------|
-| `shipper-plan` | Read workspace, filter publishable crates, topological sort |
-| `shipper-levels` | Group packages by dependency depth for parallel wave planning |
-| `shipper-chunking` | Subdivide waves into bounded-size chunks (`--max-concurrent`) |
-
-### State & persistence layer
-
-| Crate | Role |
-|-------|------|
-| `shipper::state::execution_state` | Read/write `state.json` with optional encryption (absorbed) |
-| `shipper::state::store` | `StateStore` trait — high-level read/write/list for state + events (absorbed) |
-| `shipper-encrypt` | AES-256-GCM encrypt/decrypt primitives |
-| `shipper::state::events` | Append-only JSONL event log writer (absorbed) |
-
-### Infrastructure layer
-
-| Crate | Role |
-|-------|------|
-| `shipper-registry` | HTTP client for registry API (version existence, owner queries) |
-| `shipper-sparse-index` | Derive sparse-index paths and check index content for versions |
-| `shipper-lock` | File-based advisory lock with configurable staleness timeout |
-
-### Types & utilities
-
-| Crate | Role |
-|-------|------|
-| `shipper-types` | Core domain types: `ReleaseSpec`, `ReleasePlan`, `RuntimeOptions`, `Receipt`, errors |
-| `shipper-duration` | Parse human-readable durations (`2s`, `5m`) and serde codecs |
-| `shipper-retry` | Retry strategies (exponential / linear / constant) with jitter |
-| `shipper-levels` | Dependency-level grouping data structure |
-| `shipper-webhook` | Webhook payload types and HTTP delivery |
-
----
-
-## CLI Commands
-
-The `shipper` binary (crate `shipper-cli`) exposes these subcommands:
-
-| Command | Description |
-|---------|-------------|
-| `plan` | Print the deterministic publish order |
-| `preflight` | Run all safety checks without publishing |
-| `publish` | Execute the plan (auto-resumes if matching state exists) |
-| `resume` | Continue an interrupted publish run |
-| `status` | Compare local versions against the registry |
-| `doctor` | Print environment and auth diagnostics |
-| `inspect-events` | View the structured event log |
-| `inspect-receipt` | View the audit receipt with evidence |
-| `ci <platform>` | Print CI configuration snippets (GitHub Actions, GitLab, CircleCI, Azure DevOps) |
-| `clean` | Remove state files (optionally keep receipt) |
-| `config init` | Generate a default `.shipper.toml` |
-| `config validate` | Validate a configuration file |
-| `completion <shell>` | Generate shell completions |
-
-Global flags control registry, retry, readiness, policy, parallelism,
-encryption, webhooks, and output format. CLI flags always override
-`.shipper.toml` values.
-
----
-
-## Compile-Time Feature Flags
-
-The `shipper` facade and `shipper-cli` crates do not expose feature flags
-for swapping implementations. Earlier RC builds used a `micro-*` feature
-matrix to toggle between in-tree modules and standalone microcrates; both
-the flags and the dual implementations were removed as part of the
-decrating effort. The production code path is now the only code path.
-
-Token resolution is provided in-crate by `crate::ops::auth` (re-exported
-as `shipper::auth::*`); previously this was the standalone `shipper-auth`
-microcrate.
-
----
-
-## Testing Strategy
-
-- **Unit tests** live alongside each microcrate. Leaf crates are tested in
-  isolation with no mocking required.
-- **Integration tests** in `shipper` and `shipper-cli` use `tiny_http` to mock
-  registry responses, `tempfile` for filesystem isolation, and `serial_test` for
-  tests that mutate environment variables.
-- **Snapshot tests** via `insta` cover plan output, receipt format, and config
-  serialisation.
-- **Property-based tests** via `proptest` verify invariants (e.g., plan
-  determinism, state round-trip).
-- **Fuzz targets** under `fuzz/` exercise state loading and token resolution
-  with `cargo-fuzz`.
-- `#[forbid(unsafe_code)]` is set workspace-wide.
+- [MISSION.md](../MISSION.md) — north star
+- [ROADMAP.md](../ROADMAP.md) — five existential pillars + nine competencies
+- [INVARIANTS.md](INVARIANTS.md) — events-as-truth contract
+- [structure.md](structure.md) — module map
+- [tech.md](tech.md) — tech stack
+- [configuration.md](configuration.md) — `.shipper.toml` reference
+- [preflight.md](preflight.md) — preflight checks
+- [readiness.md](readiness.md) — readiness verification
+- [failure-modes.md](failure-modes.md) — common failure scenarios

--- a/docs/explanation/why-shipper.md
+++ b/docs/explanation/why-shipper.md
@@ -1,0 +1,84 @@
+# Why Shipper exists
+
+Cargo can already package and upload crates. Cargo 1.90 even stabilized `cargo publish --workspace` for multi-package releases. So why does Shipper exist?
+
+## The short answer
+
+Because *uploading* is not the same as *releasing reliably*. The workflow around `cargo publish` is where things break:
+
+- Publishing is **irreversible** (you cannot delete a crates.io version; yank is containment, not undo)
+- CI dies, networks partition, runners cancel, rate limits exist
+- Some publish outcomes are **ambiguous** — cargo's exit code can say "failed" while the upload actually succeeded
+- Operators need to *trust* the tool, which means knowing what it's doing live and reconciling what actually happened after the fact
+
+Shipper exists to own those five responsibilities, so publishing becomes boring:
+
+1. **Prove** — establish before the irreversible step that the release can succeed
+2. **Dispatch** — execute in a registry-aware, paced way
+3. **Reconcile** — close ambiguous outcomes against registry truth before retrying
+4. **Recover** — converge safely from durable state when interrupted
+5. **Remediate** — contain or fix-forward a partial release mechanically
+
+See [ROADMAP.md](../../ROADMAP.md) for status on each.
+
+## What Shipper does *not* do
+
+Shipper is not a release orchestrator. It doesn't pick version numbers, generate changelogs, create git tags, or author GitHub Releases. Those are separate concerns with excellent existing tools ([cargo-release](https://github.com/crate-ci/cargo-release), [release-plz](https://github.com/MarcoIeni/release-plz), `gh` CLI).
+
+Shipper picks up **after** the version is decided and the tag is cut, when the actual upload needs to be safe and recoverable. That boundary matters — it's what keeps Shipper narrow enough to be good at what it does.
+
+## Why finishability has three states
+
+Preflight produces a `Finishability` enum: `Proven | NotProven | Failed`. Three states, not two.
+
+- **`Failed`** — preflight found something actually wrong (git dirty, registry unreachable, dry-run fails). Don't publish.
+- **`Proven`** — every check came back positive. Publish is expected to succeed.
+- **`NotProven`** — checks ran without errors, but some couldn't complete to "proven" status. Example: on a first-publish of a brand-new crate, ownership cannot be verified because the crate doesn't exist yet. That's not a failure; it's epistemically honest.
+
+`NotProven` reads scary but is the correct answer in common situations. [Rehearsal registry (#97)](https://github.com/EffortlessMetrics/shipper/issues/97) is how we eventually turn many `NotProven` cases into `Proven` ones — by publishing to an alternate registry first and verifying install-from-registry resolution.
+
+## Why events are truth and state is a projection
+
+Every state transition emits exactly one event to `events.jsonl` (append-only). `state.json` is a derived snapshot that `shipper resume` reads for fast recovery. `receipt.json` is an end-of-run summary.
+
+When these three disagree, events win. The projection and summary are conveniences; the append-only log is the ledger.
+
+This matters because:
+
+- If `state.json` corrupts or gets deleted, the run can be reconstructed from events alone.
+- A tool consuming Shipper output should prefer events for correctness and state for speed.
+- We can add consistency checks that detect drift between truth and projection — and any drift is a bug.
+
+Full contract: [INVARIANTS.md](../INVARIANTS.md).
+
+## Why the engine is a library and the CLI is thin
+
+`crates/shipper` contains all the domain logic. `crates/shipper-cli` parses args and calls into the library.
+
+The practical reason: other frontends — IDP plugins (Backstage, Port, Cortex), dashboards, custom automation — should be able to consume Shipper directly without shelling out. The library-first split makes that possible without a second rewrite.
+
+The philosophical reason: publishing is going to grow more frontends (chat ops, webhooks, status APIs, etc.). The library is the stable surface; CLIs, plugins, and adapters come and go.
+
+## Why we forbid `unsafe`
+
+`unsafe_code = "forbid"` is enforced workspace-wide. A tool whose pitch is safety should not opt out of Rust's. There is no release for `unsafe` blocks in orchestration code.
+
+## Why this isn't "just a retry wrapper"
+
+Retrying on failure is easy. The interesting questions are:
+
+- *Which* failures should retry? (`ErrorClass::Retryable` vs `Permanent`)
+- What about outcomes that might have succeeded despite a non-zero exit? (`ErrorClass::Ambiguous` — and this is where registry reconciliation matters)
+- How do we know when it's safe to advance to a dependent crate? (Readiness verification against sparse index + API)
+- What if the runner dies mid-retry? (Persisted state + plan-ID-guarded resume)
+- What if a successful publish turns out to be broken? (Receipt-driven yank / fix-forward — planned)
+
+Each answer is a separate responsibility. Shipper owns them all, under a single process, with a single durable ledger. That's the thing Cargo is not, and shouldn't be.
+
+## The single test
+
+If we're doing our job, the single-sentence test from [MISSION.md](../../MISSION.md) is true:
+
+> You can start a release train, stop staring at the terminal, and still trust the outcome.
+
+That's the product. Everything else is mechanism.

--- a/docs/how-to/inspect-state-and-receipts.md
+++ b/docs/how-to/inspect-state-and-receipts.md
@@ -1,0 +1,100 @@
+# How to inspect Shipper state, events, and receipts
+
+After a Shipper run, three files in `.shipper/` tell the story. Different questions → different file.
+
+## Which file for which question?
+
+| Question | File | Command |
+|---|---|---|
+| Exactly what happened, and when? | `events.jsonl` | `shipper inspect-events` |
+| What's the current state (for resume)? | `state.json` | `cat .shipper/state.json` |
+| What was the final outcome + evidence? | `receipt.json` | `shipper inspect-receipt` |
+
+**Authority order:** events are truth, state is a projection, receipt is a summary. When they disagree, events win. See [INVARIANTS.md](../INVARIANTS.md).
+
+## Reading events
+
+```bash
+shipper inspect-events
+```
+
+Or raw:
+
+```bash
+jq -c '.' .shipper/events.jsonl
+```
+
+Each line is one JSON event with:
+- `timestamp` — RFC3339 UTC
+- `event_type.type` — variant name (`package_started`, `package_published`, `preflight_complete`, etc.)
+- `package` — "all" or "<name>@<version>"
+- Event-specific payload under `event_type.*`
+
+### Count events by type
+
+```bash
+jq -r '.event_type.type' .shipper/events.jsonl | sort | uniq -c | sort -rn
+```
+
+### Extract just the publish outcomes
+
+```bash
+jq -c 'select(.event_type.type == "package_published")' .shipper/events.jsonl
+```
+
+### See every attempt (including retries)
+
+```bash
+jq -c 'select(.event_type.type == "package_attempted")' .shipper/events.jsonl | head -20
+```
+
+## Reading state
+
+```bash
+jq '.' .shipper/state.json
+```
+
+Key field: `packages[].state.state` (yes, nested) — values include `"pending"`, `"published"`, `"failed"`, `"ambiguous"`. **Not** `.packages[].status` — that field doesn't exist (common misread).
+
+```bash
+# Packages that are published
+jq '.packages[] | select(.state.state == "published") | .name' .shipper/state.json
+
+# Packages still pending
+jq '.packages[] | select(.state.state == "pending") | .name' .shipper/state.json
+```
+
+## Reading receipts
+
+```bash
+shipper inspect-receipt
+```
+
+Or JSON for CI consumption:
+
+```bash
+shipper inspect-receipt --format json | jq '.'
+```
+
+The receipt is the audit artifact. Keep it. It includes `plan_id`, per-package outcomes, captured evidence (stdout/stderr tails + exit codes), git context, and an environment fingerprint.
+
+## Verifying consistency
+
+If you want to sanity-check that events and state agree:
+
+```bash
+# package_published events
+jq -r 'select(.event_type.type == "package_published") | .event_type.crate_name' .shipper/events.jsonl | sort > /tmp/events_published.txt
+
+# packages with state.state == "published"
+jq -r '.packages[] | select(.state.state == "published") | .name' .shipper/state.json | sort > /tmp/state_published.txt
+
+diff /tmp/events_published.txt /tmp/state_published.txt
+```
+
+They should match exactly. If they don't, events are authoritative. ([#93](https://github.com/EffortlessMetrics/shipper/issues/93) tracks an end-of-run consistency check that does this automatically.)
+
+## See also
+
+- [INVARIANTS.md](../INVARIANTS.md) — the truth/projection/summary contract
+- [Tutorial: Recover from an interrupted release](../tutorials/recover-from-interruption.md)

--- a/docs/how-to/run-in-github-actions.md
+++ b/docs/how-to/run-in-github-actions.md
@@ -1,0 +1,116 @@
+# How to run a Shipper release in GitHub Actions
+
+Goal: a tag push triggers a workspace release driven by Shipper. Interruption-safe, evidence-preserved.
+
+> This repo dogfoods this setup — see `.github/workflows/release.yml` for the production example.
+
+## Minimal workflow
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags: ['v*.*.*']
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Shipper
+        run: cargo install shipper-cli --locked
+
+      - name: Plan
+        run: |
+          mkdir -p .shipper
+          shipper plan --format json | tee .shipper/plan.txt
+
+      - name: Upload plan artifact (before anything destructive)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: shipper-state-plan
+          path: .shipper/
+          include-hidden-files: true
+          retention-days: 30
+
+      - name: Preflight
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: shipper preflight --policy safe
+
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          shipper publish \
+            --policy safe \
+            --readiness-method both \
+            --max-attempts 12 \
+            --max-delay 15m
+
+      - name: Upload final state (always)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: shipper-state-final
+          path: .shipper/
+          include-hidden-files: true
+          retention-days: 90
+```
+
+## Key considerations
+
+### `include-hidden-files: true`
+
+`.shipper/` is a hidden directory. Without this flag, the artifact upload silently skips it. This bit us in rc.1 (issue #89).
+
+### Upload state at every stage
+
+Upload the `.shipper/` directory after plan, after preflight, and after publish (or on failure). If the publish job times out or dies, the most recent artifact is what you need to resume.
+
+### Timeout budget
+
+For a first-publish release of many new crates, crates.io's 1-new-crate-per-10-min rate limit applies. Budget ~10 minutes per crate past the initial 5-crate burst. A 12-crate first publish can run 70–90 minutes. Set `timeout-minutes` accordingly (the example above uses 180).
+
+### Token vs trusted publishing
+
+The example uses `CARGO_REGISTRY_TOKEN`. For a safer posture, use Trusted Publishing (OIDC) — see [#96](https://github.com/EffortlessMetrics/shipper/issues/96) for the migration status. The short version:
+
+```yaml
+permissions:
+  id-token: write
+  contents: write
+
+steps:
+  - uses: rust-lang/crates-io-auth-action@v1  # exchanges OIDC for a short-lived token
+  - run: shipper publish ...                   # uses the exchanged token automatically
+```
+
+### Resume mode
+
+If a release is interrupted, manually trigger the resume workflow (a `workflow_dispatch` with `mode: resume` and `artifact_run_id: <failed run id>`) — or copy the resume job from this repo's `.github/workflows/release.yml`.
+
+## Generate a template
+
+```bash
+shipper ci github-actions > .github/workflows/release.yml
+```
+
+This prints a recent-defaults template you can customize.
+
+## See also
+
+- [Tutorial: First publish](../tutorials/first-publish.md)
+- [Tutorial: Recover from an interrupted release](../tutorials/recover-from-interruption.md)
+- [Release runbook](../release-runbook.md) — operator reference for production releases

--- a/docs/product.md
+++ b/docs/product.md
@@ -1,0 +1,49 @@
+# Product Overview
+
+> Quick orientation for contributors and AI assistants. For mission/vision/beliefs see [../MISSION.md](../MISSION.md). For sequencing see [../ROADMAP.md](../ROADMAP.md).
+
+## What Shipper is
+
+Shipper is a publishing reliability layer for Rust workspaces. It wraps `cargo publish` with the workflow that production releases need: deterministic planning, pre-flight proof, retry absorption, ambiguity reconciliation against registry truth, persistent state, and operator-grade observability.
+
+It is intentionally narrow. Cargo packages and uploads; Shipper handles everything between *"I want to release"* and *"all crates are live, here's the audit trail."*
+
+## Who it is for
+
+See [../MISSION.md](../MISSION.md) for the full audience definition. Briefly: workspace maintainers who publish multiple interdependent crates as coherent releases through CI, and need recovery to be mechanical rather than heroic.
+
+## What's shipped (v0.3.0-rc.1)
+
+| Capability | Status |
+|---|---|
+| Deterministic publish planning (topo-sort + plan_id) | Production |
+| Workspace dry-run preflight | Production |
+| Retry/backoff with HTTP 429 handling | Production |
+| Per-step state persistence and resume | Production (resume verification pending — see [#90](https://github.com/EffortlessMetrics/shipper/issues/90)) |
+| Audit receipts with evidence | Production |
+| Multi-registry orchestration | Production |
+| Sparse-index caching | Production |
+| Workspace-aware locking | Production |
+| Shell completions, doctor diagnostics | Production |
+| OIDC trusted publishing detection | Detection only ([#96](https://github.com/EffortlessMetrics/shipper/issues/96)) |
+| Ambiguity reconciliation | Missing ([#99](https://github.com/EffortlessMetrics/shipper/issues/99) / [#102](https://github.com/EffortlessMetrics/shipper/issues/102)) |
+| Live retry visibility for operators | Missing ([#91](https://github.com/EffortlessMetrics/shipper/issues/91) / [#103](https://github.com/EffortlessMetrics/shipper/issues/103)) |
+| Yank planning / fix-forward | Missing ([#98](https://github.com/EffortlessMetrics/shipper/issues/98) / [#104](https://github.com/EffortlessMetrics/shipper/issues/104)) |
+
+See [../ROADMAP.md](../ROADMAP.md) for the nine-competency status table and sequencing.
+
+## Compared to alternatives
+
+| Tool | Use case | Relationship |
+|---|---|---|
+| `cargo publish -p X` | Single crate | Shipper is the workflow wrapper |
+| [cargo-release](https://github.com/crate-ci/cargo-release) | Version bump + tag + publish | Shipper covers the publish; cargo-release covers the versioning |
+| [release-plz](https://github.com/MarcoIeni/release-plz) | PR-based automated releases | Drives cargo-release; can drive Shipper |
+| `cargo workspaces publish` | Workspace publishing | Shipper adds preflight/state/resume/retry/evidence |
+| Cargo 1.90 `cargo publish --workspace` | Multi-package publish | Same primitive — Shipper adds the reliability layer on top |
+
+Shipper is what you reach for **after** version-decision and tag-creation are done, when the actual upload needs to be safe and recoverable.
+
+## Non-goals
+
+See [../MISSION.md](../MISSION.md) "What we are not."

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,78 @@
+# CLI reference
+
+**Canonical source:** `shipper --help` and `shipper <subcommand> --help`. The help output is generated from the same source as the CLI behavior, so it never drifts.
+
+This page is a topical map, not an exhaustive flag listing. For exhaustive flags, use `--help`.
+
+## Commands at a glance
+
+| Command | What it does | Writes state? |
+|---|---|---|
+| `shipper plan` | Compute and print the deterministic publish order | No |
+| `shipper preflight` | Run safety checks without publishing | No (emits events) |
+| `shipper publish` | Execute the plan (the irreversible step) | Yes |
+| `shipper resume` | Continue from the last persisted state | Yes |
+| `shipper status` | Compare local workspace versions to the registry | No |
+| `shipper doctor` | Environment / auth / connectivity diagnostics | No |
+| `shipper inspect-events` | View the event log | No |
+| `shipper inspect-receipt` | View the end-of-run receipt | No |
+| `shipper clean` | Clean `.shipper/` state files | Yes (destructive) |
+| `shipper config init` | Generate a default `.shipper.toml` | No |
+| `shipper config validate` | Validate an existing config | No |
+| `shipper completion <shell>` | Generate shell completion scripts | No |
+| `shipper ci <platform>` | Print a CI workflow template | No |
+
+## Most-used flags
+
+### Global
+
+- `--config <path>` — path to a custom `.shipper.toml`
+- `--manifest-path <path>` — path to the workspace `Cargo.toml`
+- `--registry <name>` — Cargo registry name (default `crates-io`)
+- `--state-dir <path>` — directory for `.shipper/` state
+- `--format <text|json>` — output format for structured commands
+- `-v/--verbose`, `-q/--quiet` — verbosity controls
+
+### Publish safety
+
+- `--policy <safe|balanced|fast>` — verification posture
+- `--verify-mode <workspace|package|none>` — dry-run granularity
+- `--readiness-method <api|index|both>` — post-publish visibility check
+- `--max-attempts <N>` — retry budget per crate (default 6)
+- `--base-delay <duration>`, `--max-delay <duration>` — backoff envelope
+- `--verify-timeout <duration>`, `--readiness-timeout <duration>` — verification budgets
+
+### Preflight
+
+- `--allow-dirty` — permit a dirty git working tree
+- `--skip-ownership-check` — skip the owners preflight
+- `--strict-ownership` — fail preflight on any ownership ambiguity
+
+### Resume
+
+- `--force-resume` — resume even if the computed plan differs from the state file (advanced; can cause duplicate publish attempts if misused)
+- `--resume-from <crate>` — start from a specific crate
+
+### Parallel
+
+- `--parallel`, `--max-concurrent <N>` — parallelize within dependency levels
+- `--per-package-timeout <duration>` — per-package timeout in parallel mode
+
+## Policy matrix
+
+| Policy | Verify mode | Readiness | Best for |
+|---|---|---|---|
+| `safe` (default) | `workspace` | `both` | Production releases |
+| `balanced` | `package` | `api` | Regular releases when you want speed without skipping essentials |
+| `fast` | `none` | none | Dev / sandbox registries only — not recommended for crates.io |
+
+## Exit codes
+
+(Exit-code reference is tracked separately; see `shipper --help` for the current list.)
+
+## See also
+
+- [Tutorial: First publish](../tutorials/first-publish.md)
+- [How-to: Run in GitHub Actions](../how-to/run-in-github-actions.md)
+- [`.shipper.toml` reference](../configuration.md)
+- [Failure modes](../failure-modes.md)

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -18,10 +18,7 @@ shipper/
 │   ├── shipper-output-sanitizer/      # ANSI strip + token redaction
 │   ├── shipper-retry/                 # Retry/backoff strategies
 │   ├── shipper-sparse-index/          # Sparse index protocol client
-│   ├── shipper-webhook/               # Webhook delivery
-│   ├── shipper-events/                # (workspace-internal)
-│   ├── shipper-state/                 # (workspace-internal)
-│   └── shipper-storage/               # (workspace-internal)
+│   └── shipper-webhook/               # Webhook delivery
 ├── docs/                              # User & contributor documentation
 │   ├── product.md                     # This area: orientation
 │   ├── structure.md                   # This file
@@ -48,7 +45,7 @@ shipper/
 └── CHANGELOG.md
 ```
 
-12 of the 15 crates are published to crates.io as part of v0.3.0-rc.1. The remaining 3 (`shipper-events`, `shipper-state`, `shipper-storage`) are workspace-internal.
+All 12 workspace crates are published to crates.io as part of v0.3.0-rc.1. There is no separate "workspace-internal" tier — when a concern needs ownership, it lives as a module inside an owner crate (see [architecture.md](architecture.md)).
 
 ## `crates/shipper` module map
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,0 +1,102 @@
+# Project Structure
+
+> Snapshot of the repository layout. Source paths drift; check `git ls-files` if anything looks off.
+
+## Workspace layout
+
+```
+shipper/
+├── crates/                            # Workspace members
+│   ├── shipper/                       # Core library — engine, plan, state, runtime
+│   ├── shipper-cli/                   # Thin CLI binary (`shipper` command)
+│   ├── shipper-config/                # .shipper.toml parsing/validation
+│   ├── shipper-types/                 # Shared types (Plan, ExecutionState, Receipt, events)
+│   ├── shipper-registry/              # Registry HTTP clients
+│   ├── shipper-cargo-failure/         # Cargo error classification (ErrorClass patterns)
+│   ├── shipper-duration/              # Human-readable duration parsing
+│   ├── shipper-encrypt/               # State encryption (optional)
+│   ├── shipper-output-sanitizer/      # ANSI strip + token redaction
+│   ├── shipper-retry/                 # Retry/backoff strategies
+│   ├── shipper-sparse-index/          # Sparse index protocol client
+│   ├── shipper-webhook/               # Webhook delivery
+│   ├── shipper-events/                # (workspace-internal)
+│   ├── shipper-state/                 # (workspace-internal)
+│   └── shipper-storage/               # (workspace-internal)
+├── docs/                              # User & contributor documentation
+│   ├── product.md                     # This area: orientation
+│   ├── structure.md                   # This file
+│   ├── tech.md                        # Tech stack
+│   ├── INVARIANTS.md                  # Events-as-truth contract
+│   ├── architecture.md
+│   ├── configuration.md
+│   ├── failure-modes.md
+│   ├── preflight.md
+│   ├── readiness.md
+│   ├── release-runbook.md
+│   └── testing.md
+├── .github/workflows/                 # CI: ci.yml, release.yml, etc.
+├── templates/                         # CI workflow snippets (github-actions, gitlab, ...)
+├── features/                          # Cucumber/BDD scenarios
+├── fuzz/                              # cargo-fuzz targets
+├── MISSION.md                         # North star: mission, vision, beliefs
+├── ROADMAP.md                         # Nine-competency thesis + sequencing
+├── CLAUDE.md                          # AI: Claude Code context
+├── GEMINI.md                          # AI: Gemini context
+├── README.md                          # User entry point
+├── CONTRIBUTING.md
+├── SECURITY.md
+└── CHANGELOG.md
+```
+
+12 of the 15 crates are published to crates.io as part of v0.3.0-rc.1. The remaining 3 (`shipper-events`, `shipper-state`, `shipper-storage`) are workspace-internal.
+
+## `crates/shipper` module map
+
+```
+crates/shipper/src/
+├── lib.rs                # Public API surface
+├── engine/               # Plan/preflight/publish/resume execution
+│   ├── mod.rs            # Top-level engine entry points (run_preflight, run_publish, run_resume)
+│   └── parallel/         # Parallel publish + readiness verification
+│       ├── publish.rs    # Per-crate publish loop with retry/backoff
+│       └── readiness.rs  # Sparse-index + API visibility queries
+├── runtime/              # Execution runtime + error classification
+│   └── execution/        # ErrorClass classification, classify_cargo_failure
+├── plan/                 # Workspace analysis + topo-sort + plan_id
+├── state/                # Persistence layer
+│   ├── execution_state/  # state.json (atomic writes)
+│   ├── events/           # events.jsonl writer (append-only)
+│   └── store/            # StateStore trait
+├── ops/                  # Operations
+│   ├── auth/             # Token resolution + OIDC detection (oidc.rs)
+│   └── lock/             # File-based distributed locking
+├── config.rs             # Internal config helpers
+├── git.rs                # Git working-tree checks
+├── encryption.rs         # State encryption (uses shipper-encrypt)
+├── webhook.rs            # Webhook event emission (uses shipper-webhook)
+├── types.rs              # Crate-internal type aliases
+├── property_tests.rs     # proptest harnesses
+└── stress_tests.rs       # Long-running validation
+```
+
+## Runtime files (`.shipper/`)
+
+Per [INVARIANTS.md](INVARIANTS.md):
+
+| File | Authority | Purpose |
+|---|---|---|
+| `events.jsonl` | **Truth** | Append-only event stream — every state transition |
+| `state.json` | Projection | Serialized `ExecutionState` for fast resume |
+| `receipt.json` | Summary | End-of-run audit summary |
+| `lock` | — | Concurrent-publish guard |
+
+## Tests
+
+- **Unit tests** — alongside the code they cover (`#[cfg(test)] mod tests`)
+- **Integration tests** — `crates/<crate>/tests/`
+- **BDD scenarios** — `features/`
+- **Fuzz targets** — `fuzz/fuzz_targets/`
+- **Snapshots** — `insta`
+- **Property tests** — `proptest`
+- Tests touching env vars or filesystem use `#[serial]` from `serial_test`
+- Registry interactions use `tiny_http` mock servers — never hit real registries

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -1,0 +1,73 @@
+# Tech Stack
+
+> Snapshot of dependencies and conventions. Versions drift — check `Cargo.toml` files for current pins.
+
+## Language & toolchain
+
+- **Rust edition 2024**
+- **MSRV: 1.92**
+- **Resolver v3**
+- `unsafe_code = "forbid"` workspace-wide — no `unsafe` blocks anywhere
+
+## Key runtime dependencies
+
+| Crate | Version (rough) | Purpose |
+|---|---|---|
+| `clap` (derive) | 4.x | CLI parsing in `shipper-cli` |
+| `clap_complete` | 4.x | Shell completion generation |
+| `anyhow` | 1.x | Error handling across library and CLI |
+| `thiserror` | 2.x | Typed error definitions |
+| `serde` / `serde_json` / `serde_with` | 1.x / 1.x / 3.x | All structured I/O (config, state, receipts, events) |
+| `cargo_metadata` | 0.23.x | Reading workspace manifests |
+| `reqwest` | 0.13.x (blocking + json + rustls) | Registry HTTP API + webhook delivery |
+| `chrono` | 0.4.x | Timestamps in events and receipts |
+| `humantime` | 2.x | Human-readable duration parsing/formatting |
+| `tokio` | 1.x | Async primitives (limited use; most logic is sync) |
+| `toml` | 1.x | `.shipper.toml` parsing |
+| `console` / `indicatif` | 0.16.x / 0.18.x | TTY output + progress bars |
+| `sha2` | 0.10.x | Plan ID computation |
+| `aes-gcm` / `hmac` | 0.10 / 0.13 | State encryption (optional) |
+| `which` | 8.x | Tool discovery (`cargo`, `git`) |
+| `dirs` / `gethostname` / `hex` / `rand` | misc | Standard utilities |
+
+## Test & dev dependencies
+
+| Crate | Purpose |
+|---|---|
+| `insta` (with `yaml` feature) | Snapshot tests |
+| `proptest` | Property-based tests |
+| `serial_test` | Serializing tests that mutate env or global state |
+| `tiny_http` | Mock registry servers for tests (real registries are never hit) |
+| `tempfile` | Filesystem isolation in tests |
+| `temp-env` | Scoped environment-variable mutation |
+| `cargo-fuzz` | Fuzzing harness for state loading + token resolution |
+
+## Build & install
+
+See [../CLAUDE.md](../CLAUDE.md) for the canonical command list. Quick reference:
+
+```bash
+cargo build --release            # production binary (LTO + strip)
+cargo install --path crates/shipper-cli --locked
+cargo test                       # workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo fmt --all -- --check
+```
+
+## CI
+
+GitHub Actions in `.github/workflows/`:
+
+- `ci.yml` — workspace test/lint/format/MSRV
+- `release.yml` — tag-triggered publish via Shipper itself (the dogfooding train)
+- Additional workflows for fuzz, security, docs as needed
+
+## Conventions
+
+- **Token handling.** Opaque strings, resolved per Cargo convention: `CARGO_REGISTRY_TOKEN` → `CARGO_REGISTRIES_<NAME>_TOKEN` → `$CARGO_HOME/credentials.toml`. Never logged. Sanitized in receipts via `shipper-output-sanitizer`.
+- **Atomic file writes.** All state files use write-temp + fsync + rename + fsync-parent.
+- **Schema versioning.** `state.json`, `receipt.json`, and `.shipper.toml` carry schema versions for future migration.
+- **Determinism.** `BTreeSet` / `BTreeMap` over `HashSet` / `HashMap` where iteration order is observable.
+- **Error classification.** `ErrorClass::{Retryable, Permanent, Ambiguous}`. Only retryable triggers backoff. Ambiguous should reconcile against registry truth ([#99](https://github.com/EffortlessMetrics/shipper/issues/99) tracks closing this).
+- **Event emission.** Every state transition emits one event in `events.jsonl`. Adding a new code path means adding the corresponding event variant in `shipper-types`.
+- **No real registry calls in tests.** Mock with `tiny_http`.

--- a/docs/tutorials/first-publish.md
+++ b/docs/tutorials/first-publish.md
@@ -1,0 +1,125 @@
+# Tutorial: First publish from a toy workspace
+
+In this tutorial you will publish a two-crate workspace to crates.io using Shipper. By the end you'll have run the full `plan → preflight → publish → inspect` flow and seen what `.shipper/` state files look like after a successful release.
+
+## What you'll learn
+
+- Install Shipper and initialize a config
+- Read a plan (what will be published, in what order)
+- Run a preflight check (what could go wrong, safely)
+- Execute the publish
+- Inspect the receipt
+
+## What you'll need
+
+- Rust toolchain (edition 2024, MSRV 1.92 — `rustup update stable` is fine)
+- A crates.io account and a token (`cargo login`)
+- A git-clean workspace with two crates, one depending on the other
+- About 15 minutes
+
+> If you want a throwaway target, publish `0.0.1-dev.1` of a unique-name crate you control. This tutorial assumes you are publishing *your own* crates — Shipper will not invent version numbers.
+
+## 1. Install
+
+```bash
+cargo install shipper-cli --locked
+```
+
+> The binary is named `shipper`; the published crate is `shipper-cli`. [Issue #95](https://github.com/EffortlessMetrics/shipper/issues/95) tracks making `cargo install shipper` work.
+
+Confirm:
+
+```bash
+shipper --version
+```
+
+## 2. Create a config
+
+```bash
+cd /path/to/your/workspace
+shipper config init
+```
+
+This writes `.shipper.toml` with sensible defaults. Open it; the defaults are fine for a first pass. Important defaults:
+
+- `policy = "safe"` — verify every step
+- `readiness = { method = "api", ... }` — check crates.io API before advancing to dependents
+
+## 3. Plan the release
+
+```bash
+shipper plan
+```
+
+You'll see a dependency-ordered list of crates and a `plan_id` (SHA256). Two properties to notice:
+
+- The order respects your dependency graph (a dependency is published before its dependents).
+- The `plan_id` is deterministic: run `shipper plan` again and the ID is identical. If it changes, your workspace state changed — that's your early-warning for "something is different than you think."
+
+## 4. Preflight
+
+```bash
+shipper preflight
+```
+
+Preflight runs checks without publishing:
+
+- Git working tree must be clean (or use `--allow-dirty`)
+- Registry must be reachable
+- `cargo publish --dry-run` must succeed for the workspace
+- For each crate: version must not already exist on crates.io
+- Optionally: ownership is verified (requires a token)
+
+Output ends with a `finishability` value:
+
+- `Proven` — everything checks out
+- `NotProven` — some checks could not be completed (e.g., ownership checks fail for crates that don't exist yet — that's normal for a first publish)
+- `Failed` — something is actually wrong; read the error above
+
+> `NotProven` is not the same as `Failed`. First publishes of brand-new crates are inherently not-provable (you can't verify ownership of a crate that doesn't exist). See [explanation/why-shipper.md](../explanation/why-shipper.md#why-finishability-has-three-states) for why this distinction exists.
+
+## 5. Publish
+
+```bash
+shipper publish
+```
+
+Shipper will:
+
+1. Publish each crate via `cargo publish`, in dependency order
+2. After each publish, wait for the new version to be visible on crates.io before moving to dependents
+3. Retry with backoff on transient failures (HTTP 429, network blips)
+4. Persist state to `.shipper/` after every step
+
+Expected wall-clock for a 2-crate workspace: 1–3 minutes.
+
+If something goes wrong mid-publish, see [the recovery tutorial](recover-from-interruption.md).
+
+## 6. Inspect what happened
+
+```bash
+shipper inspect-receipt
+```
+
+Human-readable summary of what was published, with timestamps.
+
+```bash
+shipper inspect-events
+```
+
+The full event log — every state transition with timestamp.
+
+```bash
+ls .shipper/
+# events.jsonl   <- append-only truth
+# state.json     <- projection for resume
+# receipt.json   <- end-of-run summary
+```
+
+See [explanation/INVARIANTS.md](../INVARIANTS.md) for how these three files relate.
+
+## 7. What's next
+
+- If you plan to publish from CI, follow [How-to: run in GitHub Actions](../how-to/run-in-github-actions.md).
+- To understand Shipper's safety model, read [Why Shipper exists](../explanation/why-shipper.md).
+- For the full command/flag reference, run `shipper --help` or see [reference/cli.md](../reference/cli.md).

--- a/docs/tutorials/recover-from-interruption.md
+++ b/docs/tutorials/recover-from-interruption.md
@@ -1,0 +1,105 @@
+# Tutorial: Recover from an interrupted release
+
+In this tutorial you'll deliberately interrupt a Shipper publish run, inspect the persisted state, and use `shipper resume` to complete the release without duplicating work.
+
+## What you'll learn
+
+- What gets written to `.shipper/` during a running publish
+- How `plan_id` guards resume correctness
+- How `shipper resume` decides what to skip and what to continue
+- How to tell the difference between "we have state, let's continue" and "plan changed, we shouldn't continue"
+
+## What you'll need
+
+- A workspace that's already been through the [first-publish tutorial](first-publish.md)
+- A new patch version ready to publish across multiple crates (so there are >1 step to interrupt in the middle of)
+- About 10 minutes
+
+## 1. Start a publish
+
+```bash
+shipper publish
+```
+
+Watch the output. After the first crate is published (you'll see a line like `published shipper-duration@0.0.2`), open a second terminal:
+
+## 2. Interrupt it
+
+Kill the process. On Unix:
+
+```bash
+# in a second terminal
+pkill shipper
+```
+
+Or press `Ctrl+C` in the first terminal. Shipper's signal handler writes final state before exiting.
+
+## 3. Inspect the persisted state
+
+```bash
+ls -la .shipper/
+```
+
+You'll see:
+
+- `events.jsonl` — append-only event log (grew during the run, stopped when you killed it)
+- `state.json` — projection: what's published so far, what's pending
+- `lock` — the concurrent-publish guard. Released cleanly on signal; may still be present on SIGKILL.
+
+```bash
+shipper inspect-events | tail -20
+```
+
+The last events should show package_started / package_attempted / package_published for the crate that completed, then nothing further. No `execution_finished`.
+
+## 4. Resume
+
+```bash
+shipper resume
+```
+
+Shipper will:
+
+1. Load `.shipper/state.json`
+2. Recompute the current plan from your workspace
+3. **Verify the plan_id matches**. If the workspace changed between runs, Shipper refuses to continue (this is the safety guardrail that prevents partial-publish corruption).
+4. Skip packages already marked published
+5. Continue from the first pending package
+
+You should see output like `skipping shipper-duration (already published)` followed by the next crate in the queue.
+
+## 5. What if the plan changed?
+
+Deliberately simulate: edit `Cargo.toml` of one of your crates (bump its version, add a dep, anything), then:
+
+```bash
+shipper resume
+```
+
+Shipper will refuse:
+
+```
+error: plan_id mismatch. The workspace has changed since the interrupted run.
+  expected: 23ff8f85...
+  got:      a11b7c42...
+Use --force-resume to override (advanced: may cause duplicate publish attempts).
+```
+
+Revert the change, then `shipper resume` works again.
+
+## 6. Understanding the truth model
+
+The key invariant is: **events are truth, state is a projection**.
+
+If `state.json` ever disagrees with `events.jsonl`, events win. Full details: [explanation/INVARIANTS.md](../INVARIANTS.md).
+
+In practice this means:
+
+- `state.json` can be rebuilt from `events.jsonl` if it's corrupted
+- `resume` reads `state.json` for speed, but the ground truth is in events
+- Any tool you build on top of Shipper should prefer events for correctness, state for speed
+
+## 7. What's next
+
+- Running this flow in CI requires a bit of care: the `.shipper/` directory must be uploaded as an artifact so a re-run can download it. See [how-to/run-in-github-actions.md](../how-to/run-in-github-actions.md).
+- To understand why resume exists and what edge cases still need work, see issues [#90](https://github.com/EffortlessMetrics/shipper/issues/90) and [#101](https://github.com/EffortlessMetrics/shipper/issues/101).


### PR DESCRIPTION
## Summary

Post-v0.3.0-rc.1 documentation alignment pass. Four categories of change across four commits.

### 1. Roadmap alignment
- **ROADMAP.md** — full rewrite around the nine-competency thesis; added the five-pillar safety lens (Prove / Dispatch / Reconcile / Recover / Remediate) as the existential claim above the competencies. Cross-references tracking issues #100–#109.

### 2. North star + orientation
- **MISSION.md** (new) — mission, vision, audience, and the nine convictions. Includes the single-sentence test: \"you can start a release train, stop staring at the terminal, and still trust the outcome.\"
- **docs/product.md**, **docs/structure.md**, **docs/tech.md** (new) — steering docs for contributors and AI tools.
- **docs/INVARIANTS.md** (new) — events-as-truth / state-as-projection / receipt-as-summary contract per #93.

### 3. Architecture doc rewrite
- **docs/architecture.md** — the prior version claimed 31 crates with many \"Absorbed\" microcrates no longer standalone. Replaced with the current 12-crate reality plus the architectural rule: *\"Crates are semver promises. Folders are ownership boundaries.\"*
- Also cleaned up 3 stray test-artifact directories (\`crates/shipper-events\`, \`crates/shipper-state\`, \`crates/shipper-storage\`) that were not actually crates.

### 4. Diátaxis reorg
- **docs/README.md** (new) — documentation index organized by reader purpose (tutorials / how-to / reference / explanation).
- **docs/tutorials/first-publish.md** (new) — end-to-end first-publish walkthrough.
- **docs/tutorials/recover-from-interruption.md** (new) — deliberate interrupt + resume tutorial.
- **docs/how-to/run-in-github-actions.md** (new) — minimal workflow + key considerations.
- **docs/how-to/inspect-state-and-receipts.md** (new) — which file answers which question.
- **docs/explanation/why-shipper.md** (new) — distilled \"why\" doc.
- **docs/reference/cli.md** (new) — topical map pointing at \`--help\` as canonical.
- Existing flat docs (\`preflight.md\`, \`readiness.md\`, \`failure-modes.md\`, etc.) stay in place to avoid breaking links; the new index groups them.

### 5. README + AI-doc polish
- **README.md** — tighter Documentation section with quick links grouped by reader intent; pointers to first-publish tutorial and docs/README.md. Earlier pass trimmed a 60-line Options table + 100 lines of redundant Examples.
- **CLAUDE.md / GEMINI.md** — Orientation sections now point at \`docs/README.md\` as the entry point and \`docs/explanation/why-shipper.md\` as the distilled why.

## Why

We're about to start closing the gaps from #109. Without this pass, every contributor gets stale priorities from the old ROADMAP; every AI session lacks the events-as-truth contract; new users get the wrong install command; and there's no navigable docs structure for anyone who arrives at docs/.

## Files

17 files changed, +1398 / -1097.

| File | Change |
|---|---|
| MISSION.md | new |
| ROADMAP.md | rewritten (+5-pillar lens) |
| README.md | rewritten and re-tightened |
| docs/README.md | new (Diátaxis index) |
| docs/architecture.md | full rewrite |
| docs/INVARIANTS.md, product.md, structure.md, tech.md | new |
| docs/tutorials/*, docs/how-to/*, docs/explanation/*, docs/reference/* | 6 new docs |
| CLAUDE.md, GEMINI.md | edited |

Plus removal of three stray test-artifact directories.

## Test plan

- [x] All cross-doc internal links resolve
- [x] All issue references (#90–#109) resolve
- [x] No broken references to old roadmap content
- [x] CLAUDE.md still loadable as project instructions
- [x] CI green on prior commits; latest commit CI in progress

## Related

- Master tracking issue: #109
- Per-competency umbrella: #100–#108
- Per-gap detail: #90–#99