### PR TITLE
feat(reconcile): resume-path reconciliation for Ambiguous packages (#99 follow-on)

### DIFF
--- a/crates/shipper/src/engine/mod.rs
+++ b/crates/shipper/src/engine/mod.rs
@@ -22,7 +22,7 @@ use crate::state::execution_state as state;
 use crate::types::{
     AttemptEvidence, ErrorClass, EventType, ExecutionResult, ExecutionState, Finishability,
     PackageProgress, PackageReceipt, PackageState, PreflightPackage, PreflightReport, PublishEvent,
-    ReadinessEvidence, Receipt, Registry, RuntimeOptions,
+    ReadinessEvidence, Receipt, ReconciliationOutcome, Registry, RuntimeOptions,
 };
 use crate::webhook::{self, WebhookEvent};
 
@@ -563,7 +563,7 @@ pub fn run_publish(
         // Track whether cargo publish already succeeded (e.g. from Uploaded state on resume)
         let mut cargo_succeeded = false;
 
-        match progress.state {
+        match progress.state.clone() {
             PackageState::Published | PackageState::Skipped { .. } => {
                 reporter.info(&format!(
                     "{}@{}: already complete ({})",
@@ -579,6 +579,91 @@ pub fn run_publish(
                     p.name, p.version
                 ));
                 cargo_succeeded = true;
+            }
+            PackageState::Ambiguous {
+                message: prior_reason,
+            } => {
+                // Resume-path reconciliation (#99 follow-on). A prior run left
+                // this package in Ambiguous state (reconciliation inconclusive).
+                // Before doing ANY further work, reconcile against the
+                // registry so we never re-upload a crate whose prior upload
+                // may have actually succeeded.
+                reporter.warn(&format!(
+                    "{}@{}: resume found ambiguous state ({}); reconciling against registry",
+                    p.name, p.version, prior_reason
+                ));
+
+                let readiness_config = crate::types::ReadinessConfig {
+                    enabled: effects.readiness_enabled,
+                    ..opts.readiness.clone()
+                };
+
+                event_log.record(PublishEvent {
+                    timestamp: Utc::now(),
+                    event_type: EventType::PublishReconciling {
+                        method: readiness_config.method,
+                    },
+                    package: pkg_label.clone(),
+                });
+
+                let (outcome, _evidence) =
+                    sequential_reconcile(&reg, &p.name, &p.version, &readiness_config);
+
+                event_log.record(PublishEvent {
+                    timestamp: Utc::now(),
+                    event_type: EventType::PublishReconciled {
+                        outcome: outcome.clone(),
+                    },
+                    package: pkg_label.clone(),
+                });
+                event_log.write_to_file(&events_path)?;
+                event_log.clear();
+
+                match outcome {
+                    ReconciliationOutcome::Published { .. } => {
+                        update_state(&mut st, &state_dir, &key, PackageState::Published)?;
+                        reporter.info(&format!(
+                            "{}@{}: reconciled as published on resume (no republish)",
+                            p.name, p.version
+                        ));
+                        continue;
+                    }
+                    ReconciliationOutcome::NotPublished { .. } => {
+                        // Clear the Ambiguous state — the registry confirms
+                        // no prior upload succeeded, so falling through to
+                        // the normal publish flow is safe.
+                        update_state(&mut st, &state_dir, &key, PackageState::Pending)?;
+                        reporter.info(&format!(
+                            "{}@{}: reconciled as not published; proceeding with publish",
+                            p.name, p.version
+                        ));
+                        // fall through to normal flow
+                    }
+                    ReconciliationOutcome::StillUnknown { reason, .. } => {
+                        reporter.error(&format!(
+                            "{}@{}: resume reconciliation still inconclusive: {}",
+                            p.name, p.version, reason
+                        ));
+                        webhook::maybe_send_event(
+                            &opts.webhook,
+                            WebhookEvent::PublishFailed {
+                                plan_id: ws.plan.plan_id.clone(),
+                                package_name: p.name.clone(),
+                                package_version: p.version.clone(),
+                                error_class: format!("{:?}", ErrorClass::Ambiguous),
+                                message: format!(
+                                    "resume reconciliation still inconclusive: {reason}"
+                                ),
+                            },
+                        );
+                        bail!(
+                            "{}@{}: resume reconciliation still inconclusive; operator action required. Prior reason: {}",
+                            p.name,
+                            p.version,
+                            reason
+                        );
+                    }
+                }
             }
             _ => {}
         }
@@ -1129,6 +1214,50 @@ pub(crate) fn init_state(ws: &PlannedWorkspace, state_dir: &Path) -> Result<Exec
 
     state::save_state(state_dir, &st)?;
     Ok(st)
+}
+
+/// Reconcile an ambiguous publish outcome against registry truth (sequential
+/// path mirror of [`crate::engine::parallel::reconcile::reconcile_ambiguous_upload`]).
+///
+/// Returns the same [`ReconciliationOutcome`] enum + accumulated
+/// [`ReadinessEvidence`], wrapping the sequential path's registry client
+/// (`crate::registry::RegistryClient`) rather than the parallel path's
+/// `HttpRegistryClient`. Used by the resume-path branch that handles packages
+/// found in `PackageState::Ambiguous` (#99 follow-on).
+fn sequential_reconcile(
+    reg: &RegistryClient,
+    crate_name: &str,
+    version: &str,
+    config: &crate::types::ReadinessConfig,
+) -> (
+    crate::types::ReconciliationOutcome,
+    Vec<crate::types::ReadinessEvidence>,
+) {
+    let start = Instant::now();
+    match reg.is_version_visible_with_backoff(crate_name, version, config) {
+        Ok((true, evidence)) => (
+            crate::types::ReconciliationOutcome::Published {
+                attempts: evidence.len() as u32,
+                elapsed_ms: start.elapsed().as_millis() as u64,
+            },
+            evidence,
+        ),
+        Ok((false, evidence)) => (
+            crate::types::ReconciliationOutcome::NotPublished {
+                attempts: evidence.len() as u32,
+                elapsed_ms: start.elapsed().as_millis() as u64,
+            },
+            evidence,
+        ),
+        Err(e) => (
+            crate::types::ReconciliationOutcome::StillUnknown {
+                attempts: 0,
+                elapsed_ms: start.elapsed().as_millis() as u64,
+                reason: format!("reconciliation query failed: {e}"),
+            },
+            Vec::new(),
+        ),
+    }
 }
 
 /// Emit a [`EventType::RetryBackoffStarted`] event + a human-readable warn

--- a/crates/shipper/src/engine/parallel/publish.rs
+++ b/crates/shipper/src/engine/parallel/publish.rs
@@ -210,6 +210,131 @@ pub(super) fn publish_package(
         ..opts.readiness.clone()
     };
 
+    // Resume-path reconciliation (#99 follow-on): if a prior run left this
+    // package in PackageState::Ambiguous, reconcile against registry truth
+    // BEFORE entering the retry loop so we never re-upload a crate whose
+    // prior upload may have actually succeeded.
+    let ambiguous_prior: Option<String> = {
+        let state = st.lock().unwrap();
+        state.packages.get(&key).and_then(|pr| {
+            if let PackageState::Ambiguous { message } = &pr.state {
+                Some(message.clone())
+            } else {
+                None
+            }
+        })
+    };
+
+    if let Some(prior_reason) = ambiguous_prior {
+        {
+            let mut rep = reporter.lock().unwrap();
+            rep.warn(&format!(
+                "{}@{}: resume found ambiguous state ({}); reconciling against registry",
+                p.name, p.version, prior_reason
+            ));
+        }
+        {
+            let mut log = event_log.lock().unwrap();
+            log.record(PublishEvent {
+                timestamp: Utc::now(),
+                event_type: EventType::PublishReconciling {
+                    method: readiness_config.method,
+                },
+                package: pkg_label.clone(),
+            });
+        }
+
+        let (outcome, _evidence) =
+            reconcile_ambiguous_upload(reg, &p.name, &p.version, &readiness_config);
+
+        {
+            let mut log = event_log.lock().unwrap();
+            log.record(PublishEvent {
+                timestamp: Utc::now(),
+                event_type: EventType::PublishReconciled {
+                    outcome: outcome.clone(),
+                },
+                package: pkg_label.clone(),
+            });
+            let _ = log.write_to_file(events_path);
+            log.clear();
+        }
+
+        match outcome {
+            ReconciliationOutcome::Published { .. } => {
+                {
+                    let mut state = st.lock().unwrap();
+                    update_state_locked(&mut state, &key, PackageState::Published);
+                    let _ = state::save_state(state_dir, &state);
+                }
+                {
+                    let mut rep = reporter.lock().unwrap();
+                    rep.info(&format!(
+                        "{}@{}: reconciled as published on resume (no republish)",
+                        p.name, p.version
+                    ));
+                }
+                return PackagePublishResult {
+                    result: Ok(PackageReceipt {
+                        name: p.name.clone(),
+                        version: p.version.clone(),
+                        attempts: 0,
+                        state: PackageState::Published,
+                        started_at,
+                        finished_at: Utc::now(),
+                        duration_ms: start_instant.elapsed().as_millis(),
+                        evidence: PackageEvidence {
+                            attempts: vec![],
+                            readiness_checks: vec![],
+                        },
+                    }),
+                };
+            }
+            ReconciliationOutcome::NotPublished { .. } => {
+                {
+                    let mut state = st.lock().unwrap();
+                    update_state_locked(&mut state, &key, PackageState::Pending);
+                    let _ = state::save_state(state_dir, &state);
+                }
+                {
+                    let mut rep = reporter.lock().unwrap();
+                    rep.info(&format!(
+                        "{}@{}: reconciled as not published; proceeding with publish",
+                        p.name, p.version
+                    ));
+                }
+                // Fall through to the normal retry loop below.
+            }
+            ReconciliationOutcome::StillUnknown { reason, .. } => {
+                {
+                    let mut rep = reporter.lock().unwrap();
+                    rep.error(&format!(
+                        "{}@{}: resume reconciliation still inconclusive: {}",
+                        p.name, p.version, reason
+                    ));
+                }
+                maybe_send_event(
+                    &opts.webhook,
+                    WebhookEvent::PublishFailed {
+                        plan_id: ws.plan.plan_id.clone(),
+                        package_name: p.name.clone(),
+                        package_version: p.version.clone(),
+                        error_class: format!("{:?}", ErrorClass::Ambiguous),
+                        message: format!("resume reconciliation still inconclusive: {reason}"),
+                    },
+                );
+                return PackagePublishResult {
+                    result: Err(anyhow::anyhow!(
+                        "{}@{}: resume reconciliation still inconclusive; operator action required. Prior reason: {}",
+                        p.name,
+                        p.version,
+                        reason
+                    )),
+                };
+            }
+        }
+    }
+
     // Registry-aware backoff (#94): lazy-cached answer to "is this a brand-new
     // crate?" — only consulted when a retry's error message looks like a
     // rate-limit signal. Lazy so the happy path costs zero extra registry


### PR DESCRIPTION
Closes the last remaining safety gap from [#99](https://github.com/EffortlessMetrics/shipper/issues/99) after the in-flight reconciliation landed in #111.

## The gap this closes

When a prior run left a package in \`PackageState::Ambiguous\` (reconciliation was inconclusive), a subsequent \`shipper resume\` would fall through to blind cargo retry. That risked re-uploading a crate whose original upload may have actually succeeded — the exact scenario the \"never blind retry\" rule was designed to prevent.

## What this adds

Both sequential (\`engine::mod\`) and parallel (\`engine::parallel::publish\`) publish paths detect \`PackageState::Ambiguous\` **before** any cargo activity and reconcile against registry truth first:

| Outcome | Action |
|---|---|
| \`Published\` | mark Published, return success receipt; no republish |
| \`NotPublished\` | clear state to Pending, fall through to normal publish flow |
| \`StillUnknown\` | emit \`PublishFailed\` webhook + halt with operator-actionable error |

## Implementation symmetry

- **Sequential**: new \`sequential_reconcile\` helper wraps \`RegistryClient::is_version_visible_with_backoff\` and returns the same \`(ReconciliationOutcome, Vec<ReadinessEvidence>)\` shape the parallel helper does
- **Parallel**: reuses existing \`reconcile_ambiguous_upload\` from \`engine::parallel::reconcile\`

Both emit \`PublishReconciling\` + \`PublishReconciled\` events so the event stream records resume-time reconciliation alongside any in-flight reconciliation from earlier runs.

## Verification

- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] 192 engine tests pass (no regressions)

## Related

- Parent: #99 Reconcile (biggest non-cosmetic safety gap from v0.3.0-rc.1)
- Sibling PRs already merged: #111 (in-flight reconcile), #112 (events-as-truth), #113 (retry narration), #114 (registry-aware backoff)
- Master roadmap: #109