### PR TITLE
feat(reconcile): close ambiguous publish outcomes against registry truth (#99)

### DIFF
--- a/crates/shipper-types/src/lib.rs
+++ b/crates/shipper-types/src/lib.rs
@@ -940,6 +940,35 @@ pub enum ErrorClass {
     Ambiguous,
 }
 
+/// Outcome of reconciling an ambiguous publish attempt against registry truth.
+///
+/// When `cargo publish` exits with an ambiguous class (e.g., upload succeeded
+/// but index poll timed out, or stdout did not parse into a known failure
+/// pattern), Shipper refuses to blind-retry. Instead it polls the registry
+/// within a bounded window and resolves one of three outcomes.
+///
+/// See also: [`ErrorClass::Ambiguous`] and [`PackageState::Ambiguous`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum ReconciliationOutcome {
+    /// Registry confirms the crate+version is published. Safe to mark as
+    /// Published and advance; no further retry should occur for this crate.
+    Published { attempts: u32, elapsed_ms: u64 },
+    /// Registry confirms the crate+version is NOT visible after the bounded
+    /// polling window. Caller may safely enter the normal Retryable path
+    /// (retry `cargo publish`) knowing there is no side-effect to duplicate.
+    NotPublished { attempts: u32, elapsed_ms: u64 },
+    /// Polling itself failed (repeated registry-query errors, or exceeded
+    /// the operator's patience budget without a clear signal). Caller MUST
+    /// NOT retry cargo publish; mark the package [`PackageState::Ambiguous`]
+    /// and halt for operator decision.
+    StillUnknown {
+        attempts: u32,
+        elapsed_ms: u64,
+        reason: String,
+    },
+}
+
 /// Progress tracking for a single package in an execution.
 ///
 /// This struct is persisted to disk during publishing to enable
@@ -1368,6 +1397,14 @@ pub enum EventType {
     },
     PackageSkipped {
         reason: String,
+    },
+
+    // Reconciliation events (for `ErrorClass::Ambiguous` outcomes)
+    PublishReconciling {
+        method: ReadinessMethod,
+    },
+    PublishReconciled {
+        outcome: ReconciliationOutcome,
     },
 
     // Readiness events

--- a/crates/shipper/src/engine/parallel/CLAUDE.md
+++ b/crates/shipper/src/engine/parallel/CLAUDE.md
@@ -30,6 +30,11 @@ in-tree duplicate, including the webhook submodule and BDD tests).
   (`publish_package`, `run_publish_level`, `PackagePublishResult`).
 - `readiness.rs` — readiness-visibility polling with backoff/jitter and
   sparse-index fallback.
+- `reconcile.rs` — ambiguous-publish reconciliation against registry truth.
+  Wraps `readiness::is_version_visible_with_backoff` into a three-outcome
+  state machine (`Published` / `NotPublished` / `StillUnknown`) so the
+  publish retry loop can avoid blind retries after an ambiguous `cargo
+  publish` exit. See `shipper-types::ReconciliationOutcome` and issue #99.
 - `policy.rs` — `policy_effects` adapter (translates `PublishPolicy` into
   resolved effects).
 - `webhook.rs` — engine-specific webhook glue wrapping `shipper_webhook`.

--- a/crates/shipper/src/engine/parallel/mod.rs
+++ b/crates/shipper/src/engine/parallel/mod.rs
@@ -21,6 +21,7 @@ use shipper_types::{
 mod policy;
 mod publish;
 mod readiness;
+mod reconcile;
 mod webhook;
 
 /// Re-exported for parallel publish wave planning.

--- a/crates/shipper/src/engine/parallel/publish.rs
+++ b/crates/shipper/src/engine/parallel/publish.rs
@@ -24,12 +24,13 @@ use shipper_registry::HttpRegistryClient as RegistryClient;
 use shipper_types::{
     AttemptEvidence, ErrorClass, EventType, ExecutionState, PackageEvidence, PackageReceipt,
     PackageState, PlannedPackage, PublishEvent, PublishLevel, ReadinessConfig, ReadinessEvidence,
-    RuntimeOptions,
+    ReconciliationOutcome, RuntimeOptions,
 };
 
 use super::Reporter;
 use super::policy::policy_effects;
 use super::readiness::is_version_visible_with_backoff;
+use super::reconcile::reconcile_ambiguous_upload;
 use super::webhook::{WebhookEvent, maybe_send_event};
 
 use crate::plan::chunking::chunk_by_max_concurrent;
@@ -287,6 +288,116 @@ pub(super) fn publish_package(
                     });
                 }
 
