### PR TITLE
docs: demote cargo stdout to hint; registry is authoritative (#99 follow-on)

### DIFF
--- a/crates/shipper-types/src/lib.rs
+++ b/crates/shipper-types/src/lib.rs
@@ -924,14 +924,36 @@ pub enum PackageState {
 /// let ambiguous = ErrorClass::Ambiguous;
 /// ```
 ///
-/// # Classification Heuristics
+/// # Classification is a hint, not truth
+///
+/// This enum is produced by parsing cargo's stdout/stderr — a human-facing
+/// log that is explicitly not a stable machine protocol. Pattern-matching on
+/// cargo text gives Shipper a fast first-pass signal, but **it must never be
+/// treated as the final word** on what actually happened:
+///
+/// - [`ErrorClass::Permanent`] and [`ErrorClass::Retryable`] are still
+///   hints — they drive retry scheduling, but every retry attempt re-checks
+///   the registry before and after the next `cargo publish`.
+/// - [`ErrorClass::Ambiguous`] is the dangerous case. Cargo's publish flow
+///   uploads to the registry first and polls the index afterwards; the poll
+///   can time out without affecting the upload. So a non-zero cargo exit
+///   can coexist with a successful upload. Ambiguous outcomes MUST be
+///   reconciled against registry truth before any further action — never
+///   blind-retry. See [`ReconciliationOutcome`] and the reconciliation flow
+///   in `shipper::engine::parallel::reconcile`.
+///
+/// The authoritative classification for `Ambiguous` outcomes comes from
+/// **querying the registry** (sparse index + API) after the fact. Cargo
+/// stderr is a signal; the registry is the source of truth.
+///
+/// # Classification Heuristics (hints)
 ///
 /// Shipper uses various heuristics to classify errors:
 /// - HTTP 429 (Too Many Requests) → Retryable
 /// - HTTP 401/403 (Auth errors) → Permanent
 /// - HTTP 409 (Version conflict) → Permanent
 /// - Network timeouts → Retryable
-/// - Unknown errors → Ambiguous
+/// - Unknown errors → Ambiguous (triggers registry reconciliation)
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ErrorClass {

--- a/crates/shipper/src/runtime/execution/mod.rs
+++ b/crates/shipper/src/runtime/execution/mod.rs
@@ -58,6 +58,16 @@ pub fn short_state(st: &PackageState) -> &'static str {
 }
 
 /// Classify a cargo failure output into retry semantics for publish decisioning.
+///
+/// **This is a hint, not authoritative truth.** The returned [`ErrorClass`]
+/// is produced by pattern-matching on cargo's human-facing stdout/stderr —
+/// a surface that is explicitly not a stable machine protocol. The retry
+/// loop consumes this classification as fast-path input, but the
+/// authoritative resolution for an [`ErrorClass::Ambiguous`] outcome comes
+/// from querying the registry (sparse index + API) via the reconciliation
+/// flow — never from the cargo text alone. See the `ErrorClass` rustdoc
+/// and `shipper::engine::parallel::reconcile` for the "hint vs truth"
+/// contract.
 pub fn classify_cargo_failure(stderr: &str, stdout: &str) -> (ErrorClass, String) {
     let outcome = shipper_cargo_failure::classify_publish_failure(stderr, stdout);
     let class = match outcome.class {

--- a/docs/explanation/why-shipper.md
+++ b/docs/explanation/why-shipper.md
@@ -75,6 +75,18 @@ Retrying on failure is easy. The interesting questions are:
 
 Each answer is a separate responsibility. Shipper owns them all, under a single process, with a single durable ledger. That's the thing Cargo is not, and shouldn't be.
 
+## Cargo stdout is a hint; the registry is the truth
+
+Cargo's `publish` command uploads to the registry, then polls the index, then reports success or failure. The poll can time out while the upload succeeded. Cargo's stdout/stderr are a human-facing log — explicitly **not** a stable machine protocol.
+
+Shipper treats cargo text as a **fast-path hint**, never the authoritative answer:
+
+- Classification into `ErrorClass::{Retryable, Permanent, Ambiguous}` comes from pattern-matching cargo's stderr. Useful. Not definitive.
+- On `Ambiguous` (cargo exit uncertain), Shipper **never blind-retries**. It polls the registry (sparse index + API) via the reconciliation flow and resolves one of `Published` / `NotPublished` / `StillUnknown`. The registry is authoritative.
+- On `StillUnknown` (even the registry queries couldn't resolve), Shipper halts and surfaces the state for operator decision — uploading a potential duplicate is worse than waiting.
+
+This is why Shipper can be *safer* than a naive `cargo publish` loop in a shell script: the shell script only has cargo's exit code to go on, and Cargo's exit code is sometimes just wrong about whether the upload happened.
+
 ## The single test
 
 If we're doing our job, the single-sentence test from [MISSION.md](../../MISSION.md) is true:


### PR DESCRIPTION
Closes one of the remaining [#99](https://github.com/EffortlessMetrics/shipper/issues/99) follow-ons: make it explicit that cargo's stdout/stderr is a **hint** for Shipper's retry classification, not the authoritative answer.

## What this changes

- **\`ErrorClass\` rustdoc** (shipper-types) — new \"Classification is a hint, not truth\" section. Explains that pattern-matching cargo text is a fast-path signal, and that \`Ambiguous\` outcomes MUST be reconciled against registry truth via \`ReconciliationOutcome\`. Never blind-retry.
- **\`classify_cargo_failure\` rustdoc** (shipper runtime::execution) — states up-front \"This is a hint, not authoritative truth\" and points readers at the reconcile flow.
- **\`docs/explanation/why-shipper.md\`** — new section \"Cargo stdout is a hint; the registry is the truth\" connecting the contract to *why* Shipper can be safer than a naive \`cargo publish\` shell loop.

## Why this matters

After #111 (in-flight reconcile) and #115 (resume-path reconcile) landed, the reconciliation flow is authoritative **in code**. This PR makes it authoritative **in the documented contract** — so contributors adding new patterns to cargo-failure classification know where the hint ends and truth begins.

## Verification

- \`cargo doc --no-deps -Dwarnings\` clean
- \`cargo test -p shipper-types\` — 268 pass
- \`cargo test -p shipper --lib runtime::execution\` — 134 pass
- No code changes, no schema changes, no snapshot churn

## Files

| File | Change |
|---|---|
| \`crates/shipper-types/src/lib.rs\` | +\`ErrorClass\` rustdoc \"hint vs truth\" section |
| \`crates/shipper/src/runtime/execution/mod.rs\` | +\`classify_cargo_failure\` rustdoc hint disclaimer |
| \`docs/explanation/why-shipper.md\` | +section explaining the hint/truth contract at product level |

Net: 3 files, +46 / -2.

## #99 scorecard after this merge

- [x] Core in-flight reconciliation state machine (#111)
- [x] Resume-path reconciliation (#115)
- [x] Docs/contracts: cargo text is a hint, registry is truth (**this PR**)
- [ ] BDD integration scenarios for the three outcomes (scouted on #99; next PR)

## Related

- Parent: #99
- Pillar: #102 Reconcile
- Master roadmap: #109