### PR TITLE
feat(narrate): retry visibility — structured events + live CLI narration (#91)

### DIFF
--- a/crates/shipper-types/src/lib.rs
+++ b/crates/shipper-types/src/lib.rs
@@ -1449,6 +1449,20 @@ pub enum EventType {
         drift: StateEventDrift,
     },
 
+    // Retry visibility (#91) — emitted immediately before Shipper sleeps on a
+    // retry backoff. `attempt` is the just-failed attempt number (1-indexed),
+    // so the next attempt will be `attempt + 1` of `max_attempts`. `reason`
+    // classifies why the retry is happening; `message` is the one-line
+    // human-facing description (typically from cargo-failure classification).
+    RetryBackoffStarted {
+        attempt: u32,
+        max_attempts: u32,
+        delay_ms: u64,
+        next_attempt_at: DateTime<Utc>,
+        reason: ErrorClass,
+        message: String,
+    },
+
     // Readiness events
     ReadinessStarted {
         method: ReadinessMethod,

--- a/crates/shipper/src/engine/mod.rs
+++ b/crates/shipper/src/engine/mod.rs
@@ -772,13 +772,19 @@ pub fn run_publish(
                                 opts.retry_strategy,
                                 opts.retry_jitter,
                             );
-                            reporter.warn(&format!(
-                                "{}@{}: retrying in {}",
-                                p.name,
-                                p.version,
-                                humantime::format_duration(delay)
-                            ));
-                            thread::sleep(delay);
+                            emit_retry_backoff_event(
+                                &mut event_log,
+                                &events_path,
+                                reporter,
+                                &pkg_label,
+                                &p.name,
+                                &p.version,
+                                attempt,
+                                opts.max_attempts,
+                                delay,
+                                class.clone(),
+                                &msg,
+                            )?;
                         }
                     }
                     continue;
@@ -825,7 +831,9 @@ pub fn run_publish(
 
                 break;
             } else {
-                last_err = Some((ErrorClass::Ambiguous, "publish succeeded locally, but version not observed on registry within timeout".into()));
+                let message =
+                    "published locally, but version not observed on registry within timeout";
+                last_err = Some((ErrorClass::Ambiguous, message.to_string()));
                 let delay = backoff_delay(
                     opts.base_delay,
                     opts.max_delay,
@@ -833,7 +841,19 @@ pub fn run_publish(
                     opts.retry_strategy,
                     opts.retry_jitter,
                 );
-                thread::sleep(delay);
+                emit_retry_backoff_event(
+                    &mut event_log,
+                    &events_path,
+                    reporter,
+                    &pkg_label,
+                    &p.name,
+                    &p.version,
+                    attempt,
+                    opts.max_attempts,
+                    delay,
+                    ErrorClass::Ambiguous,
+                    message,
+                )?;
             }
         }
 
@@ -1093,6 +1113,59 @@ pub(crate) fn init_state(ws: &PlannedWorkspace, state_dir: &Path) -> Result<Exec
 
     state::save_state(state_dir, &st)?;
     Ok(st)
+}
+
+/// Emit a [`EventType::RetryBackoffStarted`] event + a human-readable warn
+/// line, then `thread::sleep(delay)`. Used at every retry-backoff site in the
+/// sequential publish loop so operators never stare at a silent CI log during
+/// the wait window. See #91. (The parallel path has a mirror helper in
+/// `engine::parallel::publish::emit_retry_backoff` that handles its
+/// `Arc<Mutex<_>>` wrapping.)
+#[allow(clippy::too_many_arguments)]
+fn emit_retry_backoff_event(
+    event_log: &mut events::EventLog,
+    events_path: &Path,
+    reporter: &mut dyn Reporter,
+    pkg_label: &str,
+    pkg_name: &str,
+    pkg_version: &str,
+    attempt: u32,
+    max_attempts: u32,
+    delay: std::time::Duration,
+    reason: ErrorClass,
+    message: &str,
+) -> Result<()> {
+    let next_attempt_at =
+        Utc::now() + chrono::Duration::from_std(delay).unwrap_or_else(|_| chrono::Duration::zero());
+
+    event_log.record(PublishEvent {
+        timestamp: Utc::now(),
+        event_type: EventType::RetryBackoffStarted {
+            attempt,
+            max_attempts,
+            delay_ms: delay.as_millis() as u64,
+            next_attempt_at,
+            reason: reason.clone(),
+            message: message.to_string(),
+        },
+        package: pkg_label.to_string(),
+    });
+    event_log.write_to_file(events_path)?;
+    event_log.clear();
+
+    reporter.warn(&format!(
+        "{}@{}: {} ({:?}); next attempt in {} (attempt {}/{})",
+        pkg_name,
+        pkg_version,
+        message,
+        reason,
+        humantime::format_duration(delay),
+        attempt.saturating_add(1),
+        max_attempts,
+    ));
+
+    thread::sleep(delay);
+    Ok(())
 }
 
 fn verify_published(
@@ -2208,7 +2281,7 @@ mod tests {
                 let receipt = run_publish(&ws, &opts, &mut reporter).expect("publish");
                 assert!(matches!(receipt.packages[0].state, PackageState::Published));
                 assert_eq!(receipt.packages[0].attempts, 2);
-                assert!(reporter.warns.iter().any(|w| w.contains("retrying in")));
+                assert!(reporter.warns.iter().any(|w| w.contains("next attempt in")));
                 server.join();
             },
         );

