### PR TITLE
docs: operator-trust pack — not_proven explainer + stalled-run triage + state-files cheat sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,9 @@ Top of the repo:
 Quick links:
 
 - **Learn:** [First publish tutorial](docs/tutorials/first-publish.md) • [Recover from interruption](docs/tutorials/recover-from-interruption.md)
-- **Do:** [Run in GitHub Actions](docs/how-to/run-in-github-actions.md) • [Inspect state & receipts](docs/how-to/inspect-state-and-receipts.md)
-- **Look up:** [CLI reference](docs/reference/cli.md) • [`.shipper.toml`](docs/configuration.md) • [Failure modes](docs/failure-modes.md)
-- **Understand:** [Why Shipper](docs/explanation/why-shipper.md) • [Architecture](docs/architecture.md) • [Invariants](docs/INVARIANTS.md)
+- **Do:** [Run in GitHub Actions](docs/how-to/run-in-github-actions.md) • [Inspect state & receipts](docs/how-to/inspect-state-and-receipts.md) • [Inspect a stalled run](docs/how-to/inspect-a-stalled-run.md)
+- **Look up:** [CLI reference](docs/reference/cli.md) • [State files cheat sheet](docs/reference/state-files.md) • [`.shipper.toml`](docs/configuration.md) • [Failure modes](docs/failure-modes.md)
+- **Understand:** [Why Shipper](docs/explanation/why-shipper.md) • [`not_proven` explained](docs/explanation/finishability.md) • [Architecture](docs/architecture.md) • [Invariants](docs/INVARIANTS.md)
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,8 @@ Step-by-step learning paths. Start here if you've never used Shipper before.
 Task-oriented recipes. Each solves one focused problem.
 
 - [Run a release in GitHub Actions](how-to/run-in-github-actions.md)
-- [Inspect state, events, and receipts](how-to/inspect-state-and-receipts.md)
+- [Inspect state, events, and receipts](how-to/inspect-state-and-receipts.md) — post-hoc inspection ("what happened")
+- [Inspect a stalled or interrupted run](how-to/inspect-a-stalled-run.md) — live triage ("is it alive?")
 
 Operator runbook (promotion to how-to pending): [release-runbook.md](release-runbook.md)
 
