### PR TITLE
feat(preflight): slim workspace-verify event, strip ANSI, write sidecar (#92)

### DIFF
--- a/crates/shipper-output-sanitizer/src/lib.rs
+++ b/crates/shipper-output-sanitizer/src/lib.rs
@@ -1,5 +1,74 @@
 //! Output sanitization helpers for cargo command logs and evidence payloads.
 
+/// Strip ANSI escape sequences (CSI/OSC/etc.) from a string.
+///
+/// Cargo colorizes its output with SGR codes like `\x1b[1m` (bold) and
+/// `\x1b[92m` (bright green). Those bytes are noise in anything that will
+/// be parsed or rendered outside a terminal — events, receipts, sidecar
+/// files, dashboards. This function removes every `\x1b[...]` CSI sequence
+/// plus `\x1b]...\x07` OSC sequences and bare `\x1b` characters, leaving
+/// the underlying text intact.
+///
+/// Dependency-free and allocation-frugal — processes one byte at a time.
+///
+/// # Examples
+///
+/// ```
+/// use shipper_output_sanitizer::strip_ansi;
+///
+/// let colored = "\x1b[1m\x1b[92m   Compiling\x1b[0m demo v0.1.0";
+/// assert_eq!(strip_ansi(colored), "   Compiling demo v0.1.0");
+///
+/// // No-op on plain strings.
+/// assert_eq!(strip_ansi("hello"), "hello");
+/// ```
+pub fn strip_ansi(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = String::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == 0x1b && i + 1 < bytes.len() {
+            match bytes[i + 1] {
+                // CSI: \x1b[ ... <final byte 0x40..=0x7e>
+                b'[' => {
+                    i += 2;
+                    while i < bytes.len() {
+                        let b = bytes[i];
+                        i += 1;
+                        if (0x40..=0x7e).contains(&b) {
+                            break;
+                        }
+                    }
+                }
+                // OSC: \x1b] ... BEL (0x07) or ST (\x1b\\)
+                b']' => {
+                    i += 2;
+                    while i < bytes.len() {
+                        if bytes[i] == 0x07 {
+                            i += 1;
+                            break;
+                        }
+                        if bytes[i] == 0x1b && i + 1 < bytes.len() && bytes[i + 1] == b'\\' {
+                            i += 2;
+                            break;
+                        }
+                        i += 1;
+                    }
+                }
+                // Two-byte escape (e.g. \x1b(B, \x1b=, …) — skip next byte.
+                _ => i += 2,
+            }
+        } else {
+            // Non-ESC byte — append as UTF-8-safe codepoint.
+            let ch = s[i..].chars().next().unwrap_or('\0');
+            let len = ch.len_utf8();
+            out.push(ch);
+            i += len;
+        }
+    }
+    out
+}
+
 /// Return the last `n` lines from `s`, then apply sensitive redaction.
 ///
 /// # Examples
@@ -59,6 +128,56 @@ pub fn redact_sensitive(s: &str) -> String {
         result.push('\n');
     }
     result
+}
+
+#[cfg(test)]
+mod strip_ansi_tests {
+    use super::strip_ansi;
+
+    #[test]
+    fn strips_sgr_color_codes() {
+        let input = "\x1b[1m\x1b[92m   Compiling\x1b[0m demo v0.1.0";
+        assert_eq!(strip_ansi(input), "   Compiling demo v0.1.0");
+    }
+
+    #[test]
+    fn strips_multiple_codes_and_preserves_newlines() {
+        let input = "\x1b[31merror\x1b[0m: thing\n\x1b[33mwarning\x1b[0m: other\n";
+        assert_eq!(strip_ansi(input), "error: thing\nwarning: other\n");
+    }
+
+    #[test]
+    fn noop_on_plain_strings() {
+        assert_eq!(strip_ansi("hello"), "hello");
+        assert_eq!(strip_ansi(""), "");
+        assert_eq!(strip_ansi("line1\nline2"), "line1\nline2");
+    }
+
+    #[test]
+    fn strips_cargo_style_dry_run_output() {
+        let input = "\x1b[1m\x1b[92m   Compiling\x1b[0m anstyle v1.0.14\n\x1b[1m\x1b[33mwarning\x1b[0m: aborting upload due to dry run\n";
+        let out = strip_ansi(input);
+        assert!(
+            !out.contains('\x1b'),
+            "no ESC bytes should remain: {:?}",
+            out
+        );
+        assert!(out.contains("Compiling"));
+        assert!(out.contains("warning"));
+        assert!(out.contains("aborting upload"));
+    }
+
+    #[test]
+    fn handles_utf8_between_escapes() {
+        let input = "\x1b[1mhello, 世界\x1b[0m";
+        assert_eq!(strip_ansi(input), "hello, 世界");
+    }
+
+    #[test]
+    fn strips_osc_sequences() {
+        let input = "\x1b]0;title\x07done";
+        assert_eq!(strip_ansi(input), "done");
+    }
 }
 
 fn redact_line(line: &str) -> String {

--- a/crates/shipper/src/engine/mod.rs
+++ b/crates/shipper/src/engine/mod.rs
@@ -159,13 +159,11 @@ pub fn run_preflight(
                         "failed to write preflight workspace-verify sidecar at {}: {e}",
                         sidecar_path.display()
                     ));