--- a/crates/shipper/src/engine/parallel/publish.rs
+++ b/crates/shipper/src/engine/parallel/publish.rs
@@ -41,6 +41,64 @@ pub(super) struct PackagePublishResult {
     pub(super) result: anyhow::Result<PackageReceipt>,
 }
 
+/// Emit a [`EventType::RetryBackoffStarted`] event + a human-readable warn
+/// line through the Reporter, then `thread::sleep(delay)`. Used at every
+/// retry-backoff site in the publish loop so operators never stare at a
+/// silent CI log during the wait window. See #91.
+#[allow(clippy::too_many_arguments)]
+fn emit_retry_backoff(
+    event_log: &Arc<Mutex<events::EventLog>>,
+    events_path: &Path,
+    reporter: &Arc<Mutex<dyn Reporter + Send>>,
+    pkg_label: &str,
+    pkg_name: &str,
+    pkg_version: &str,
+    attempt: u32,
+    max_attempts: u32,
+    delay: std::time::Duration,
+    reason: ErrorClass,
+    message: &str,
+) {
+    let next_attempt_at =
+        Utc::now() + chrono::Duration::from_std(delay).unwrap_or_else(|_| chrono::Duration::zero());
+
+    // Record the event (flushed with the next batch of events)
+    {
+        let mut log = event_log.lock().unwrap();
+        log.record(PublishEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::RetryBackoffStarted {
+                attempt,
+                max_attempts,
+                delay_ms: delay.as_millis() as u64,
+                next_attempt_at,
+                reason: reason.clone(),
+                message: message.to_string(),
+            },
+            package: pkg_label.to_string(),
+        });
+        let _ = log.write_to_file(events_path);
+        log.clear();
+    }
+
+    // Human line: reason + attempt count + duration
+    {
+        let mut rep = reporter.lock().unwrap();
+        rep.warn(&format!(
+            "{}@{}: {} ({:?}); next attempt in {} (attempt {}/{})",
+            pkg_name,
+            pkg_version,
+            message,
+            reason,
+            humantime::format_duration(delay),
+            attempt.saturating_add(1),
+            max_attempts,
+        ));
+    }
+
+    thread::sleep(delay);
+}
+
 /// Publish a single package with retries (parallel-safe version)
 #[allow(clippy::too_many_arguments)]
 pub(super) fn publish_package(
@@ -452,16 +510,19 @@ pub(super) fn publish_package(
                             opts.retry_strategy,
                             opts.retry_jitter,
                         );
-                        {
-                            let mut rep = reporter.lock().unwrap();
-                            rep.warn(&format!(
-                                "{}@{}: retrying in {}",
-                                p.name,
-                                p.version,
-                                humantime::format_duration(delay)
-                            ));
-                        }
-                        thread::sleep(delay);
+                        emit_retry_backoff(
+                            event_log,
+                            events_path,
+                            reporter,
+                            &pkg_label,
+                            &p.name,
+                            &p.version,
+                            attempt,
+                            opts.max_attempts,
+                            delay,
+                            class.clone(),
+                            &msg,
+                        );
                     }
                 }
                 continue;
