### PR TITLE
feat(yank): shipper yank <crate>@<version> (#98 PR 1)

### DIFF
--- a/crates/shipper-cli/src/main.rs
+++ b/crates/shipper-cli/src/main.rs
@@ -230,6 +230,32 @@ enum Commands {
         #[arg(long)]
         keep_receipt: bool,
     },
+    /// Yank a crate@version from the registry — containment, not undo.
+    ///
+    /// `cargo yank` marks a specific version as not-installable for NEW
+    /// dependency resolves. Existing lockfile pins and already-downloaded
+    /// copies are unaffected. See
+    /// [cargo yank docs](https://doc.rust-lang.org/cargo/commands/cargo-yank.html).
+    ///
+    /// Part of [#98 Remediate](https://github.com/EffortlessMetrics/shipper/issues/98).
+    /// Follow-on commands (`shipper plan-yank`, `shipper fix-forward`)
+    /// compose this primitive into reverse-topological containment and
+    /// fix-forward plans.
+    Yank {
+        /// Name of the crate to yank (e.g., `shipper-types`).
+        #[arg(long = "crate", value_name = "NAME")]
+        crate_name: String,
+        /// Version to yank (e.g., `0.3.0-rc.1`).
+        #[arg(long, value_name = "VERSION")]
+        version: String,
+        /// Operator-supplied reason (recorded in the event log, audit
+        /// trails, and any future receipts that reference this yank).
+        ///
+        /// Example: `"CVE-2026-0001 disclosed; containing while patch
+        /// released"`.
+        #[arg(long)]
+        reason: String,
+    },
     /// Configuration file management.
     #[command(subcommand)]
     Config(ConfigCommands),
@@ -594,6 +620,75 @@ fn main() -> Result<()> {
         }
         Commands::Ci(ci_cmd) => {
             run_ci(ci_cmd, &opts.state_dir, &planned.workspace_root)?;
+        }
+        Commands::Yank {
+            crate_name,
+            version,
+            reason,
+        } => {
+            use shipper::cargo;
+            use shipper::state::events::{EventLog, events_path};
+            use shipper::types::{EventType, PublishEvent};
+
+            reporter.warn(&format!(
+                "yanking {crate_name}@{version} from registry \
+                 (containment, not undo) — reason: {reason}"
+            ));
+
+            let workspace_root =
+                std::env::current_dir().context("failed to resolve current dir for cargo yank")?;
+            let registry_name = opts
+                .registries
+                .first()
+                .map(|r| r.name.clone())
+                .unwrap_or_else(|| "crates-io".to_string());
+
+            let out = cargo::cargo_yank(
+                &workspace_root,
+                crate_name.as_str(),
+                version.as_str(),
+                registry_name.as_str(),
+                opts.output_lines,
+                None,
+            )?;
+
+            let mut log = EventLog::new();
+            log.record(PublishEvent {
+                timestamp: chrono::Utc::now(),
+                event_type: EventType::PackageYanked {
+                    crate_name: crate_name.clone(),
+                    version: version.clone(),
+                    reason: reason.clone(),
+                    exit_code: out.exit_code,
+                },
+                package: format!("{crate_name}@{version}"),
+            });
+            let events_file = events_path(&opts.state_dir);
+            if let Err(err) = log.write_to_file(&events_file) {
+                reporter.warn(&format!(
+                    "failed to append PackageYanked event to {}: {err:#}",
+                    events_file.display()
+                ));
+            }
+
+            if out.exit_code == 0 {
+                reporter.info(&format!(
+                    "yanked {crate_name}@{version} successfully. \
+                     existing lockfile pins are NOT invalidated; \
+                     downstream consumers should `cargo update -p {crate_name}` \
+                     to pick up the next available version."
+                ));
+            } else {
+                reporter.error(&format!(
+                    "cargo yank exited {} for {crate_name}@{version}. \
+                     stderr tail:\n{}",
+                    out.exit_code, out.stderr_tail
+                ));
+                anyhow::bail!(
+                    "yank failed for {crate_name}@{version} (cargo exit {})",
+                    out.exit_code
+                );
+            }
         }
         Commands::Clean { keep_receipt } => {
             run_clean(

--- a/crates/shipper-cli/tests/e2e_expanded.rs
+++ b/crates/shipper-cli/tests/e2e_expanded.rs
@@ -1412,6 +1412,19 @@ fn help_clean_snapshot() {
     assert_snapshot!("help_clean", normalize_stderr(&stdout));
 }
 
+/// Snapshot: `yank --help` output.
+#[test]
+fn help_yank_snapshot() {
+    let output = shipper_cmd()
+        .args(["yank", "--help"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_snapshot!("help_yank", normalize_stderr(&stdout));
+}
+
 /// Snapshot: `config init --help` output.
 #[test]
 fn help_config_init_snapshot() {

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__help_text.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__help_text.snap
@@ -17,6 +17,7 @@ Commands:
   inspect-receipt  View detailed receipt with evidence
   ci               Print CI configuration snippets for various platforms
   clean            Clean state files (state.json, receipt.json, events.jsonl)
+  yank             Yank a crate@version from the registry — containment, not undo
   config           Configuration file management
   completion       Generate shell completion scripts for the specified shell
   help             Print this message or the help of the given subcommand(s)

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__no_subcommand_error.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__no_subcommand_error.snap
@@ -17,6 +17,7 @@ Commands:
   inspect-receipt  View detailed receipt with evidence
   ci               Print CI configuration snippets for various platforms
   clean            Clean state files (state.json, receipt.json, events.jsonl)
+  yank             Yank a crate@version from the registry — containment, not undo
   config           Configuration file management
   completion       Generate shell completion scripts for the specified shell
   help             Print this message or the help of the given subcommand(s)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_root.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_root.snap
@@ -17,6 +17,7 @@ Commands:
   inspect-receipt  View detailed receipt with evidence
   ci               Print CI configuration snippets for various platforms
   clean            Clean state files (state.json, receipt.json, events.jsonl)
+  yank             Yank a crate@version from the registry — containment, not undo
   config           Configuration file management
   completion       Generate shell completion scripts for the specified shell
   help             Print this message or the help of the given subcommand(s)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_yank.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_yank.snap
@@ -137,6 +137,16 @@ Options:
       --resume-from <RESUME_FROM>
           Optional package name to resume from
 
+      --rehearsal-registry <REHEARSAL_REGISTRY>
+          Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch.
+          
+          See issue #97. Plumbed through today; phase-2 execution (actual publish to the rehearsal registry + install/smoke checks + live dispatch gate) lands in a follow-on PR.
+
+      --skip-rehearsal
+          Skip rehearsal even if `.shipper.toml` enables it.
+          
+          Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_yank.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_yank.snap
@@ -1,0 +1,153 @@
+---
+source: crates/shipper-cli/tests/e2e_expanded.rs
+expression: normalize_stderr(&stdout)
+---
+Yank a crate@version from the registry — containment, not undo.
+
+`cargo yank` marks a specific version as not-installable for NEW dependency resolves. Existing lockfile pins and already-downloaded copies are unaffected. See [cargo yank docs](https://doc.rust-lang.org/cargo/commands/cargo-yank.html).
+
+Part of [#98 Remediate](https://github.com/EffortlessMetrics/shipper/issues/98). Follow-on commands (`shipper plan-yank`, `shipper fix-forward`) compose this primitive into reverse-topological containment and fix-forward plans.
+
+Usage: shipper yank [OPTIONS] --crate <NAME> --version <VERSION> --reason <REASON>
+
+Options:
+      --config <CONFIG>
+          Path to a custom configuration file (.shipper.toml)
+
+      --crate <NAME>
+          Name of the crate to yank (e.g., `shipper-types`)
+
+      --manifest-path <MANIFEST_PATH>
+          Path to the workspace Cargo.toml
+          
+          [default: Cargo.toml]
+
+      --version <VERSION>
+          Version to yank (e.g., `[VERSION]`)
+
+      --reason <REASON>
+          Operator-supplied reason (recorded in the event log, audit trails, and any future receipts that reference this yank).
+          
+          Example: `"CVE-2026-0001 disclosed; containing while patch released"`.
+
+      --registry <REGISTRY>
+          Cargo registry name (default: crates-io)
+
+      --api-base <API_BASE>
+          Registry API base URL (default: <https://crates.io>)
+
+      --package <PACKAGES>
+          Restrict to specific packages (repeatable). If omitted, publishes all publishable workspace members
+
+      --state-dir <STATE_DIR>
+          Directory for shipper state and receipts (default: .shipper)
+
+      --output-lines <OUTPUT_LINES>
+          Number of output lines to capture for evidence (default: 50)
+
+      --allow-dirty
+          Allow publishing from a dirty git working tree
+
+      --skip-ownership-check
+          Skip owners/permissions preflight
+
+      --strict-ownership
+          Fail preflight if ownership checks fail or if no token is available.
+          
+          Note: crates.io token scopes may not allow querying owners; this is best-effort.
+
+      --no-verify
+          Pass --no-verify to cargo publish
+
+      --max-attempts <MAX_ATTEMPTS>
+          Max attempts per crate publish step (default: 6)
+
+      --base-delay <BASE_DELAY>
+          Base backoff delay (e.g. 2s, 500ms; default: 2s)
+
+      --max-delay <MAX_DELAY>
+          Max backoff delay (e.g. 2m; default: 2m)
+
+      --retry-strategy <RETRY_STRATEGY>
+          Retry strategy: immediate, exponential (default), linear, constant
+
+      --retry-jitter <RETRY_JITTER>
+          Jitter factor for retry delays (0.0 = no jitter, 1.0 = full jitter; default: 0.5)
+
+      --verify-timeout <VERIFY_TIMEOUT>
+          How long to wait for registry visibility after a successful publish (default: 2m)
+
+      --verify-poll <VERIFY_POLL>
+          Poll interval for checking registry visibility (default: 5s)
+
+      --readiness-method <READINESS_METHOD>
+          Readiness check method: api (default, fast), index (slower, more accurate), both (slowest, most reliable)
+
+      --readiness-timeout <READINESS_TIMEOUT>
+          How long to wait for registry visibility during readiness checks (default: 5m)
+
+      --readiness-poll <READINESS_POLL>
+          Poll interval for readiness checks (default: 2s)
+
+      --no-readiness
+          Disable readiness checks (for advanced users)
+
+      --force-resume
+          Force resume even if the computed plan differs from the state file
+
+      --force
+          Force override of existing locks (use with caution)
+
+      --lock-timeout <LOCK_TIMEOUT>
+          Lock timeout duration (e.g. 1h, 30m; default: 1h). Locks older than this are considered stale
+
+      --policy <POLICY>
+          Publish policy: safe (verify+strict), balanced (verify when needed), fast (no verify; default: safe)
+
+      --verify-mode <VERIFY_MODE>
+          Verify mode: workspace (default), package (per-crate), none (no verify)
+
+      --parallel
+          Enable parallel publishing (packages at the same dependency level are published concurrently)
+
+      --max-concurrent <MAX_CONCURRENT>
+          Maximum number of concurrent publish operations (implies --parallel)
+
+      --per-package-timeout <PER_PACKAGE_TIMEOUT>
+          Timeout per package publish operation when using parallel mode (e.g. 30m, 1h)
+
+      --webhook-url <WEBHOOK_URL>
+          Webhook URL to send publish event notifications to
+
+      --webhook-secret <WEBHOOK_SECRET>
+          Optional secret for signing webhook payloads
+
+      --encrypt
+          Enable encryption for state files
+
+      --encrypt-passphrase <ENCRYPT_PASSPHRASE>
+          Passphrase for state file encryption (or use SHIPPER_ENCRYPT_KEY env var)
+
+      --registries <REGISTRIES>
+          Target registries for multi-registry publishing (comma-separated list) Example: --registries crates-io,my-registry
+
+      --all-registries
+          Publish to all configured registries
+
+      --resume-from <RESUME_FROM>
+          Optional package name to resume from
+
+      --format <FORMAT>
+          Output format: text (default) or json
+          
+          [default: text]
+          [possible values: text, json]
+
+      --verbose
+          Show detailed dependency analysis for plan command
+
+  -q, --quiet
+          Suppress informational output
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/crates/shipper-types/src/lib.rs
+++ b/crates/shipper-types/src/lib.rs
@@ -1471,6 +1471,17 @@ pub enum EventType {
         drift: StateEventDrift,
     },
 
+    // Remediation / containment (#98). Emitted when `shipper yank` executes
+    // a cargo yank against a specific crate+version. Reason is operator-
+    // supplied (e.g., "CVE-2026-0001 disclosed"); plan_id ties the yank
+    // to the remediation run that issued it.
+    PackageYanked {
+        crate_name: String,
+        version: String,
+        reason: String,
+        exit_code: i32,
+    },
+
     // Retry visibility (#91) — emitted immediately before Shipper sleeps on a
     // retry backoff. `attempt` is the just-failed attempt number (1-indexed),
     // so the next attempt will be `attempt + 1` of `max_attempts`. `reason`

--- a/crates/shipper/src/ops/cargo/mod.rs
+++ b/crates/shipper/src/ops/cargo/mod.rs
@@ -29,6 +29,52 @@ fn tail_lines(s: &str, n: usize) -> String {
     sanitize_tail_lines(s, n)
 }
 
+/// Invoke `cargo yank` against the configured registry.
+///
+/// Yanks a specific `<crate>@<version>` so the registry refuses to resolve
+/// it for new dependency resolves. **This is containment, not undo**:
+/// existing lockfiles and already-downloaded copies are unaffected.
+/// See [`cargo yank` docs](https://doc.rust-lang.org/cargo/commands/cargo-yank.html).
+///
+/// Output is captured (stdout/stderr tails, exit code, elapsed). The
+/// caller is responsible for:
+/// - classifying the result via existing [`crate::runtime::execution::classify_cargo_failure`]
+/// - emitting a `PackageYanked` event if a state-dir is present
+/// - retrying on transient failures (network, 5xx, 429)
+///
+/// Used by `shipper yank` and (in follow-on PRs under #98) by
+/// `shipper plan-yank` / `shipper fix-forward` when executing a yank plan.
+pub fn cargo_yank(
+    workspace_root: &Path,
+    package_name: &str,
+    version: &str,
+    registry_name: &str,
+    output_lines: usize,
+    timeout: Option<Duration>,
+) -> Result<CargoOutput> {
+    let start = Instant::now();
+    let version_arg = format!("--version={version}");
+    let mut args: Vec<&str> = vec!["yank", package_name, &version_arg];
+
+    // If the user configured a non-default registry, pass it through.
+    if !registry_name.trim().is_empty() && registry_name != "crates-io" {
+        args.push("--registry");
+        args.push(registry_name);
+    }
+
+    let output =
+        process::run_command_with_timeout(&cargo_program(), &args, workspace_root, timeout)
+            .context("failed to execute cargo yank; is Cargo installed?")?;
+
+    Ok(CargoOutput {
+        exit_code: output.exit_code,
+        stdout_tail: tail_lines(&output.stdout, output_lines),
+        stderr_tail: tail_lines(&output.stderr, output_lines),
+        duration: start.elapsed(),
+        timed_out: output.timed_out,
+    })
+}
+
 pub fn cargo_publish(
     workspace_root: &Path,
     package_name: &str,
@@ -562,6 +608,117 @@ mod tests {
                 let err = cargo_publish(td.path(), "x", "crates-io", false, false, 50, None)
                     .expect_err("must fail");
                 assert!(format!("{err:#}").contains("failed to execute cargo publish"));
+            },
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn cargo_yank_passes_flags_and_captures_output() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        fs::create_dir_all(&bin).expect("mkdir");
+        let fake_cargo = write_fake_cargo(&bin);
+
+        let args_log = td.path().join("args.txt");
+        let cwd_log = td.path().join("cwd.txt");
+
+        let ws = td.path().join("workspace");
+        fs::create_dir_all(&ws).expect("mkdir ws");
+
+        temp_env::with_vars(
+            [
+                (
+                    "SHIPPER_CARGO_BIN",
+                    Some(fake_cargo.to_str().expect("fake cargo utf8")),
+                ),
+                ("SHIPPER_ARGS_LOG", Some(args_log.to_str().expect("utf8"))),
+                ("SHIPPER_CWD_LOG", Some(cwd_log.to_str().expect("utf8"))),
+                ("SHIPPER_EXIT_CODE", Some("0")),
+            ],
+            || {
+                let out =
+                    cargo_yank(&ws, "my-crate", "1.2.3", "private-reg", 50, None).expect("yank");
+
+                assert_eq!(out.exit_code, 0);
+                assert!(out.stdout_tail.contains("fake-stdout"));
+
+                let args = fs::read_to_string(&args_log).expect("args");
+                assert!(args.contains("yank"));
+                assert!(args.contains("my-crate"));
+                assert!(args.contains("--version=1.2.3"));
+                assert!(args.contains("--registry private-reg"));
+
+                let cwd = fs::read_to_string(&cwd_log).expect("cwd");
+                assert!(cwd.trim_end().ends_with("workspace"));
+            },
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn cargo_yank_omits_registry_for_crates_io() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        fs::create_dir_all(&bin).expect("mkdir");
+        let fake_cargo = write_fake_cargo(&bin);
+
+        let args_log = td.path().join("args.txt");
+        let cwd_log = td.path().join("cwd.txt");
+
+        let ws = td.path().join("workspace");
+        fs::create_dir_all(&ws).expect("mkdir ws");
+
+        temp_env::with_vars(
+            [
+                (
+                    "SHIPPER_CARGO_BIN",
+                    Some(fake_cargo.to_str().expect("fake cargo utf8")),
+                ),
+                ("SHIPPER_ARGS_LOG", Some(args_log.to_str().expect("utf8"))),
+                ("SHIPPER_CWD_LOG", Some(cwd_log.to_str().expect("utf8"))),
+                ("SHIPPER_EXIT_CODE", Some("0")),
+            ],
+            || {
+                let _ = cargo_yank(&ws, "my-crate", "0.1.0", "crates-io", 50, None).expect("yank");
+
+                let args = fs::read_to_string(&args_log).expect("args");
+                assert!(!args.contains("--registry"));
+                assert!(args.contains("yank"));
+                assert!(args.contains("--version=0.1.0"));
+            },
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn cargo_yank_propagates_nonzero_exit_code() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        fs::create_dir_all(&bin).expect("mkdir");
+        let fake_cargo = write_fake_cargo(&bin);
+
+        let args_log = td.path().join("args.txt");
+        let cwd_log = td.path().join("cwd.txt");
+
+        let ws = td.path().join("workspace");
+        fs::create_dir_all(&ws).expect("mkdir ws");
+
+        temp_env::with_vars(
+            [
+                (
+                    "SHIPPER_CARGO_BIN",
+                    Some(fake_cargo.to_str().expect("fake cargo utf8")),
+                ),
+                ("SHIPPER_ARGS_LOG", Some(args_log.to_str().expect("utf8"))),
+                ("SHIPPER_CWD_LOG", Some(cwd_log.to_str().expect("utf8"))),
+                ("SHIPPER_EXIT_CODE", Some("101")),
+            ],
+            || {
+                let out =
+                    cargo_yank(&ws, "my-crate", "1.2.3", "crates-io", 50, None).expect("spawn");
+                assert_eq!(out.exit_code, 101);
+                assert!(out.stderr_tail.contains("fake-stderr"));
             },
         );
     }


### PR DESCRIPTION
## Summary

Opens the Remediate pillar (#98) with its first primitive: a single
`shipper yank <crate>@<version>` command. **Containment, not undo** —
existing lockfile pins stay pinned; the yank only prevents NEW resolves
against that version. Downstream consumers get told to `cargo update -p <name>`.

- **ops/cargo**: new `cargo_yank(workspace, name, version, registry, lines, timeout)`,
  mirrors `cargo_publish` invariants (non-default registry passthrough,
  timeout polling, output redaction + tailing via `shipper-output-sanitizer`).
- **CLI**: `shipper yank --crate <NAME> --version <VERSION> --reason <REASON>`
  - Emits `PackageYanked { crate_name, version, reason, exit_code }` to
    `<state_dir>/events.jsonl` — the reason is operator-supplied
    (e.g. `"CVE-2026-0001 disclosed; containing while patch released"`)
    and enters the event log alongside publish events.
  - Loud operator warning about containment semantics + fix-forward
    guidance (`cargo update -p <NAME>`).
- **types**: `EventType::PackageYanked` variant.
- **tests**:
  - 3 fake-cargo unit tests in `ops/cargo` (args passthrough,
    crates-io registry omission, non-zero exit propagation)
  - `yank --help` snapshot in `e2e_expanded`

## Scope

Intentionally tight. Follow-on PRs under #98 compose this primitive into:

- `shipper plan-yank` — reverse-topological containment plan
- `shipper fix-forward` — patch, publish, update-pin

Receipt augmentation (compromised_at/by/superseded_by) is **not** in
this PR — it was explored and pulled to tighten scope; will land on the
plan-yank PR where the schema change pays for itself.

## Test plan

- [x] `cargo test -p shipper --lib ops::cargo::tests::cargo_yank` — 3/3 pass
- [x] `cargo test -p shipper-cli --test e2e_expanded help_yank_snapshot` — green
- [x] `cargo fmt --all` — clean
- [x] `cargo clippy -p shipper -p shipper-cli --all-targets --all-features -- -D warnings` — no issues
- [ ] CI multi-OS green