@@ -32,6 +33,7 @@ Operator runbook (promotion to how-to pending): [release-runbook.md](release-run
 Exhaustive, precise, stable specs.
 
 - [CLI reference](reference/cli.md) (canonical source: `shipper --help` / `shipper <cmd> --help`)
+- [State files cheat sheet](reference/state-files.md) — `.shipper/` file roles, authority order, jq recipes
 - [`.shipper.toml` configuration](configuration.md)
 - [Preflight checks](preflight.md)
 - [Readiness verification](readiness.md)
@@ -42,6 +44,7 @@ Exhaustive, precise, stable specs.
 Design decisions and reasoning. Read these to understand *why* things are the way they are.
 
 - [Why Shipper exists](explanation/why-shipper.md)
+- [Understanding `finishability` (especially `not_proven`)](explanation/finishability.md)
 - [Architecture](architecture.md)
 - [Events-as-truth invariant](INVARIANTS.md)
 - [Product overview](product.md)

--- a/docs/explanation/finishability.md
+++ b/docs/explanation/finishability.md
@@ -1,0 +1,73 @@
+# Understanding `finishability` — especially `not_proven`
+
+`shipper preflight` ends by emitting a `finishability` value — one of three states. Two of them are obvious; the third reads alarming but is usually fine. This page explains what each means, why `not_proven` is the *correct* answer in common cases, and when to worry vs when to proceed.
+
+## The three states
+
+```rust
+Finishability::Proven     // every check came back positive; publish is expected to succeed
+Finishability::NotProven  // checks ran without errors, but some couldn't complete to "proven"
+Finishability::Failed     // preflight found something actually wrong; do not publish
+```
+
+Preflight runs these checks, roughly in order:
+1. **Git cleanliness** — working tree has no uncommitted changes (unless `--allow-dirty`)
+2. **Registry reachability** — the API base URL responds
+3. **Workspace dry-run** — `cargo publish --dry-run` succeeds across the workspace
+4. **Version-not-taken** — for each crate, the version about to be published isn't already on the registry
+5. **Ownership** (best-effort) — the configured token is listed as an owner of each crate
+
+`Failed` triggers on hard violations: dirty tree without `--allow-dirty`, registry unreachable, dry-run fails, version already taken. Something is actually broken; don't publish.
+
+`Proven` triggers when everything — including ownership — comes back positive.
+
+`NotProven` triggers when the *completed* checks all passed but at least one check *couldn't reach a conclusion*. This is the state that reads scary and usually isn't.
+
+## Why `not_proven` is the correct answer for first-publish runs
+
+The canonical case: you're publishing a brand-new crate to crates.io for the first time.
+
+- Version-not-taken? ✅ Passes — the crate doesn't exist yet, so no version is taken.
+- Workspace dry-run? ✅ Passes — cargo can package the crate locally.
+- **Ownership?** ❓ Can't complete. There's no crate yet, so there's no owners endpoint to query. The check returns "not verified" — not because you *aren't* the owner, but because the question doesn't apply yet.
+
+Preflight correctly refuses to claim `Proven` in this case — it would be lying. The crate doesn't exist yet; ownership is literally unverifiable until after the first publish. But nothing is *wrong*; the dry-run passed, the registry is reachable, the version is available. So the honest answer is `NotProven`.
+
+On the v0.3.0-rc.1 first publish of 12 new Shipper crates, preflight correctly reported `finishability=not_proven` for every one, and the publish train completed successfully.
+
+## What to do when you see `not_proven`
+
+### If this is a first publish of new crates
+Proceed. The ownership check can't complete until the crate exists; you have no way to advance past `not_proven` for a brand-new crate except by publishing it. The release.yml workflow in this repo deliberately treats `not_proven` as non-failing because of exactly this case.
+
+### If this is a new version of an existing crate and you see `not_proven`
+Read the preflight report carefully — it lists the specific checks that didn't conclude. Common causes:
+
+- **Token doesn't have owner permissions** on the crate — real fix: `cargo owner --add` or rotate the token.
+- **Registry API temporarily returned an unexpected shape** — usually a crates.io hiccup; re-run preflight.
+- **Network flake on the owners endpoint** — re-run.
+
+### If you're not sure
+Run `shipper preflight --format json` and inspect the per-package detail. Each `PreflightPackage` entry shows which individual checks passed or didn't conclude, so you can tell whether it's the "new crate, owners endpoint doesn't apply" case or something genuinely actionable.
+
+## Why Shipper doesn't auto-promote `not_proven` to `proven`
+
+We considered it — rename `not_proven` to `provisional_new_crate` when the only unverified check is ownership on a crate that doesn't exist yet — but that's a product-wording change that can happen anytime. The *state* is correct.
+
+A future upgrade path exists via the rehearsal registry ([#97](https://github.com/EffortlessMetrics/shipper/issues/97)): publishing the exact packaged artifacts to an alternate registry first, then resolving + installing from that registry, would let preflight promote many `NotProven` cases to `Proven`. That's the next tier of proof; until it lands, first-publish `NotProven` is epistemically honest and operationally fine.
+
+## The short version
+
+| Situation | `finishability` | Action |
+|---|---|---|
+| Everything green | `Proven` | Publish |
+| First publish of new crate; ownership can't be verified yet | `NotProven` | **Publish** — this is normal |
+| Token lacks ownership on an existing crate | `NotProven` | Fix ownership (`cargo owner --add`) or rotate token |
+| Git dirty, dry-run failed, version taken, registry unreachable | `Failed` | Do not publish; fix the actual problem |
+
+## See also
+
+- [MISSION.md — the single test](../../MISSION.md) (`you can start a release train...`)
+- [why-shipper.md](why-shipper.md#why-finishability-has-three-states) — the deeper "why three states"
+- [#97 Rehearsal registry](https://github.com/EffortlessMetrics/shipper/issues/97) — future path to promote more `NotProven` cases to `Proven`
+- [preflight.md](../preflight.md) — what each preflight check does

--- a/docs/how-to/inspect-a-stalled-run.md
+++ b/docs/how-to/inspect-a-stalled-run.md
@@ -1,0 +1,119 @@
+# How to inspect a stalled or interrupted run
+
+Your CI log has been quiet for 10 minutes. Or the workflow got cancelled mid-publish. Or you're trying to figure out whether the train is still alive or genuinely hung. This guide is the triage path.
+
+> **Related:** [Inspect state, events, and receipts](inspect-state-and-receipts.md) covers the "what happened after the run" case. This doc is about the "is it alive right now?" and "what will resume do?" cases.
+
+## Triage: which file answers which question?
+
+| Question | File | Command |
+|---|---|---|
+| Is the train alive or hung? | `events.jsonl` (latest entries) | `tail -n 20 .shipper/events.jsonl \| jq -c '.'` |
+| What's the current crate? | `events.jsonl` (last `package_started`) | see below |
+| How long has it been waiting? | `events.jsonl` (last `retry_backoff_started`) | see below |
+| Which crates finished? | `events.jsonl` (published events) OR `state.json` | see below |
+| What's next when I resume? | `state.json` (packages with `state.state == "pending"`) | see below |
+| Why did it fail? | `events.jsonl` (last `package_failed` / `publish_reconciled.StillUnknown`) | see below |
+
+**Authority order**: `events.jsonl` > `state.json` > `receipt.json`. When they disagree, events win. Per [INVARIANTS.md](../INVARIANTS.md).
+
+## "Is it alive?" — the 30-second check
+
+```bash
+# What was the last event, and how recent?
+jq -c '.' .shipper/events.jsonl | tail -1
+```
+
+If the last event is a `retry_backoff_started`, the run is alive and waiting. Check `next_attempt_at`:
+
+```bash
+jq -c 'select(.event_type.type == "retry_backoff_started") | .event_type' .shipper/events.jsonl | tail -1
+```
+
+Expected output includes `next_attempt_at` (an ISO-8601 timestamp). If it's still in the future, the train is alive and scheduled to retry. If it's in the past by more than a few minutes, something may actually be stuck.
+
+```bash
+# Which crate are we currently working on?
+jq -r 'select(.event_type.type == "package_started") | .package' .shipper/events.jsonl | tail -1
+```
+
+## "What's normal waiting?"
+
+crates.io's publish rate limits:
+
+- **Brand-new crates**: 5-crate burst, then 1 new crate per 10 minutes
+- **New versions of existing crates**: 30 per minute after a 30-burst
+
+If you're publishing 12 new crates, expect ~90-minute wall clock. Silence between retries of up to ~10 minutes is **normal**. If it's been 30+ minutes since the last event, investigate.
+
+`retry_backoff_started` events (added in [#91](https://github.com/EffortlessMetrics/shipper/issues/91)) now carry the full context — reason, attempt number, next-attempt time. A run that's correctly waiting on crates.io will emit these regularly.
+
+## "What did already publish successfully?"
+
+```bash
+# From events.jsonl (authoritative)
+jq -r 'select(.event_type.type == "package_published") | .package' .shipper/events.jsonl | sort -u
+
+# From state.json (projection, fast)
+jq -r '.packages[] | select(.state.state == "published") | .name' .shipper/state.json | sort -u
+```
+
+If these two lists disagree, events are truth. A mismatch triggers `StateEventDriftDetected` at end-of-run (added in [#93](https://github.com/EffortlessMetrics/shipper/issues/93)).
+
+## "What will resume do?"
+
+`shipper resume` reads `state.json`, validates the `plan_id` matches the current workspace, and continues from the first non-terminal package. Terminal states for resume: `Published`, `Skipped`. Non-terminal: `Pending`, `Failed`, `Ambiguous`.
+
+```bash
+# What's pending?
+jq -r '.packages[] | select(.state.state == "pending") | .name' .shipper/state.json
+
+# Anything ambiguous that will trigger resume-time reconciliation?
+jq -r '.packages[] | select(.state.state == "ambiguous") | "\(.name): \(.state.message)"' .shipper/state.json
+
+# Anything failed?
+jq -r '.packages[] | select(.state.state == "failed") | "\(.name): \(.state.message)"' .shipper/state.json
+```
+
+On `Ambiguous` state, resume will reconcile against the registry *before* any cargo activity — see [why-shipper.md](../explanation/why-shipper.md#cargo-stdout-is-a-hint-the-registry-is-the-truth).
+
+## "Why did it fail?"
+
+```bash
+# Last failure event with full context
+jq -c 'select(.event_type.type == "package_failed") | .event_type' .shipper/events.jsonl | tail -1
+
+# Reconciliation outcomes (in-flight or resume-time)
+jq -c 'select(.event_type.type == "publish_reconciled") | .event_type.outcome' .shipper/events.jsonl
+```
+
+If you see `"outcome": {"outcome": "still_unknown"}`, the registry couldn't resolve the ambiguous publish — this is the one case where operator judgment is required. The `reason` field tells you what the reconciliation query errored with.
+
+## Common scenarios
+
+### Scenario: workflow was cancelled mid-publish
+
+1. Download the `shipper-state-final` artifact from the cancelled run (or `shipper-state-preflight` / `shipper-state-plan` if later stages never ran).
+2. Trigger the `release-resume` workflow_dispatch with `mode=resume` and `artifact_run_id=<cancelled-run-id>`.
+3. The resume job downloads the artifact, runs `shipper resume`, and continues.
+
+### Scenario: runner timed out after 6 hours
+
+Same procedure. The `.shipper/` artifact was uploaded at each stage (plan / preflight / final) so even a mid-publish timeout leaves the most recent state available.
+
+### Scenario: "how do I know it's really done?"
+
+Once the workflow completes successfully, the receipt is the audit artifact:
+
+```bash
+jq '.' .shipper/receipt.json | head -40
+```
+
+Per-package state, timestamps, attempt counts, and evidence (captured stdout/stderr, registry readiness checks) all land here. Keep it for audit.
+
+## See also
+
+- [INVARIANTS.md](../INVARIANTS.md) — the truth/projection/summary contract
+- [inspect-state-and-receipts.md](inspect-state-and-receipts.md) — post-hoc inspection (what happened)
+- [state-files.md](../reference/state-files.md) — one-page cheat sheet
+- [Tutorial: Recover from an interrupted release](../tutorials/recover-from-interruption.md) — end-to-end walkthrough

--- a/docs/reference/state-files.md
+++ b/docs/reference/state-files.md
@@ -1,0 +1,135 @@
+# State files reference — `.shipper/`
+
+One-page cheat sheet. For the full contract see [INVARIANTS.md](../INVARIANTS.md); for triage recipes see [inspect-a-stalled-run.md](../how-to/inspect-a-stalled-run.md).
+
+## Authority order
+
+**`events.jsonl` > `state.json` > `receipt.json`**
+
+When they disagree, events win. `state.json` and `receipt.json` are projections/summaries derived from events. An end-of-run consistency check emits `StateEventDriftDetected` if drift is found.
+
+## Per-file summary
+
+| File | Authority | Purpose | When written | Format |
+|---|---|---|---|---|
+| `events.jsonl` | **Truth** (append-only) | Every state transition with timestamp | Per event | JSONL (one event per line) |
+| `state.json` | Projection | Serialized `ExecutionState` for fast resume | Per package state change | JSON |
+| `receipt.json` | Summary | End-of-run audit artifact with evidence | Once, at run completion | JSON |
+| `lock` | — | Concurrent-publish guard | Held during the run | Small text file |
+
+## Which file for which question?
+
+| Question | File |
+|---|---|
+| What happened, in order? | `events.jsonl` |
+| What's the current state (fast lookup)? | `state.json` |
+| Did the whole release succeed, and what's the audit trail? | `receipt.json` |
+| What would `shipper resume` skip? | `state.json` (packages with `state.state == "published"`) |
+| What's the truth when they disagree? | `events.jsonl` |
+
+## Key field paths
+
+### `events.jsonl` (one JSON object per line)
+
+```json
+{
+  "timestamp": "2026-04-17T...",
+  "event_type": {"type": "package_published", "duration_ms": 3400},
+  "package": "shipper-types@0.3.0-rc.1"
+}
+```
+
+Common event types:
+- `plan_created` — beginning
+- `preflight_started`, `preflight_workspace_verify`, `preflight_complete`
+- `package_started`, `package_attempted`, `package_published`, `package_failed`, `package_skipped`
+- `retry_backoff_started` — added in [#91](https://github.com/EffortlessMetrics/shipper/issues/91); carries attempt N/M, delay, reason, next-attempt time
+- `publish_reconciling`, `publish_reconciled` — added in [#99](https://github.com/EffortlessMetrics/shipper/issues/99); registry-truth resolution of ambiguous outcomes
+- `state_event_drift_detected` — added in [#93](https://github.com/EffortlessMetrics/shipper/issues/93); end-of-run consistency check
+- `execution_started`, `execution_finished`
+
+### `state.json`
+
+```json
+{
+  "state_version": "...",
+  "plan_id": "23ff8f85...",
+  "registry": {"name": "crates-io", "api_base": "https://crates.io"},
+  "packages": {
+    "shipper-types@0.3.0-rc.1": {
+      "name": "shipper-types",
+      "version": "0.3.0-rc.1",
+      "attempts": 1,
+      "state": {"state": "published"},
+      "last_updated_at": "..."
+    }
+  }
+}
+```
+
+**Field path caveat**: package state lives at `.packages[].state.state` (nested), **not** `.packages[].status`. Common misread.
+
+### `receipt.json`
+
+```json
+{
+  "receipt_version": "shipper.receipt.v2",
+  "plan_id": "...",
+  "registry": {...},
+  "started_at": "...",
+  "finished_at": "...",
+  "packages": [
+    {
+      "name": "shipper-types",
+      "version": "0.3.0-rc.1",
+      "attempts": 1,
+      "state": {"state": "published"},
+      "started_at": "...",
+      "finished_at": "...",
+      "duration_ms": 3400,
+      "evidence": {...}
+    }
+  ],
+  "event_log_path": ".shipper/events.jsonl",
+  "git_context": {...},
+  "environment": {...}
+}
+```
+
+## jq one-liners
+
+```bash
+# All packages that published successfully
+jq -r 'select(.event_type.type == "package_published") | .package' .shipper/events.jsonl | sort -u
+
+# Last event (is the run alive?)
+jq -c '.' .shipper/events.jsonl | tail -1
+
+# Package states from state.json
+jq -r '.packages[] | "\(.name): \(.state.state)"' .shipper/state.json
+
+# Plan ID for comparison across runs
+jq -r '.plan_id' .shipper/state.json
+
+# Reconciliation outcomes
+jq -c 'select(.event_type.type == "publish_reconciled") | .event_type' .shipper/events.jsonl
+
+# Drift (should be empty on a healthy run)
+jq -c 'select(.event_type.type == "state_event_drift_detected")' .shipper/events.jsonl
+```
+
+## Sidecar files
+
+Depending on what ran, `.shipper/` may also contain:
+
+| File | Produced by | Contents |
+|---|---|---|
+| `preflight_workspace_verify.txt` | Preflight, when workspace dry-run ran | Full ANSI-stripped cargo output ([#92](https://github.com/EffortlessMetrics/shipper/issues/92)) |
+| `plan.txt` | `shipper plan --format json` (with tee) | Plan JSON for artifact inspection |
+
+## See also
+
+- [INVARIANTS.md](../INVARIANTS.md) — truth/projection/summary contract (normative)
+- [how-to/inspect-a-stalled-run.md](../how-to/inspect-a-stalled-run.md) — triage recipes
+- [how-to/inspect-state-and-receipts.md](../how-to/inspect-state-and-receipts.md) — post-run inspection
+- [explanation/why-shipper.md](../explanation/why-shipper.md) — why the three-file split exists


### PR DESCRIPTION
Closes the \"scary-but-correct UX\" papercuts flagged across multiple external retrospectives. Three new docs covering operator-legibility gaps where Shipper's behaviour is correct but the operator's mental model wasn't supported.

## New docs (Diátaxis)

| File | Quadrant | Purpose |
|---|---|---|
| \`docs/explanation/finishability.md\` | Explanation | Why \`finishability = not_proven\` is honest-not-alarming on first publish |
| \`docs/how-to/inspect-a-stalled-run.md\` | How-to | Live triage — \"is the train alive?\" 30-second check, question-to-file map, jq recipes |
| \`docs/reference/state-files.md\` | Reference | One-page cheat sheet — authority order, per-file fields, field-path caveats, jq one-liners |

## Index updates

- \`docs/README.md\` (Diátaxis index): new entries under their quadrants
- Root \`README.md\`: extended quick-links strip

## Why these three specifically

Three external retrospectives converged on the same list:
- \`not_proven\` reads alarming but is epistemically honest for first-publish (ownership can't be verified on a crate that doesn't exist yet)
- Operators don't always know which file (\`events.jsonl\` / \`state.json\` / \`receipt.json\`) answers which question
- There's no live-triage guide for \"is it still alive?\" vs \"did it stall?\"

The existing \`inspect-state-and-receipts.md\` covers **post-hoc** inspection. The new \`inspect-a-stalled-run.md\` is distinguished: **live** triage, during the run.

## Scope

Pure docs. No code, no schema, no snapshot churn. 5 files changed, +334 / -4.

## Related

- [#103 Narrate umbrella](https://github.com/EffortlessMetrics/shipper/issues/103) — operator legibility is the theme; scout comment proposed this pack
- Complements #117 (cargo-stdout-as-hint docs) merged earlier this session
- #93 events-as-truth (the INVARIANTS the cheat sheet references)

## Verification

- Markdown renders cleanly
- All internal doc links resolve
- All issue references (#91, #92, #93, #97, #99) are real open/closed issues
- No \`cargo doc\` changes needed (no rustdoc edits)