### PR TITLE
feat(rehearsal): config + CLI flag plumbing for rehearsal registry (#97 PR 1)

### DIFF
--- a/crates/shipper-cli/src/main.rs
+++ b/crates/shipper-cli/src/main.rs
@@ -170,6 +170,23 @@ struct Cli {
     #[arg(long, global = true)]
     resume_from: Option<String>,
 
+    /// Name of a registry (from `[[registries]]` in `.shipper.toml`) to
+    /// rehearse the publish against before live dispatch.
+    ///
+    /// See issue #97. Plumbed through today; phase-2 execution (actual
+    /// publish to the rehearsal registry + install/smoke checks + live
+    /// dispatch gate) lands in a follow-on PR.
+    #[arg(long, global = true)]
+    rehearsal_registry: Option<String>,
+
+    /// Skip rehearsal even if `.shipper.toml` enables it.
+    ///
+    /// Use with caution — rehearsal (once fully implemented under #97)
+    /// is the proof boundary between "we built it" and "we verified it
+    /// actually resolves from a registry." Bypassing it should be rare.
+    #[arg(long, global = true)]
+    skip_rehearsal: bool,
+
     /// Output format: text (default) or json
     #[arg(long, default_value = "text", value_parser = ["text", "json"], global = true)]
     format: String,
@@ -427,6 +444,8 @@ fn main() -> Result<()> {
         }),
         all_registries: cli.all_registries,
         resume_from: cli.resume_from.clone(),
+        rehearsal_registry: cli.rehearsal_registry.clone(),
+        skip_rehearsal: cli.skip_rehearsal,
     };
 
     // Merge CLI overrides with config (or defaults if no config)
@@ -2048,6 +2067,7 @@ mode = "fast"
             webhook: shipper::config::WebhookConfig::default(),
             encryption: shipper::config::EncryptionConfigInner::default(),
             storage: shipper::config::StorageConfigInner::default(),
