### PR TITLE
feat(dispatch): crates.io-aware backoff for new-crate rate limits (#94)

### DIFF
--- a/crates/shipper/src/engine/mod.rs
+++ b/crates/shipper/src/engine/mod.rs
@@ -14,7 +14,8 @@ use crate::plan::PlannedWorkspace;
 use crate::registry::RegistryClient;
 use crate::runtime::environment;
 use crate::runtime::execution::{
-    backoff_delay, classify_cargo_failure, pkg_key, resolve_state_dir, short_state, update_state,
+    backoff_delay, classify_cargo_failure, pkg_key, registry_aware_backoff, resolve_state_dir,
+    short_state, update_state,
 };
 use crate::state::events;
 use crate::state::execution_state as state;
@@ -639,6 +640,11 @@ pub fn run_publish(
 
         reporter.info(&format!("{}@{}: publishing...", p.name, p.version));
 
+        // Registry-aware backoff (#94): lazy-cached "is this a new crate?"
+        // Only queried when a retry's error message looks like a rate limit,
+        // so the happy path costs zero extra registry calls.
+        let mut is_new_crate_cached: Option<bool> = None;
+
         let mut attempt = st
             .packages
             .get(&key)
@@ -765,12 +771,22 @@ pub fn run_publish(
                             ));
                         }
                         ErrorClass::Retryable | ErrorClass::Ambiguous => {
-                            let delay = backoff_delay(
+                            let is_new_crate =
+                                if crate::runtime::execution::looks_like_rate_limit(&msg) {
+                                    *is_new_crate_cached.get_or_insert_with(|| {
+                                        reg.check_new_crate(&p.name).unwrap_or(false)
+                                    })
+                                } else {
+                                    false
+                                };
+                            let delay = registry_aware_backoff(
                                 opts.base_delay,
                                 opts.max_delay,
                                 attempt,
                                 opts.retry_strategy,
                                 opts.retry_jitter,
+                                is_new_crate,
+                                &msg,
                             );
                             emit_retry_backoff_event(
                                 &mut event_log,

--- a/crates/shipper/src/engine/parallel/publish.rs
+++ b/crates/shipper/src/engine/parallel/publish.rs
@@ -16,7 +16,7 @@ use chrono::Utc;
 use crate::ops::cargo;
 use crate::plan::PlannedWorkspace;
 use crate::runtime::execution::{
-    backoff_delay, classify_cargo_failure, pkg_key, update_state_locked,
+    backoff_delay, classify_cargo_failure, pkg_key, registry_aware_backoff, update_state_locked,
 };
 use crate::state::events;
 use crate::state::execution_state as state;
@@ -209,6 +209,12 @@ pub(super) fn publish_package(
         enabled: effects.readiness_enabled,
         ..opts.readiness.clone()
     };
+
+    // Registry-aware backoff (#94): lazy-cached answer to "is this a brand-new
+    // crate?" — only consulted when a retry's error message looks like a
+    // rate-limit signal. Lazy so the happy path costs zero extra registry
+    // calls, cached so we don't re-query across retries of the same package.
+    let mut is_new_crate_cached: Option<bool> = None;
 
     while attempt < opts.max_attempts {
         attempt += 1;
@@ -503,12 +509,24 @@ pub(super) fn publish_package(
                         // Ambiguous can only reach here if reconciliation
                         // returned NotPublished — registry confirms no
                         // duplicate-upload risk, so cargo retry is safe.
-                        let delay = backoff_delay(
+                        // Only query crate_exists when the error looks like
+                        // a rate limit (saves a registry round-trip for
+                        // generic network/transient failures).
+                        let is_new_crate = if crate::runtime::execution::looks_like_rate_limit(&msg)
+                        {
+                            *is_new_crate_cached
+                                .get_or_insert_with(|| !reg.crate_exists(&p.name).unwrap_or(true))
+                        } else {
+                            false
+                        };
+                        let delay = registry_aware_backoff(
                             opts.base_delay,
                             opts.max_delay,
                             attempt,
                             opts.retry_strategy,
                             opts.retry_jitter,
+                            is_new_crate,
+                            &msg,
                         );
                         emit_retry_backoff(
                             event_log,

--- a/crates/shipper/src/runtime/execution/mod.rs
+++ b/crates/shipper/src/runtime/execution/mod.rs
@@ -87,6 +87,51 @@ pub fn backoff_delay(
     calculate_delay(&config, attempt)
 }
 
+/// crates.io's documented rate-limit window for new-crate publishes: 10 min.
+/// After the 5-crate account burst is consumed, new crates are admitted at
+/// most once per `CRATES_IO_NEW_CRATE_WINDOW`. Source:
+/// <https://crates.io/docs/rate-limits>.
+pub const CRATES_IO_NEW_CRATE_WINDOW: Duration = Duration::from_secs(10 * 60);
+
+/// Return `true` if an error message looks like a rate-limit signal
+/// (HTTP 429 / "too many requests" / "rate limit" phrasings that appear
+/// in cargo publish stderr or common registry error bodies). Used to gate
+/// the crates.io-aware backoff adjustment: we only extend the delay when
+/// we believe we're actually being rate-limited.
+pub fn looks_like_rate_limit(message: &str) -> bool {
+    let m = message.to_lowercase();
+    m.contains("429")
+        || m.contains("rate limit")
+        || m.contains("rate-limit")
+        || m.contains("too many requests")
+}
+
+/// Registry-aware backoff. Layered on top of the generic [`backoff_delay`]:
+/// if we're publishing a brand-new crate and the retry is caused by a
+/// rate-limit signal, floor the delay at [`CRATES_IO_NEW_CRATE_WINDOW`]
+/// so we stop burning retries during the 10-minute window crates.io has
+/// already told us to wait through. Everything else uses the generic delay.
+///
+/// Preflight discovers `is_new_crate` already (one `check_new_crate` call
+/// per package at publish start); wiring it here costs no additional I/O.
+/// See issues #94 and #91 for the design discussion.
+pub fn registry_aware_backoff(
+    base: Duration,
+    max: Duration,
+    attempt: u32,
+    strategy: RetryStrategyType,
+    jitter: f64,
+    is_new_crate: bool,
+    error_message: &str,
+) -> Duration {
+    let generic = backoff_delay(base, max, attempt, strategy, jitter);
+    if is_new_crate && looks_like_rate_limit(error_message) {
+        generic.max(CRATES_IO_NEW_CRATE_WINDOW)
+    } else {
+        generic
+    }
+}
+
 /// Update a package state inside an in-memory execution state.
 pub fn update_state_locked(st: &mut ExecutionState, key: &str, new_state: PackageState) {
     if let Some(pr) = st.packages.get_mut(key) {
@@ -106,6 +151,104 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+
+    // ---- Tests for looks_like_rate_limit + registry_aware_backoff (#94) ----
+
+    #[test]
+    fn looks_like_rate_limit_matches_common_phrasings() {
+        assert!(looks_like_rate_limit("HTTP 429 Too Many Requests"));
+        assert!(looks_like_rate_limit("rate limit exceeded"));
+        assert!(looks_like_rate_limit("rate-limited by server"));
+        assert!(looks_like_rate_limit("received 429"));
+        assert!(looks_like_rate_limit("429: retry later"));
+    }
+
+    #[test]
+    fn looks_like_rate_limit_ignores_unrelated_errors() {
+        assert!(!looks_like_rate_limit("connection refused"));
+        assert!(!looks_like_rate_limit("DNS lookup failed"));
+        assert!(!looks_like_rate_limit("invalid manifest"));
+        assert!(!looks_like_rate_limit("500 internal server error"));
+        assert!(!looks_like_rate_limit(""));
+    }
+
+    #[test]
+    fn registry_aware_backoff_extends_for_new_crate_rate_limit() {
+        let short = Duration::from_secs(10);
+        let d = registry_aware_backoff(
+            short,
+            Duration::from_secs(120),
+            1,
+            RetryStrategyType::Exponential,
+            0.0,
+            true,
+            "HTTP 429 Too Many Requests",
+        );
+        assert!(
+            d >= CRATES_IO_NEW_CRATE_WINDOW,
+            "expected delay floored at 10 min for new-crate rate limit; got {:?}",
+            d
+        );
+    }
+
+    #[test]
+    fn registry_aware_backoff_unchanged_for_existing_crate_rate_limit() {
+        // Existing crate hitting a 429 uses the higher per-minute budget;
+        // Shipper should NOT over-extend to the 10-min new-crate window.
+        let base = Duration::from_secs(2);
+        let max = Duration::from_secs(120);
+        let d = registry_aware_backoff(
+            base,
+            max,
+            1,
+            RetryStrategyType::Exponential,
+            0.0,
+            false,
+            "HTTP 429 Too Many Requests",
+        );
+        assert!(
+            d < CRATES_IO_NEW_CRATE_WINDOW,
+            "expected generic backoff for existing crate; got {:?}",
+            d
+        );
+    }
+
+    #[test]
+    fn registry_aware_backoff_unchanged_for_new_crate_non_rate_limit() {
+        // New crate hit a non-rate-limit retryable (network blip); we should
+        // NOT wait 10 min for a transient network issue.
+        let base = Duration::from_secs(2);
+        let max = Duration::from_secs(120);
+        let d = registry_aware_backoff(
+            base,
+            max,
+            1,
+            RetryStrategyType::Exponential,
+            0.0,
+            true,
+            "connection reset by peer",
+        );
+        assert!(
+            d < CRATES_IO_NEW_CRATE_WINDOW,
+            "expected generic backoff for network error; got {:?}",
+            d
+        );
+    }
+
+    #[test]
+    fn registry_aware_backoff_respects_longer_generic_when_it_exceeds_window() {
+        // If the generic exponential delay is already >= 10 min, don't floor
+        // downward — use whichever is larger.
+        let base = Duration::from_secs(60 * 20); // 20 min
+        let max = Duration::from_secs(60 * 30);
+        let d = registry_aware_backoff(base, max, 1, RetryStrategyType::Constant, 0.0, true, "429");
+        assert!(
+            d >= base,
+            "expected to keep the larger delay; got {:?}, base {:?}",
+            d,
+            base
+        );
+    }
 
     fn make_progress(
         name: &str,


### PR DESCRIPTION
Closes [#94](https://github.com/EffortlessMetrics/shipper/issues/94) PR 1 — the retry efficiency gap from v0.3.0-rc.1.

## Problem

Generic exponential backoff from \`opts.base_delay\` wastes ~5 attempts when a new-crate publish hits crates.io's documented 10-minute new-crate rate-limit window. The v0.3.0-rc.1 retrospective estimated **35 of 41 retries were preventable** for exactly this reason.

## Solution

Add a layered \`registry_aware_backoff\`: if a retry's error message looks like a rate-limit AND the crate is brand-new, floor the delay at the documented 10-minute window. Everything else keeps generic exponential.

### New helpers (\`runtime/execution\`)

- \`CRATES_IO_NEW_CRATE_WINDOW = 10 * 60s\` — documented constant from [crates.io rate-limit docs](https://crates.io/docs/rate-limits)
- \`looks_like_rate_limit(msg)\` — detects \"429\", \"rate limit\", \"too many requests\" phrasings in cargo stderr
- \`registry_aware_backoff(..., is_new_crate, error_message)\` — wraps \`backoff_delay\`, floors at the window only when both conditions match

### Wire-in (both paths, lazy detection)

Both parallel and sequential retry loops replace \`backoff_delay\` with \`registry_aware_backoff\`, but:

1. \`crate_exists\` / \`check_new_crate\` is **only queried** when the error message matches a rate-limit phrasing → **zero extra network calls on the happy path** or on generic network-blip retries
2. The answer is **cached** per-package via \`Option<bool>\` → subsequent retries don't re-query

## Test plan

- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] 5 new unit tests:
  - \`looks_like_rate_limit\` positive + negative phrasings
  - extends for new-crate + rate-limit (floored at 10 min)
  - UNCHANGED for existing-crate + rate-limit (higher per-minute budget)
  - UNCHANGED for new-crate + non-rate-limit (don't wait 10 min for a network blip)
  - respects longer generic delay when it exceeds the window
- [x] 192 engine tests pass (no regressions)
- [x] shipper-types (268), state::consistency (9), reconcile (2) all green

An initial eager version of this change added an extra registry request at publish-start that broke 32 existing tests whose mock servers weren't provisioned for it. The lazy-detection refactor fixed that cleanly.

## Expected impact

On the next first-publish wave, rate-limited retries of brand-new crates skip the wasted short backoffs and go directly to ~10-minute waits. Projected ~35-retry savings per the v0.3.0-rc.1 pattern. Narration from #91 makes the wait visible, so the operator sees one big wait instead of six small misleading ones.

## Out of scope

- \`Retry-After\` HTTP header parsing (requires cargo stderr → structured response plumbing) — follow-up #94 PR 2
- Full \`RegistryProfile\` trait — follow-up #94 PR 3
- \`PublishRegime\` enum threaded through \`PlannedPackage\` — not needed for this win; lazy detection at retry time is sufficient

## Related

- Parent: #94
- Umbrella: #106 (Profile/Adapt — was Partial, moves toward Done)
- Master roadmap: #109 (Now block item 4)