@@ -518,7 +579,9 @@ pub(super) fn publish_package(
 
                     break;
                 } else {
-                    last_err = Some((ErrorClass::Ambiguous, "publish succeeded locally, but version not observed on registry within timeout".into()));
+                    let message =
+                        "published locally, but version not observed on registry within timeout";
+                    last_err = Some((ErrorClass::Ambiguous, message.to_string()));
                     let delay = backoff_delay(
                         opts.base_delay,
                         opts.max_delay,
@@ -526,11 +589,24 @@ pub(super) fn publish_package(
                         opts.retry_strategy,
                         opts.retry_jitter,
                     );
-                    thread::sleep(delay);
+                    emit_retry_backoff(
+                        event_log,
+                        events_path,
+                        reporter,
+                        &pkg_label,
+                        &p.name,
+                        &p.version,
+                        attempt,
+                        opts.max_attempts,
+                        delay,
+                        ErrorClass::Ambiguous,
+                        message,
+                    );
                 }
             }
             Err(_) => {
-                last_err = Some((ErrorClass::Ambiguous, "readiness check failed".into()));
+                let message = "readiness check failed";
+                last_err = Some((ErrorClass::Ambiguous, message.to_string()));
                 let delay = backoff_delay(
                     opts.base_delay,
                     opts.max_delay,
@@ -538,7 +614,19 @@ pub(super) fn publish_package(
                     opts.retry_strategy,
                     opts.retry_jitter,
                 );
-                thread::sleep(delay);
+                emit_retry_backoff(
+                    event_log,
+                    events_path,
+                    reporter,
+                    &pkg_label,
+                    &p.name,
+                    &p.version,
+                    attempt,
+                    opts.max_attempts,
+                    delay,
+                    ErrorClass::Ambiguous,
+                    message,
+                );
             }
         }
     }


### PR DESCRIPTION
Closes [#91](https://github.com/EffortlessMetrics/shipper/issues/91) PR 1 — the highest-leverage operator-UX fix from ROADMAP's Now block.

## Problem

During v0.3.0-rc.1's first real publish, Shipper absorbed 41 retries across a 69-minute run and emitted **zero live signal** during the 9–12 minute rate-limit windows. Operators had to run an external sparse-index polling monitor to know the train was alive. Three \`thread::sleep(delay)\` sites were fully silent.

## Solution

New \`EventType::RetryBackoffStarted\` variant carries the full retry context:
\`attempt\`, \`max_attempts\`, \`delay_ms\`, \`next_attempt_at: DateTime<Utc>\`, \`reason: ErrorClass\`, \`message: String\`.

Two helpers, one per retry loop shape:
- \`engine::parallel::publish::emit_retry_backoff\` — handles Arc<Mutex<_>> wrapping (3 call sites)
- \`engine::mod::emit_retry_backoff_event\` — raw &mut refs (2 call sites)

Each emits the structured event, warns via Reporter with rich format, then sleeps.

## Behaviour delta

**Before:** silent \`thread::sleep(delay)\` on every retry.

**After:** every retry emits one event + one warn line:
\`\`\`
shipper-sparse-index@0.3.0-rc.1: HTTP 429 Too Many Requests (Retryable); next attempt in 10m 30s (attempt 3/12)
\`\`\`

Three previously-silent readiness-retry sites now also narrate.

## Files

| File | Change |
|---|---|
| \`crates/shipper-types/src/lib.rs\` | +\`EventType::RetryBackoffStarted\` variant |
| \`crates/shipper/src/engine/parallel/publish.rs\` | +\`emit_retry_backoff\` helper; 3 sites rewired |
| \`crates/shipper/src/engine/mod.rs\` | +\`emit_retry_backoff_event\` helper; 2 sites rewired; 1 assertion updated to match new message |

Net: 3 files, +199 / -24.

## Test plan

- [x] \`cargo check\` + \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] shipper-types: 268 pass
- [x] engine + parallel + consistency modules: 199 pass (no regressions)
- [x] Updated one test assertion that matched the old \"retrying in\" text to the new \"next attempt in\" text

## Out of scope

- \`RateLimitDetected\` event + \`Retry-After\` parsing — ties into #94 registry-aware backoff
- \`shipper watch\` subcommand / ETA aggregation — follow-up if/when needed; the structured event is available for any consumer to render

## Related

- Parent issue: #91
- Competency umbrella: #103 (Narrate — was Partial, moves notably toward Done)
- Master roadmap: #109 (Now block item 3)