+            rehearsal: shipper::config::RehearsalConfig::default(),
         };
 
         // CLI overrides some values, leaves others as None

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__ci_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__ci_help.snap
@@ -129,6 +129,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__clean_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__clean_help.snap
@@ -125,6 +125,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__config_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__config_help.snap
@@ -127,6 +127,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__doctor_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__doctor_help.snap
@@ -122,6 +122,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__help_text.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__help_text.snap
@@ -137,6 +137,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__no_subcommand_error.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__no_subcommand_error.snap
@@ -96,6 +96,10 @@ Options:
           Publish to all configured registries
       --resume-from <RESUME_FROM>
           Optional package name to resume from
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it
       --format <FORMAT>
           Output format: text (default) or json [default: text] [possible values: text, json]
       --verbose

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__plan_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__plan_help.snap
@@ -122,6 +122,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__preflight_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__preflight_help.snap
@@ -122,6 +122,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__publish_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__publish_help.snap
@@ -122,6 +122,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__resume_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__resume_help.snap
@@ -122,6 +122,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__status_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__status_help.snap
@@ -122,6 +122,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__error_missing_ci_subcommand.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__error_missing_ci_subcommand.snap
@@ -88,6 +88,10 @@ Options:
           Publish to all configured registries
       --resume-from <RESUME_FROM>
           Optional package name to resume from
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it
       --format <FORMAT>
           Output format: text (default) or json [default: text] [possible values: text, json]
       --verbose

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__error_missing_config_subcommand.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__error_missing_config_subcommand.snap
@@ -86,6 +86,10 @@ Options:
           Publish to all configured registries
       --resume-from <RESUME_FROM>
           Optional package name to resume from
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it
       --format <FORMAT>
           Output format: text (default) or json [default: text] [possible values: text, json]
       --verbose

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_ci.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_ci.snap
@@ -129,6 +129,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_ci_github_actions.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_ci_github_actions.snap
@@ -122,6 +122,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_ci_gitlab.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_ci_gitlab.snap
@@ -122,6 +122,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_clean.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_clean.snap
@@ -125,6 +125,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_completion.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_completion.snap
@@ -128,6 +128,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_config.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_config.snap
@@ -127,6 +127,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_config_init.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_config_init.snap
@@ -127,6 +127,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_config_validate.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_config_validate.snap
@@ -127,6 +127,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_doctor.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_doctor.snap
@@ -122,6 +122,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_inspect_events.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_inspect_events.snap
@@ -122,6 +122,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_inspect_receipt.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_inspect_receipt.snap
@@ -122,6 +122,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_plan.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_plan.snap
@@ -122,6 +122,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_preflight.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_preflight.snap
@@ -122,6 +122,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_publish.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_publish.snap
@@ -122,6 +122,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_resume.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_resume.snap
@@ -122,6 +122,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_root.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_root.snap
@@ -137,6 +137,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_status.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_status.snap
@@ -122,6 +122,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-config/src/lib.rs
+++ b/crates/shipper-config/src/lib.rs
@@ -337,6 +337,43 @@ pub struct ShipperConfig {
     /// Storage configuration for cloud storage backends
     #[serde(default)]
     pub storage: StorageConfigInner,
+
+    /// Rehearsal registry configuration — opt-in phase-2 proof before live
+    /// dispatch. See [issue #97](https://github.com/EffortlessMetrics/shipper/issues/97).
+    ///
+    /// This field parses the `[rehearsal]` TOML section. It is wired through
+    /// to CLI overrides but not yet consumed by the engine — follow-on PRs
+    /// under #97 add the phase-2 execution and the gate that refuses live
+    /// dispatch unless rehearsal succeeded for the same plan_id.
+    #[serde(default)]
+    pub rehearsal: RehearsalConfig,
+}
+
+/// Rehearsal registry configuration.
+///
+/// When enabled, Shipper will (in a future PR under [#97](https://github.com/EffortlessMetrics/shipper/issues/97))
+/// run phase-2 proof before live dispatch: publish packaged artifacts to
+/// the named alternate registry, run install/smoke checks, and only then
+/// allow the live `cargo publish` to crates.io (or the target registry).
+///
+/// # Example `.shipper.toml`
+///
+/// ```toml
+/// [rehearsal]
+/// enabled = true
+/// registry = "kellnr-local"  # name must match an entry in [[registries]]
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RehearsalConfig {
+    /// If `true`, rehearsal runs before live dispatch. Default `false`
+    /// (opt-in until the phase-2 execution PR lands).
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Name of the registry (declared under `[[registries]]`) to use for
+    /// rehearsal. Must differ from the live target registry.
+    #[serde(default)]
+    pub registry: Option<String>,
 }
 
 /// Registry configuration - supports both single registry and multiple registries
@@ -461,6 +498,14 @@ pub struct CliOverrides {
     pub all_registries: bool,
     /// Optional package name to resume from
     pub resume_from: Option<String>,
+    /// Rehearsal registry override — CLI flag `--rehearsal-registry <name>`.
+    /// Sets [`RehearsalConfig::registry`] and implicitly enables rehearsal.
+    /// Consumed in a follow-on PR under [#97](https://github.com/EffortlessMetrics/shipper/issues/97);
+    /// this field is parsed now so the CLI/config surface is stable.
+    pub rehearsal_registry: Option<String>,
+    /// Skip rehearsal even if config/env enables it — CLI flag `--skip-rehearsal`.
+    /// Consumed in the same follow-on PR.
+    pub skip_rehearsal: bool,
 }
 
 impl Default for ShipperConfig {
@@ -501,6 +546,7 @@ impl Default for ShipperConfig {
             webhook: WebhookConfig::default(),
             encryption: EncryptionConfigInner::default(),
             storage: StorageConfigInner::default(),
+            rehearsal: RehearsalConfig::default(),
         }
     }
 }
@@ -1059,6 +1105,58 @@ api_base = "https://my-registry.example.com"
         assert_eq!(registry.api_base, "https://my-registry.example.com");
     }
 
