### PR TITLE
feat(release): Trusted Publishing (OIDC) for crates.io (#96)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ env:
 
 permissions:
   contents: write
+  # OIDC for Trusted Publishing (crates-io-auth-action). Needed by publish /
+  # rehearse / resume jobs; read-only reach is fine for the others. See #96.
+  id-token: write
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -222,11 +225,23 @@ jobs:
           include-hidden-files: true
           retention-days: 30
 
+      # --- Step 3b: mint a short-lived crates.io token via Trusted Publishing
+      # Requires each published crate to be pre-registered as a trusted
+      # publisher on crates.io with this repo + workflow + `release`
+      # environment. See docs/how-to/run-in-github-actions.md.
+      #
+      # Falls back to the CARGO_REGISTRY_TOKEN secret if the action doesn't
+      # run or outputs no token — kept as a safety rail for the very first
+      # release after OIDC is wired up and during incident response.
+      - name: Mint crates.io token (Trusted Publishing)
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
       # --- Step 4: preflight ------------------------------------------------
       - name: shipper preflight
         id: preflight
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           shipper preflight \
             --registry crates-io \
@@ -256,7 +271,7 @@ jobs:
       - name: shipper publish
         id: publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           shipper publish \
             --registry crates-io \
@@ -399,12 +414,20 @@ jobs:
             --verbose \
             | tee .shipper/plan.txt
 
+      # Mint a Trusted Publishing token for the deeper preflight (ownership
+      # queries benefit from a real token). OIDC unavailable? Fall back to
+      # the CARGO_REGISTRY_TOKEN secret — rehearse keeps working either way.
+      - name: Mint crates.io token (Trusted Publishing)
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+        continue-on-error: true
+
       # Preflight against crates.io without publishing. A token isn't strictly
       # required here (ownership checks are best-effort), but supply it if the
       # `release` environment is available for a deeper check.
       - name: shipper preflight (dry-run)
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           shipper preflight \
             --registry crates-io \
@@ -480,9 +503,15 @@ jobs:
           ls -la .shipper/
           [ -f .shipper/state.json ] || { echo "::error::.shipper/state.json missing from recovered artifact"; exit 1; }
 
+      # Mint a fresh Trusted Publishing token for the resume (previous run's
+      # token is already expired). Falls back to secret if OIDC unavailable.
+      - name: Mint crates.io token (Trusted Publishing)
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
       - name: shipper resume
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           shipper resume \
             --registry crates-io \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,11 +233,31 @@ jobs:
       # Falls back to the CARGO_REGISTRY_TOKEN secret if the action doesn't
       # run or outputs no token — kept as a safety rail for the very first
       # release after OIDC is wired up and during incident response.
+      #
+      # # Mixed-registration caveat (#96 review)
+      #
+      # If the OIDC action succeeds but only some of the crates in the
+      # plan are registered as trusted publishers for this repo, the
+      # minted token will 401 on the unregistered crates mid-train —
+      # AFTER some publishes have already succeeded. The `preflight`
+      # step below uses `--policy safe` which enables per-crate
+      # ownership checks with this same token; any scope mismatch
+      # surfaces there and the `Fail fast if preflight failed` gate
+      # refuses to start the publish train. Operators enabling Trusted
+      # Publishing for the first time MUST register all published
+      # crates BEFORE their first live run — see
+      # docs/how-to/run-in-github-actions.md for the one-time
+      # registration checklist.
       - name: Mint crates.io token (Trusted Publishing)
         id: auth
         uses: rust-lang/crates-io-auth-action@v1
 
       # --- Step 4: preflight ------------------------------------------------
+      # `--policy safe` enables ownership checks. For existing crates
+      # those checks exercise the minted OIDC token against crates.io;
+      # a scope mismatch surfaces here before any publish. New crates
+      # have no owner record yet so the check is best-effort — hence
+      # the one-time-registration operator checklist in the how-to.
       - name: shipper preflight
         id: preflight
         env:
@@ -377,6 +397,15 @@ jobs:
     name: Release rehearse (plan + preflight dry-run)
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'rehearse'
     runs-on: ubuntu-latest
+    # Bind to the `release` environment so the OIDC token minted here is
+    # scoped identically to the production `publish-crates-io` job's.
+    # Without this, rehearsal would validate only the mint *mechanism*
+    # while silently passing a real scope-binding misconfiguration
+    # (production job asks for a `release`-scoped token and gets denied,
+    # but rehearsal never exercised the same scope). Matching scopes
+    # here means rehearsal fails fast on the same scope errors prod
+    # would hit. See #96 review discussion.
+    environment: release
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6

--- a/docs/how-to/run-in-github-actions.md
+++ b/docs/how-to/run-in-github-actions.md
@@ -100,7 +100,23 @@ leak.
    - Workflow filename: `release.yml` (or whatever yours is called)
    - Environment: `release` (match the `environment:` name in the job
      below — this is the scope guard)
-3. Repeat for every crate the workspace publishes.
+3. Repeat for **every** crate the workspace publishes. Do NOT enable
+   OIDC until the list is complete.
+
+> **Why "every crate"**: if only some crates are registered, the
+> OIDC action still succeeds and mints a token — but that token 401s
+> on the unregistered crates mid-train, after some publishes have
+> already succeeded. Shipper's preflight catches scope mismatches
+> for *existing* crates via ownership checks, but new crates have no
+> owner record yet so the first-publish case depends on operator
+> discipline. Complete registration first; rehearse second; tag third.
+>
+> **Rehearsal validates the mechanism.** `release.yml`'s
+> `release-rehearse` job binds to `environment: release` so the OIDC
+> scope it mints matches production. A rehearsal that mints
+> successfully proves the scope wiring. A mid-train 401 on a
+> different crate proves you missed a registration step — fix the
+> missing registration, don't retry the tag.
 
 **Workflow**:
 

--- a/docs/how-to/run-in-github-actions.md
+++ b/docs/how-to/run-in-github-actions.md
@@ -83,19 +83,68 @@ Upload the `.shipper/` directory after plan, after preflight, and after publish 
 
 For a first-publish release of many new crates, crates.io's 1-new-crate-per-10-min rate limit applies. Budget ~10 minutes per crate past the initial 5-crate burst. A 12-crate first publish can run 70–90 minutes. Set `timeout-minutes` accordingly (the example above uses 180).
 
-### Token vs trusted publishing
+### Token vs Trusted Publishing
 
-The example uses `CARGO_REGISTRY_TOKEN`. For a safer posture, use Trusted Publishing (OIDC) — see [#96](https://github.com/EffortlessMetrics/shipper/issues/96) for the migration status. The short version:
+The example above uses `CARGO_REGISTRY_TOKEN` — a long-lived personal
+access token stored as a repo secret. **Prefer Trusted Publishing
+(OIDC)**: short-lived tokens, scoped to a specific repo + workflow + ref
+pattern + GitHub Actions environment. No secrets to rotate, no PATs to
+leak.
+
+**One-time setup on crates.io** (per crate):
+
+1. Log in to <https://crates.io>, open the crate's **Settings →
+   Trusted Publishing** panel.
+2. Add a new trusted publisher:
+   - Repository: `<owner>/<repo>`
+   - Workflow filename: `release.yml` (or whatever yours is called)
+   - Environment: `release` (match the `environment:` name in the job
+     below — this is the scope guard)
+3. Repeat for every crate the workspace publishes.
+
+**Workflow**:
 
 ```yaml
 permissions:
-  id-token: write
   contents: write
+  id-token: write           # required to mint the OIDC token
 
-steps:
-  - uses: rust-lang/crates-io-auth-action@v1  # exchanges OIDC for a short-lived token
-  - run: shipper publish ...                   # uses the exchanged token automatically
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release    # must match the crates.io trusted-publisher config
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo install shipper-cli --locked
+
+      # Exchange the workflow's OIDC token for a short-lived
+      # crates.io publish token. Output: steps.auth.outputs.token.
+      - id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: shipper publish
+        env:
+          # Falls back to the long-lived secret if OIDC is unavailable
+          # (e.g. during incident response or the first bootstrap run).
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN }}
+        run: shipper publish --policy safe
 ```
+
+**Troubleshooting**:
+
+- `id-token: write` missing → GitHub refuses the OIDC exchange → the
+  action fails loudly; add the permission.
+- Crate not registered as a trusted publisher → `cargo publish` returns
+  401 despite a valid-looking token. Check crates.io's Trusted
+  Publishing panel for the crate.
+- Tag/branch mismatch → token minted for the wrong ref pattern →
+  crates.io refuses. The `environment:` name is the tightest scope —
+  make sure the workflow's environment matches what you registered.
+
+See `.github/workflows/release.yml` in this repo for the production
+example, and [#96](https://github.com/EffortlessMetrics/shipper/issues/96)
+for the migration history.
 
 ### Resume mode
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -14,8 +14,17 @@ Current RC baseline: `v0.3.0-rc.1`, commit [`5beab9b`](https://github.com/Effort
 3. **No mainline changes since the rehearsal.** Any commit to `main` after the rehearsal invalidates the plan ID. If mainline moved, re-rehearse.
 4. **crates.io is healthy.** Open [status.crates.io](https://status.crates.io/) immediately before starting. If the **git index** is running behind but the **sparse index** is healthy, that's OK — the workflow is configured with `--readiness-method both` so it will hit the sparse index path. If the **sparse index** itself is reporting incidents, abort and wait.
 5. **Token / auth is present.**
-   - Trusted Publishing (preferred): the GitHub Actions OIDC path is configured for this repo on crates.io. Verify the trusted-publishing configuration for each of the 12 crates if they've been pre-registered.
-   - Token fallback: `CARGO_REGISTRY_TOKEN` repo secret is set with publish scope for all 12 crates.
+   - **Trusted Publishing (primary path)**: the `release.yml` workflow
+     mints a short-lived token via `rust-lang/crates-io-auth-action@v1`
+     (see #96). Each of the 12 crates must be registered on crates.io
+     as a trusted publisher for this repo + `release.yml` +
+     `release` environment. Verify via crates.io's "Trusted Publishing"
+     settings panel for any one of the crates; if it's missing for any
+     crate, `cargo publish` will 401 for that crate and the train stalls.
+   - **Token fallback**: `CARGO_REGISTRY_TOKEN` repo secret is still
+     consulted if the OIDC action can't mint (incident response, pre-
+     registration gaps). Keep it set with publish scope for all 12
+     crates until Trusted Publishing is confirmed end-to-end.
 
 ## Cut the tag
 


### PR DESCRIPTION
## Summary

Switch the release workflow from a long-lived `CARGO_REGISTRY_TOKEN`
secret to **Trusted Publishing** via `rust-lang/crates-io-auth-action@v1`.
Short-lived tokens, scoped to this repo + `release.yml` + `release`
environment. Closes #96.

Shipper's auth layer (`ops/auth/oidc.rs`) already detects
`ACTIONS_ID_TOKEN_REQUEST_URL` + `_TOKEN` and returns
`AuthType::TrustedPublishing` — only the workflow side was missing.

## Changes

- **`.github/workflows/release.yml`**:
  - `id-token: write` at workflow level.
  - `publish-crates-io`, `release-rehearse`, `release-resume`: each runs
    `rust-lang/crates-io-auth-action@v1` before invoking shipper, feeds
    `steps.auth.outputs.token` into `CARGO_REGISTRY_TOKEN`.
  - Fallback: `steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN`
    so incident response / bootstrap still works when OIDC can't mint.
  - `release-rehearse` marks the auth step `continue-on-error: true`
    (rehearse is best-effort and shouldn't block on a missing OIDC scope).
- **`docs/how-to/run-in-github-actions.md`**: replace minimal stub with
  full recipe — one-time crates.io registration steps, environment scope
  guard, troubleshooting section (3 common failure modes).
- **`docs/release-runbook.md`**: promote Trusted Publishing from
  "preferred" to primary auth path; keep token fallback documented.

## Prerequisite (NOT code — one-time admin task)

Each of the 12 crates must be registered on crates.io as a Trusted
Publisher with:
- Repository: `EffortlessMetrics/shipper`
- Workflow: `release.yml`
- Environment: `release`

Until registration is complete for **all** 12 crates, the fallback keeps
the train runnable via the secret. First release on the OIDC path
should be a rehearse run, then a real tag.

## Test plan

- [x] `release.yml` parses as valid YAML.
- [ ] Next `workflow_dispatch mode=rehearse` run should show the
      "Mint crates.io token" step succeed (or `continue-on-error` if the
      repo isn't yet registered).
- [ ] First real publish via the OIDC path: observe that every
      per-crate `cargo publish` inside `shipper publish` picks up the
      minted token without reaching for the secret.