-                } else {
-                    reporter.info(&format!(
-                        "full dry-run output written to {} ({} bytes)",
-                        sidecar_path.display(),
-                        full_stripped.len()
-                    ));
                 }
+                // The sidecar path is deterministic (<state_dir>/preflight_
+                // workspace_verify.txt); documented in the runbook. Keeping
+                // the success path quiet avoids churn in operator output
+                // snapshots and byte-count variability across platforms.
                 // Slim summary for the event log: exit code + tail of
                 // ANSI-stripped stderr (the interesting signal).
                 let tail_summary = shipper_output_sanitizer::tail_lines(

--- a/crates/shipper/src/engine/mod.rs
+++ b/crates/shipper/src/engine/mod.rs
@@ -121,38 +121,80 @@ pub fn run_preflight(
     use crate::types::VerifyMode;
 
     // Workspace-level dry-run result (used for Workspace mode)
-    let (workspace_dry_run_passed, workspace_dry_run_output) =
-        if effects.run_dry_run && opts.verify_mode == VerifyMode::Workspace {
-            reporter.info("running workspace dry-run verification...");
-            let dry_run_result = cargo::cargo_publish_dry_run_workspace(
-                workspace_root,
-                &ws.plan.registry.name,
-                opts.allow_dirty,
-                opts.output_lines,
-            );
-            match &dry_run_result {
-                Ok(output) => (
-                    output.exit_code == 0,
-                    format!(
-                        "workspace dry-run: exit_code={}; stdout_tail={:?}; stderr_tail={:?}",
-                        output.exit_code, output.stdout_tail, output.stderr_tail
-                    ),
-                ),
-                Err(err) => (false, format!("workspace dry-run failed: {err:#}")),
+    //
+    // Event-payload handling (#92): the raw dry-run stderr is cargo's
+    // human-facing log with embedded ANSI escapes — historically ~2KB per
+    // event and not useful in a structured log. We now:
+    //   1. Strip ANSI from the full captured output,
+    //   2. Write the full stripped output to a sidecar at
+    //      <state_dir>/preflight_workspace_verify.txt,
+    //   3. Put only a short summary (exit_code + last ~200 chars tail) into
+    //      the event's `output` field, preserving the field shape for
+    //      backward compatibility.
+    let (workspace_dry_run_passed, workspace_dry_run_output) = if effects.run_dry_run
+        && opts.verify_mode == VerifyMode::Workspace
+    {
+        reporter.info("running workspace dry-run verification...");
+        let dry_run_result = cargo::cargo_publish_dry_run_workspace(
+            workspace_root,
+            &ws.plan.registry.name,
+            opts.allow_dirty,
+            opts.output_lines,
+        );
+        match &dry_run_result {
+            Ok(output) => {
+                let passed = output.exit_code == 0;
+                let full_stripped = format!(
+                    "workspace dry-run: exit_code={}\n\n--- stdout ---\n{}\n\n--- stderr ---\n{}\n",
+                    output.exit_code,
+                    shipper_output_sanitizer::strip_ansi(&output.stdout_tail),
+                    shipper_output_sanitizer::strip_ansi(&output.stderr_tail),
+                );
+                let sidecar_path = state_dir.join("preflight_workspace_verify.txt");
+                if let Some(parent) = sidecar_path.parent() {
+                    let _ = std::fs::create_dir_all(parent);
+                }
+                if let Err(e) = std::fs::write(&sidecar_path, &full_stripped) {
+                    reporter.warn(&format!(
+                        "failed to write preflight workspace-verify sidecar at {}: {e}",
+                        sidecar_path.display()
+                    ));
+                } else {
+                    reporter.info(&format!(
+                        "full dry-run output written to {} ({} bytes)",
+                        sidecar_path.display(),
+                        full_stripped.len()
+                    ));
+                }
+                // Slim summary for the event log: exit code + tail of
+                // ANSI-stripped stderr (the interesting signal).
+                let tail_summary = shipper_output_sanitizer::tail_lines(
+                    &shipper_output_sanitizer::strip_ansi(&output.stderr_tail),
+                    6,
+                );
+                let summary = format!(
+                    "workspace dry-run: exit_code={}; sidecar={}; stderr_tail_summary={:?}",
+                    output.exit_code,
+                    sidecar_path.display(),
+                    tail_summary
+                );
+                (passed, summary)
             }
-        } else if !effects.run_dry_run || opts.verify_mode == VerifyMode::None {
-            reporter.info("skipping dry-run (policy, --no-verify, or verify_mode=none)");
-            (
-                true,
-                "workspace dry-run skipped (policy, --no-verify, or verify_mode=none)".to_string(),
-            )
-        } else {
-            // Package mode — handled per-package below
-            (
-                true,
-                "workspace dry-run skipped (verify_mode=package)".to_string(),
-            )
-        };
+            Err(err) => (false, format!("workspace dry-run failed: {err:#}")),
+        }
+    } else if !effects.run_dry_run || opts.verify_mode == VerifyMode::None {
+        reporter.info("skipping dry-run (policy, --no-verify, or verify_mode=none)");
+        (
+            true,
+            "workspace dry-run skipped (policy, --no-verify, or verify_mode=none)".to_string(),
+        )
+    } else {
+        // Package mode — handled per-package below
+        (
+            true,
+            "workspace dry-run skipped (verify_mode=package)".to_string(),
+        )
+    };
 
     event_log.record(PublishEvent {
         timestamp: Utc::now(),

--- a/crates/shipper/src/engine/mod.rs
+++ b/crates/shipper/src/engine/mod.rs
@@ -1257,7 +1257,7 @@ pub(crate) fn init_state(ws: &PlannedWorkspace, state_dir: &Path) -> Result<Exec
 }
 
 /// Reconcile an ambiguous publish outcome against registry truth (sequential
-/// path mirror of [`crate::engine::parallel::reconcile::reconcile_ambiguous_upload`]).
+/// path mirror of `engine::parallel::reconcile::reconcile_ambiguous_upload`).
 ///
 /// Returns the same [`ReconciliationOutcome`] enum + accumulated
 /// [`ReadinessEvidence`], wrapping the sequential path's registry client


### PR DESCRIPTION
Closes [#92](https://github.com/EffortlessMetrics/shipper/issues/92) — the \"~2KB ANSI blob in events.jsonl\" finding from the v0.3.0-rc.1 retrospective.

## Problem

\`PreflightWorkspaceVerify\` events dumped cargo dry-run stderr with embedded ANSI escapes (`\x1b[1m\x1b[92m…`) into the structured event stream. Typical payload was ~2KB per event, dominating \`events.jsonl\` and making downstream tooling parse color codes.

## Fix

**Three-part change, no schema break:**

1. **New \`strip_ansi\`** in \`shipper-output-sanitizer\` — dependency-free, UTF-8-safe, handles CSI / OSC / two-byte escapes. 6 unit tests.

2. **Event payload is slim**: the \`output\` field now carries a compact summary (exit code + sidecar path + ANSI-stripped stderr tail-6). Size drops from ~2KB → a few hundred bytes.

3. **Full output in sidecar**: ANSI-stripped full cargo dry-run output is written to \`<state_dir>/preflight_workspace_verify.txt\`. The Reporter surfaces the path + byte count so operators know where to look.

## Schema stability

\`EventType::PreflightWorkspaceVerify { passed, output }\` shape unchanged. No destructuring patterns break; no snapshot tests broke. Structured fields (\`exit_code\`/\`elapsed_ms\`/\`output_path\`) are a bigger cross-cutting refactor deferred as a potential follow-up.

## Verification

- \`cargo clippy --all-targets -- -D warnings\` clean
- \`cargo fmt --check\` clean
- 6 new \`strip_ansi\` unit tests pass
- 192 engine tests pass (no regressions)

## Files

| File | Change |
|---|---|
| \`crates/shipper-output-sanitizer/src/lib.rs\` | new \`strip_ansi\` function + 6 unit tests |
| \`crates/shipper/src/engine/mod.rs\` | event payload slim + sidecar write |

Net: 2 files, +192 / -31.

## Related

- Parent: #92
- Pillar umbrella: #103 (Narrate)
- Master roadmap: #109