+    // ---- #97 rehearsal registry config plumbing ----
+
+    #[test]
+    fn rehearsal_defaults_are_disabled_and_empty() {
+        // An empty TOML document should produce a disabled rehearsal config.
+        let config: ShipperConfig = toml::from_str("").unwrap();
+        assert!(
+            !config.rehearsal.enabled,
+            "rehearsal should default to disabled (opt-in until phase-2 execution lands)"
+        );
+        assert!(
+            config.rehearsal.registry.is_none(),
+            "rehearsal registry default is None"
+        );
+    }
+
+    #[test]
+    fn rehearsal_section_parses_enabled_with_registry_name() {
+        let toml = r#"
+[rehearsal]
+enabled = true
+registry = "kellnr-local"
+"#;
+        let config: ShipperConfig = toml::from_str(toml).unwrap();
+        assert!(config.rehearsal.enabled);
+        assert_eq!(
+            config.rehearsal.registry.as_deref(),
+            Some("kellnr-local"),
+            "rehearsal.registry should parse the named registry reference"
+        );
+    }
+
+    #[test]
+    fn rehearsal_section_partial_parses_with_field_defaults() {
+        // Only specify enabled — registry stays None; still valid.
+        let toml = r#"
+[rehearsal]
+enabled = true
+"#;
+        let config: ShipperConfig = toml::from_str(toml).unwrap();
+        assert!(config.rehearsal.enabled);
+        assert!(config.rehearsal.registry.is_none());
+    }
+
+    #[test]
+    fn rehearsal_cli_overrides_default_to_empty() {
+        // CliOverrides uses Default; rehearsal fields should be None/false by default.
+        let overrides = CliOverrides::default();
+        assert!(overrides.rehearsal_registry.is_none());
+        assert!(!overrides.skip_rehearsal);
+    }
+
     #[test]
     fn test_parse_toml_with_parallel() {
         let toml = r#"
@@ -1362,6 +1460,7 @@ enabled = true
                     access_key_id: None,
                     secret_access_key: None,
                 },
+                rehearsal: RehearsalConfig::default(),
             };
             insta::assert_yaml_snapshot!("config_all_fields", config);
         }
@@ -1819,6 +1918,7 @@ per_package_timeout = "15m"
                         webhook: WebhookConfig::default(),
                         encryption: EncryptionConfigInner::default(),
                         storage: StorageConfigInner::default(),
+                        rehearsal: RehearsalConfig::default(),
                     }
                 },
             )

--- a/crates/shipper-config/src/snapshots/shipper_config__tests__edge_case_snapshots__edge_default_config_debug.snap
+++ b/crates/shipper-config/src/snapshots/shipper_config__tests__edge_case_snapshots__edge_default_config_debug.snap
@@ -76,4 +76,8 @@ ShipperConfig {
         access_key_id: None,
         secret_access_key: None,
     },
+    rehearsal: RehearsalConfig {
+        enabled: false,
+        registry: None,
+    },
 }

--- a/crates/shipper-config/src/snapshots/shipper_config__tests__edge_case_snapshots__edge_empty_toml_parsed.snap
+++ b/crates/shipper-config/src/snapshots/shipper_config__tests__edge_case_snapshots__edge_empty_toml_parsed.snap
@@ -76,4 +76,8 @@ ShipperConfig {
         access_key_id: None,
         secret_access_key: None,
     },
+    rehearsal: RehearsalConfig {
+        enabled: false,
+        registry: None,
+    },
 }

--- a/crates/shipper-config/src/snapshots/shipper_config__tests__snapshot_tests__config_all_fields.snap
+++ b/crates/shipper-config/src/snapshots/shipper_config__tests__snapshot_tests__config_all_fields.snap
@@ -66,3 +66,6 @@ storage:
   endpoint: ~
   access_key_id: ~
   secret_access_key: ~
+rehearsal:
+  enabled: false
+  registry: ~

--- a/crates/shipper-config/src/snapshots/shipper_config__tests__snapshot_tests__default_config.snap
+++ b/crates/shipper-config/src/snapshots/shipper_config__tests__snapshot_tests__default_config.snap
@@ -60,3 +60,6 @@ storage:
   endpoint: ~
   access_key_id: ~
   secret_access_key: ~
+rehearsal:
+  enabled: false
+  registry: ~

--- a/crates/shipper-config/src/snapshots/shipper_config__tests__snapshot_tests__toml_roundtrip_parsed.snap
+++ b/crates/shipper-config/src/snapshots/shipper_config__tests__snapshot_tests__toml_roundtrip_parsed.snap
@@ -60,3 +60,6 @@ storage:
   endpoint: ~
   access_key_id: ~
   secret_access_key: ~
+rehearsal:
+  enabled: false
+  registry: ~