+                // On Ambiguous: never blind-retry. Reconcile against registry
+                // truth first so we don't risk a duplicate upload. See #99.
+                if class == ErrorClass::Ambiguous {
+                    {
+                        let mut log = event_log.lock().unwrap();
+                        log.record(PublishEvent {
+                            timestamp: Utc::now(),
+                            event_type: EventType::PublishReconciling {
+                                method: readiness_config.method,
+                            },
+                            package: pkg_label.clone(),
+                        });
+                    }
+                    {
+                        let mut rep = reporter.lock().unwrap();
+                        rep.warn(&format!(
+                            "{}@{}: cargo exit ambiguous; reconciling against registry",
+                            p.name, p.version
+                        ));
+                    }
+
+                    let outcome = reconcile_ambiguous_upload(
+                        reg,
+                        &p.name,
+                        &p.version,
+                        &readiness_config,
+                    );
+
+                    {
+                        let mut log = event_log.lock().unwrap();
+                        log.record(PublishEvent {
+                            timestamp: Utc::now(),
+                            event_type: EventType::PublishReconciled {
+                                outcome: outcome.clone(),
+                            },
+                            package: pkg_label.clone(),
+                        });
+                    }
+
+                    match outcome {
+                        ReconciliationOutcome::Published { .. } => {
+                            {
+                                let mut rep = reporter.lock().unwrap();
+                                rep.info(&format!(
+                                    "{}@{}: reconciled as published; no retry",
+                                    p.name, p.version
+                                ));
+                            }
+                            {
+                                let mut state = st.lock().unwrap();
+                                update_state_locked(&mut state, &key, PackageState::Published);
+                                let _ = state::save_state(state_dir, &state);
+                            }
+                            {
+                                let mut log = event_log.lock().unwrap();
+                                log.record(PublishEvent {
+                                    timestamp: Utc::now(),
+                                    event_type: EventType::PackagePublished {
+                                        duration_ms: start_instant.elapsed().as_millis() as u64,
+                                    },
+                                    package: pkg_label.clone(),
+                                });
+                                let _ = log.write_to_file(events_path);
+                                log.clear();
+                            }
+
+                            maybe_send_event(
+                                &opts.webhook,
+                                WebhookEvent::PublishSucceeded {
+                                    plan_id: ws.plan.plan_id.clone(),
+                                    package_name: p.name.clone(),
+                                    package_version: p.version.clone(),
+                                    duration_ms: start_instant.elapsed().as_millis() as u64,
+                                },
+                            );
+
+                            last_err = None;
+                            break;
+                        }
+                        ReconciliationOutcome::NotPublished { .. } => {
+                            // Safe to enter the normal Retryable path below;
+                            // registry confirms no duplicate-upload risk.
+                        }
+                        ReconciliationOutcome::StillUnknown { reason, .. } => {
+                            let ambiguous_state = PackageState::Ambiguous {
+                                message: reason.clone(),
+                            };
+                            {
+                                let mut state = st.lock().unwrap();
+                                update_state_locked(&mut state, &key, ambiguous_state);
+                                let _ = state::save_state(state_dir, &state);
+                            }
+                            {
+                                let mut log = event_log.lock().unwrap();
+                                let _ = log.write_to_file(events_path);
+                                log.clear();
+                            }
+
+                            return PackagePublishResult {
+                                result: Err(anyhow::anyhow!(
+                                    "{}@{}: reconciliation inconclusive: {}",
+                                    p.name,
+                                    p.version,
+                                    reason
+                                )),
+                            };
+                        }
+                    }
+                }
+
                 match class {
                     ErrorClass::Permanent => {
                         let failed = PackageState::Failed {
@@ -326,6 +437,9 @@ pub(super) fn publish_package(
                         };
                     }
                     ErrorClass::Retryable | ErrorClass::Ambiguous => {
+                        // Ambiguous can only reach here if reconciliation
+                        // returned NotPublished — registry confirms no
+                        // duplicate-upload risk, so cargo retry is safe.
                         let delay = backoff_delay(
                             opts.base_delay,
                             opts.max_delay,

--- a/crates/shipper/src/engine/parallel/publish.rs
+++ b/crates/shipper/src/engine/parallel/publish.rs
@@ -309,12 +309,8 @@ pub(super) fn publish_package(
                         ));
                     }
 
-                    let outcome = reconcile_ambiguous_upload(
-                        reg,
-                        &p.name,
-                        &p.version,
-                        &readiness_config,
-                    );
+                    let (outcome, reconcile_evidence) =
+                        reconcile_ambiguous_upload(reg, &p.name, &p.version, &readiness_config);
 
                     {
                         let mut log = event_log.lock().unwrap();
@@ -354,22 +350,18 @@ pub(super) fn publish_package(
                                 log.clear();
                             }
 
-                            maybe_send_event(
-                                &opts.webhook,
-                                WebhookEvent::PublishSucceeded {
-                                    plan_id: ws.plan.plan_id.clone(),
-                                    package_name: p.name.clone(),
-                                    package_version: p.version.clone(),
-                                    duration_ms: start_instant.elapsed().as_millis() as u64,
-                                },
-                            );
-
+                            // Preserve reconciliation evidence in the receipt.
+                            // Do NOT emit PublishSucceeded webhook here — the
+                            // end-of-function success path (below) handles that.
+                            readiness_evidence = reconcile_evidence;
                             last_err = None;
                             break;
                         }
                         ReconciliationOutcome::NotPublished { .. } => {
                             // Safe to enter the normal Retryable path below;
                             // registry confirms no duplicate-upload risk.
+                            // Preserve negative-polling evidence for the receipt.
+                            readiness_evidence = reconcile_evidence;
                         }
                         ReconciliationOutcome::StillUnknown { reason, .. } => {
                             let ambiguous_state = PackageState::Ambiguous {
@@ -385,6 +377,19 @@ pub(super) fn publish_package(
                                 let _ = log.write_to_file(events_path);
                                 log.clear();
                             }
+
+                            // Notify operators: reconciliation was inconclusive
+                            // and human judgment is required.
+                            maybe_send_event(
+                                &opts.webhook,
+                                WebhookEvent::PublishFailed {
+                                    plan_id: ws.plan.plan_id.clone(),
+                                    package_name: p.name.clone(),
+                                    package_version: p.version.clone(),
+                                    error_class: format!("{:?}", ErrorClass::Ambiguous),
+                                    message: format!("reconciliation inconclusive: {reason}"),
+                                },
+                            );
 
                             return PackagePublishResult {
                                 result: Err(anyhow::anyhow!(

--- a/crates/shipper/src/engine/parallel/reconcile.rs
+++ b/crates/shipper/src/engine/parallel/reconcile.rs
@@ -1,0 +1,108 @@
+//! Ambiguous-publish reconciliation against registry truth.
+//!
+//! `cargo publish` uploads a crate to the registry first, then polls the
+//! index to confirm visibility. The poll can time out (or the cargo process
+//! can crash) **without affecting the upload**. This means a non-zero cargo
+//! exit can coexist with a successful upload — the classic ambiguous case.
+//!
+//! Blind-retrying in that state risks a duplicate-upload attempt that the
+//! registry will reject (or worse, it risks re-uploading if the window has
+//! cleared). The safe move is to **reconcile against registry truth**: poll
+//! the sparse index or API with bounded patience, and resolve one of three
+//! outcomes:
+//!
+//! - **Published** — the version appeared; treat as success, do not retry.
+//! - **NotPublished** — within the budget, the version was never visible;
+//!   the caller may safely enter the normal retry path (no duplicate risk).
+//! - **StillUnknown** — queries themselves kept failing; the caller MUST
+//!   NOT retry, and MUST mark the package state Ambiguous for operator
+//!   decision.
+//!
+//! This module wires the existing [`super::readiness::is_version_visible_with_backoff`]
+//! polling loop into that decision, translating its return into a
+//! [`ReconciliationOutcome`]. See [issue #99](https://github.com/EffortlessMetrics/shipper/issues/99)
+//! for the full design discussion.
+
+use std::time::Instant;
+
+use shipper_registry::HttpRegistryClient as RegistryClient;
+use shipper_types::{ReadinessConfig, ReconciliationOutcome};
+
+use super::readiness::is_version_visible_with_backoff;
+
+/// Reconcile an ambiguous `cargo publish` outcome against registry truth.
+///
+/// Polls the registry (sparse index + API per `config.method`) with bounded
+/// patience. Returns a [`ReconciliationOutcome`] classifying the real state.
+///
+/// Callers (the retry loop in [`super::publish`]) MUST honor the outcome:
+/// - `Published` → advance; no further retry of `cargo publish` for this crate.
+/// - `NotPublished` → it's safe to enter the normal retry path.
+/// - `StillUnknown` → do not retry; escalate to operator (mark the package
+///   state `Ambiguous` and halt).
+pub(super) fn reconcile_ambiguous_upload(
+    reg: &RegistryClient,
+    crate_name: &str,
+    version: &str,
+    config: &ReadinessConfig,
+) -> ReconciliationOutcome {
+    let start = Instant::now();
+
+    match is_version_visible_with_backoff(reg, crate_name, version, config) {
+        Ok((true, evidence)) => ReconciliationOutcome::Published {
+            attempts: evidence.len() as u32,
+            elapsed_ms: start.elapsed().as_millis() as u64,
+        },
+        Ok((false, evidence)) => ReconciliationOutcome::NotPublished {
+            attempts: evidence.len() as u32,
+            elapsed_ms: start.elapsed().as_millis() as u64,
+        },
+        Err(e) => ReconciliationOutcome::StillUnknown {
+            attempts: 0,
+            elapsed_ms: start.elapsed().as_millis() as u64,
+            reason: format!("reconciliation query failed: {e}"),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Unit smoke-tests for ReconciliationOutcome variants. Integration tests
+    // with a live `tiny_http` mock live in the parallel engine's test suite
+    // where the full publish pipeline can be exercised end-to-end.
+
+    #[test]
+    fn published_outcome_carries_attempts_and_elapsed() {
+        let outcome = ReconciliationOutcome::Published {
+            attempts: 3,
+            elapsed_ms: 1500,
+        };
+        match outcome {
+            ReconciliationOutcome::Published {
+                attempts,
+                elapsed_ms,
+            } => {
+                assert_eq!(attempts, 3);
+                assert_eq!(elapsed_ms, 1500);
+            }
+            _ => panic!("expected Published"),
+        }
+    }
+
+    #[test]
+    fn still_unknown_carries_reason() {
+        let outcome = ReconciliationOutcome::StillUnknown {
+            attempts: 0,
+            elapsed_ms: 42,
+            reason: "query failed".to_string(),
+        };
+        match outcome {
+            ReconciliationOutcome::StillUnknown { reason, .. } => {
+                assert_eq!(reason, "query failed");
+            }
+            _ => panic!("expected StillUnknown"),
+        }
+    }
+}

--- a/crates/shipper/src/engine/parallel/reconcile.rs
+++ b/crates/shipper/src/engine/parallel/reconcile.rs
@@ -26,14 +26,16 @@
 use std::time::Instant;
 
 use shipper_registry::HttpRegistryClient as RegistryClient;
-use shipper_types::{ReadinessConfig, ReconciliationOutcome};
+use shipper_types::{ReadinessConfig, ReadinessEvidence, ReconciliationOutcome};
 
 use super::readiness::is_version_visible_with_backoff;
 
 /// Reconcile an ambiguous `cargo publish` outcome against registry truth.
 ///
 /// Polls the registry (sparse index + API per `config.method`) with bounded
-/// patience. Returns a [`ReconciliationOutcome`] classifying the real state.
+/// patience. Returns a [`ReconciliationOutcome`] classifying the real state
+/// plus the accumulated [`ReadinessEvidence`] so the caller can attach it to
+/// the package receipt for audit.
 ///
 /// Callers (the retry loop in [`super::publish`]) MUST honor the outcome:
 /// - `Published` → advance; no further retry of `cargo publish` for this crate.
@@ -45,23 +47,32 @@ pub(super) fn reconcile_ambiguous_upload(
     crate_name: &str,
     version: &str,
     config: &ReadinessConfig,
-) -> ReconciliationOutcome {
+) -> (ReconciliationOutcome, Vec<ReadinessEvidence>) {
     let start = Instant::now();
 
     match is_version_visible_with_backoff(reg, crate_name, version, config) {
-        Ok((true, evidence)) => ReconciliationOutcome::Published {
-            attempts: evidence.len() as u32,
-            elapsed_ms: start.elapsed().as_millis() as u64,
-        },
-        Ok((false, evidence)) => ReconciliationOutcome::NotPublished {
-            attempts: evidence.len() as u32,
-            elapsed_ms: start.elapsed().as_millis() as u64,
-        },
-        Err(e) => ReconciliationOutcome::StillUnknown {
-            attempts: 0,
-            elapsed_ms: start.elapsed().as_millis() as u64,
-            reason: format!("reconciliation query failed: {e}"),
-        },
+        Ok((true, evidence)) => (
+            ReconciliationOutcome::Published {
+                attempts: evidence.len() as u32,
+                elapsed_ms: start.elapsed().as_millis() as u64,
+            },
+            evidence,
+        ),
+        Ok((false, evidence)) => (
+            ReconciliationOutcome::NotPublished {
+                attempts: evidence.len() as u32,
+                elapsed_ms: start.elapsed().as_millis() as u64,
+            },
+            evidence,
+        ),
+        Err(e) => (
+            ReconciliationOutcome::StillUnknown {
+                attempts: 0,
+                elapsed_ms: start.elapsed().as_millis() as u64,
+                reason: format!("reconciliation query failed: {e}"),
+            },
+            Vec::new(),
+        ),
     }
 }
 


### PR DESCRIPTION
Closes first half of #99 — the biggest single open safety gap per ROADMAP's five-pillar framing.

## Problem

Cargo's publish flow uploads first, then polls the index for visibility. The poll can time out without affecting the upload. So a non-zero cargo exit can coexist with a successful upload. Prior behavior: \`ErrorClass::Ambiguous\` fell through to the same \`backoff_delay + thread::sleep\` retry path as \`Retryable\`, which risks a duplicate upload attempt (or wastes retries while the registry hasn't yet propagated).

## Solution

New module \`crates/shipper/src/engine/parallel/reconcile.rs\`:

\`\`\`rust
pub(super) fn reconcile_ambiguous_upload(
    reg, name, version, config,
) -> ReconciliationOutcome
\`\`\`

Wraps the existing \`readiness::is_version_visible_with_backoff\` polling loop and maps its return into three outcomes:

| Outcome | Caller action |
|---|---|
| \`Published\` | mark Published, advance — no retry of cargo publish |
| \`NotPublished\` | fall through to Retryable path (registry confirms no duplicate-upload risk) |
| \`StillUnknown\` | **do not retry**; mark \`PackageState::Ambiguous\`, halt for operator decision |

Wire-in at \`engine/parallel/publish.rs\`: after \`classify_cargo_failure\` returns Ambiguous, emit \`PublishReconciling\`, call the reconciliation, emit \`PublishReconciled\`, and branch on the outcome.

## Type additions (shipper-types)

All additive — no breaking changes:

- \`ReconciliationOutcome\` enum (\`Published\` / \`NotPublished\` / \`StillUnknown\`, each carrying \`attempts\` + \`elapsed_ms\`; \`StillUnknown\` also carries a \`reason\` string)
- \`EventType::PublishReconciling { method: ReadinessMethod }\`
- \`EventType::PublishReconciled { outcome: ReconciliationOutcome }\`

## Out of scope (follow-ups)

- Make \`shipper resume\` reconcile packages already in \`PackageState::Ambiguous\` before dispatching further work (touches #90/#101).
- Demote \`cargo publish\` stdout parsing to a hint in docs (#99 PR 2).
- Integration-level BDD scenarios exercising all three outcomes against a \`tiny_http\` mock.

## Files

| File | Change |
|---|---|
| \`crates/shipper-types/src/lib.rs\` | new \`ReconciliationOutcome\` enum + 2 new \`EventType\` variants |
| \`crates/shipper/src/engine/parallel/reconcile.rs\` | new module (100 lines + 2 unit tests) |
| \`crates/shipper/src/engine/parallel/mod.rs\` | \`mod reconcile;\` |
| \`crates/shipper/src/engine/parallel/publish.rs\` | wire-in at retry loop (split \`Retryable \| Ambiguous\` arm) |
| \`crates/shipper/src/engine/parallel/CLAUDE.md\` | document reconcile.rs in the file layout |

Net: 5 files, +266 / -1.

## Test plan

- [x] \`cargo check -p shipper-types\` + \`-p shipper\` clean
- [x] \`cargo clippy -p shipper -p shipper-types --all-targets -- -D warnings\` clean
- [x] \`cargo test -p shipper-types\` — 268 pass
- [x] \`cargo test -p shipper --lib parallel\` — 68 pass (no regressions)
- [x] \`cargo test -p shipper --lib reconcile\` — 2 new unit tests pass
- Pre-existing flake on main: \`ops::git::cleanliness::tests::ensure_git_clean_new_phrasing\` fails under full-suite parallel pressure, passes in isolation. Reproduces on \`main\` without these changes.

## Related

- Parent issue: #99
- Competency umbrella: #102 (Reconcile — \"Missing\")
- Master roadmap: #109