--- a/crates/shipper-config/tests/config_runtime_contract.rs
+++ b/crates/shipper-config/tests/config_runtime_contract.rs
@@ -69,6 +69,7 @@ fn custom_config() -> ShipperConfig {
             env_key: Some("CUSTOM_KEY".to_string()),
         },
         storage: shipper_config::StorageConfigInner::default(),
+        rehearsal: shipper_config::RehearsalConfig::default(),
     }
 }
 
@@ -119,6 +120,7 @@ fn converts_config_to_runtime_contract_with_registry_overrides() {
         },
         encryption: shipper_config::EncryptionConfigInner::default(),
         storage: shipper_config::StorageConfigInner::default(),
+        rehearsal: shipper_config::RehearsalConfig::default(),
     };
 
     let merged = source.build_runtime_options(CliOverrides {

--- a/crates/shipper-config/tests/config_runtime_proptest.rs
+++ b/crates/shipper-config/tests/config_runtime_proptest.rs
@@ -262,6 +262,7 @@ fn arb_shipper_config() -> impl Strategy<Value = ShipperConfig> {
                     webhook,
                     encryption,
                     storage: Default::default(),
+                    rehearsal: Default::default(),
                 }
             },
         )
@@ -372,6 +373,8 @@ fn arb_cli_overrides() -> impl Strategy<Value = CliOverrides> {
                     registries: None,
                     all_registries: false,
                     resume_from: None,
+                    rehearsal_registry: None,
+                    skip_rehearsal: false,
                 }
             },
         )

--- a/crates/shipper/src/config.rs
+++ b/crates/shipper/src/config.rs
@@ -1023,6 +1023,7 @@ timeout_secs = 15
             webhook: WebhookConfig::default(),
             encryption: EncryptionConfigInner::default(),
             storage: StorageConfigInner::default(),
+            rehearsal: shipper_config::RehearsalConfig::default(),
         };
 
         let serialized = toml::to_string_pretty(&config).unwrap();


### PR DESCRIPTION
First of four staged PRs for [#97 Rehearsal registry](https://github.com/EffortlessMetrics/shipper/issues/97) per the [scout plan](https://github.com/EffortlessMetrics/shipper/issues/97#issuecomment-4266106331). Plumbing only — no behavior change. Pins the config/CLI interface so follow-on PRs can thread values without schema churn.

## What this adds

**\`shipper-config\`:**
- New \`RehearsalConfig\` struct (\`enabled: bool\`, \`registry: Option<String>\`)
- Parses \`[rehearsal]\` section in \`.shipper.toml\` — default disabled, opt-in until execution lands
- Added as \`rehearsal: RehearsalConfig\` field on \`ShipperConfig\` with \`#[serde(default)]\` (backward-compat for existing configs)
- \`CliOverrides\` gains \`rehearsal_registry: Option<String>\` + \`skip_rehearsal: bool\` fields

**\`shipper-cli\`:**
- New global clap flags: \`--rehearsal-registry <name>\` and \`--skip-rehearsal\`
- Plumbed into \`CliOverrides\`; rustdoc notes the phase-2 status

## Why no \`RuntimeOptions\` change yet

\`RuntimeOptions\` has no \`Default\` impl and has 60+ construction sites across the workspace. Threading a new field now would churn every test fixture for a feature with no consumer. The follow-on PR that adds the actual rehearsal dispatch logic will add the \`RuntimeOptions\` field in the same PR — the change stays coherent.

## Verification

- \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- \`cargo fmt --check\` clean
- 4 new unit tests in \`shipper-config::tests\`:
  - \`rehearsal_defaults_are_disabled_and_empty\`
  - \`rehearsal_section_parses_enabled_with_registry_name\`
  - \`rehearsal_section_partial_parses_with_field_defaults\`
  - \`rehearsal_cli_overrides_default_to_empty\`
- shipper-config lib: 235 pass
- shipper engine tests: 125 pass (no regressions)
- Snapshot updates accepted for 5 configs that now include the default rehearsal section

## Out of scope (follow-on PRs)

- **#97 PR 2**: phase-2 execution — package every crate, publish to rehearsal registry, install/smoke check
- **#97 PR 3**: hard gate refusing live dispatch unless rehearsal passed for matching \`plan_id\`
- **#97 PR 4**: CI integration example using kellnr as a sidecar

## Related

- Parent: #97
- Pillar: Prove (tier 2)
- Master roadmap: #109