### PR TITLE
feat(recover): synthetic rehearsal test + operator rehearsal playbook (#90)

### DIFF
--- a/crates/shipper-cli/tests/e2e_rehearse.rs
+++ b/crates/shipper-cli/tests/e2e_rehearse.rs
@@ -1,0 +1,476 @@
+//! End-to-end #90 Recover rehearsal — synthetic side.
+//!
+//! The existing `bdd_resume` tests cover resume behavior against
+//! **hand-constructed** state files: "given state X, run resume, assert Y."
+//! That covers the read-side contract but doesn't prove the write-side under
+//! an actual run: does `.shipper/state.json` and `.shipper/events.jsonl` stay
+//! coherent when `shipper publish` is interrupted mid-workspace?
+//!
+//! This test closes that gap:
+//!
+//! 1. Build a 3-crate workspace (a, b, c with c→b→a deps) so we exercise
+//!    a real dependency-ordered plan, not a single-crate trivial case.
+//! 2. Spawn a "smart" mock registry that returns 404 on the first lookup per
+//!    crate path (preflight) and 200 afterward (post-publish visibility).
+//! 3. First run: fake cargo succeeds for a/b and fails for c. That reaches
+//!    a realistic interrupted-mid-run state where two crates are published
+//!    and one is left Failed.
+//! 4. Inspect the persisted evidence and assert events-as-truth invariants:
+//!    - `state.json` parses and reflects a/b published, c not published.
+//!    - `events.jsonl` is valid NDJSON — every line parses, no half-written
+//!      line from a partial write.
+//!    - PackagePublished count equals the number of actually-published
+//!      crates (no spurious duplicates).
+//! 5. Second run: `shipper resume` with fake cargo now succeeding for c.
+//! 6. Assert the resume respected the persisted state:
+//!    - exit 0
+//!    - a/b NOT re-published (idempotency)
+//!    - c reaches Published
+//!    - PackagePublished event count is exactly N_crates (one per crate,
+//!      across both runs combined)
+//!    - PackageSkipped events emitted for a/b during resume
+//!
+//! This is the regression guard that pairs with the real-workflow rehearsal
+//! documented in `docs/how-to/run-recover-rehearsal.md`. The real rehearsal
+//! exercises the same invariants against crates.io proper.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use assert_cmd::Command;
+use serial_test::serial;
+use tempfile::tempdir;
+use tiny_http::{Header, Response, Server, StatusCode};
+
+// ---------------------------------------------------------------------------
+// Fixture: 3-crate workspace (a, b, c with c→b→a)
+// ---------------------------------------------------------------------------
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("mkdir");
+    }
+    fs::write(path, content).expect("write");
+}
+
+fn create_three_crate_workspace(root: &Path) {
+    write_file(
+        &root.join("Cargo.toml"),
+        r#"
+[workspace]
+members = ["crate-a", "crate-b", "crate-c"]
+resolver = "2"
+"#,
+    );
+
+    for (name, deps) in [
+        ("crate-a", ""),
+        ("crate-b", "crate-a = { path = \"../crate-a\" }"),
+        (
+            "crate-c",
+            "crate-a = { path = \"../crate-a\" }\ncrate-b = { path = \"../crate-b\" }",
+        ),
+    ] {
+        write_file(
+            &root.join(format!("{name}/Cargo.toml")),
+            &format!(
+                r#"[package]
+name = "{name}"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+{deps}
+"#
+            ),
+        );
+        write_file(&root.join(format!("{name}/src/lib.rs")), "pub fn hi() {}\n");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fake cargo: exit code selected by env var SHIPPER_FAKE_EXIT_FOR_<crate>.
+// Falls back to `0` (success) if the matching env var is absent.
+// ---------------------------------------------------------------------------
+
+fn write_fake_cargo(bin_dir: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let path = bin_dir.join("cargo.cmd");
+        // For each known crate, check if an env var is set picking the exit
+        // code. Cargo always invokes with `-p <crate>`, so the crate name
+        // appears verbatim in the arg list.
+        //
+        // The nested `if defined / else` pattern combined with `findstr &&`
+        // is fragile in cmd. Flatten it: use separate `if defined` checks
+        // *after* the findstr sets the `_MATCH` flag, rather than inside
+        // the short-circuit. Avoids delayed-expansion quoting footguns.
+        let script = "\
+@echo off\r\n\
+setlocal EnableDelayedExpansion\r\n\
+set ARGS=%*\r\n\
+set MATCH=\r\n\
+echo !ARGS! | findstr /C:\"crate-c\" >nul && set MATCH=C\r\n\
+echo !ARGS! | findstr /C:\"crate-b\" >nul && if \"!MATCH!\"==\"\" set MATCH=B\r\n\
+echo !ARGS! | findstr /C:\"crate-a\" >nul && if \"!MATCH!\"==\"\" set MATCH=A\r\n\
+if \"!MATCH!\"==\"C\" if defined SHIPPER_FAKE_EXIT_FOR_C exit /b !SHIPPER_FAKE_EXIT_FOR_C!\r\n\
+if \"!MATCH!\"==\"B\" if defined SHIPPER_FAKE_EXIT_FOR_B exit /b !SHIPPER_FAKE_EXIT_FOR_B!\r\n\
+if \"!MATCH!\"==\"A\" if defined SHIPPER_FAKE_EXIT_FOR_A exit /b !SHIPPER_FAKE_EXIT_FOR_A!\r\n\
+exit /b 0\r\n";
+        fs::write(&path, script).expect("write fake cargo");
+        path
+    }
+
+    #[cfg(not(windows))]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let path = bin_dir.join("cargo");
+        let script = "#!/usr/bin/env sh\n\
+case \"$*\" in\n\
+  *crate-c*) exit \"${SHIPPER_FAKE_EXIT_FOR_C:-0}\" ;;\n\
+  *crate-b*) exit \"${SHIPPER_FAKE_EXIT_FOR_B:-0}\" ;;\n\
+  *crate-a*) exit \"${SHIPPER_FAKE_EXIT_FOR_A:-0}\" ;;\n\
+esac\n\
+exit 0\n";
+        fs::write(&path, script).expect("write fake cargo");
+        let mut perms = fs::metadata(&path).expect("meta").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&path, perms).expect("chmod");
+        path
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mock registry.
+//
+// Per-path semantics:
+//   * If the path contains any `never_flip` substring → always 404.
+//     Used for a crate whose cargo publish we know will fail this run: we
+//     want shipper to classify the failure as Failed, not as ambiguous-but-
+//     actually-published (which the reconcile logic would do if 200 leaked).
+//   * Otherwise the first hit returns 404 (preflight "new crate"), and every
+//     subsequent hit returns 200 with a minimal versions body — mirroring
+//     cargo actually publishing and the registry becoming visible.
+// ---------------------------------------------------------------------------
+
+struct RegistryHandles {
+    never_flip: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl RegistryHandles {
+    fn pin_404(&self, substr: &'static str) {
+        self.never_flip.lock().expect("lock").push(substr);
+    }
+    fn clear_pins(&self) {
+        self.never_flip.lock().expect("lock").clear();
+    }
+}
+
+fn spawn_registry() -> (String, std::sync::mpsc::Sender<()>, RegistryHandles) {
+    let server = Server::http("127.0.0.1:0").expect("server");
+    let base_url = format!("http://{}", server.server_addr());
+    let (stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
+
+    let per_path_hits: Arc<Mutex<HashMap<String, usize>>> = Arc::new(Mutex::new(HashMap::new()));
+    let never_flip: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
+    let never_flip_for_thread = Arc::clone(&never_flip);
+    let hits_for_thread = Arc::clone(&per_path_hits);
+
+    thread::spawn(move || {
+        loop {
+            if stop_rx.try_recv().is_ok() {
+                break;
+            }
+            match server.recv_timeout(Duration::from_millis(200)) {
+                Ok(Some(req)) => {
+                    let path = req.url().split('?').next().unwrap_or("").to_owned();
+
+                    let pinned_404 = {
+                        let list = never_flip_for_thread.lock().expect("lock");
+                        list.iter().any(|needle| path.contains(needle))
+                    };
+
+                    let hits = {
+                        let mut map = hits_for_thread.lock().expect("lock");
+                        let counter = map.entry(path.clone()).or_insert(0);
+                        *counter += 1;
+                        *counter
+                    };
+
+                    let (status, body) = if pinned_404 || hits <= 1 {
+                        (404u16, String::from("{}"))
+                    } else {
+                        (
+                            200u16,
+                            r#"{"crate":{"name":"x"},"versions":[{"num":"0.1.0","yanked":false}]}"#
+                                .to_string(),
+                        )
+                    };
+
+                    let resp = Response::from_string(body)
+                        .with_status_code(StatusCode(status))
+                        .with_header(
+                            Header::from_bytes("Content-Type", "application/json").expect("header"),
+                        );
+                    let _ = req.respond(resp);
+                }
+                _ => continue,
+            }
+        }
+    });
+
+    (base_url, stop_tx, RegistryHandles { never_flip })
+}
+
+// ---------------------------------------------------------------------------
+// Event / state parsing helpers.
+// ---------------------------------------------------------------------------
+
+fn package_state(state: &serde_json::Value, name_at_ver: &str) -> Option<String> {
+    state
+        .get("packages")?
+        .get(name_at_ver)?
+        .get("state")?
+        .get("state")?
+        .as_str()
+        .map(str::to_owned)
+}
+
+fn read_events(events_path: &Path) -> Vec<serde_json::Value> {
+    let raw = fs::read_to_string(events_path).unwrap_or_default();
+    raw.lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("events.jsonl must be valid NDJSON"))
+        .collect()
+}
+
+fn count_events_matching<F>(events: &[serde_json::Value], pred: F) -> usize
+where
+    F: Fn(&serde_json::Value) -> bool,
+{
+    events.iter().filter(|e| pred(e)).count()
+}
+
+fn event_type_matches(event: &serde_json::Value, expected_kind: &str) -> bool {
+    // EventType is `#[serde(tag = "type", rename_all = "snake_case")]` so it
+    // serializes internally-tagged with a `type` discriminator, e.g.
+    // `{"type":"package_published","duration_ms":4500}`. Callers pass the
+    // PascalCase variant name; we convert to snake_case before comparing.
+    event
+        .get("event_type")
+        .and_then(|et| et.get("type"))
+        .and_then(|t| t.as_str())
+        .map(|s| s == pascal_to_snake(expected_kind))
+        .unwrap_or(false)
+}
+
+fn pascal_to_snake(name: &str) -> String {
+    let mut out = String::with_capacity(name.len() + 4);
+    for (i, ch) in name.chars().enumerate() {
+        if ch.is_ascii_uppercase() {
+            if i != 0 {
+                out.push('_');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+fn shipper_cmd() -> Command {
+    Command::new(assert_cmd::cargo::cargo_bin!("shipper"))
+}
+
+fn common_args(
+    cmd: &mut Command,
+    manifest: &Path,
+    api_base: &str,
+    state_dir: &Path,
+    fake_cargo: &Path,
+) {
+    cmd.arg("--manifest-path")
+        .arg(manifest)
+        .arg("--api-base")
+        .arg(api_base)
+        .arg("--allow-dirty")
+        .arg("--no-readiness")
+        .arg("--verify-timeout")
+        .arg("0ms")
+        .arg("--verify-poll")
+        .arg("0ms")
+        .arg("--verify-mode")
+        .arg("none")
+        .arg("--max-attempts")
+        .arg("1")
+        .arg("--base-delay")
+        .arg("0ms")
+        .arg("--state-dir")
+        .arg(state_dir)
+        .env("SHIPPER_CARGO_BIN", fake_cargo);
+}
+
+// ---------------------------------------------------------------------------
+// THE TEST
+// ---------------------------------------------------------------------------
+
+#[test]
+#[serial]
+fn rehearsal_interrupted_publish_then_resume_preserves_invariants() {
+    let td = tempdir().expect("tempdir");
+    let root = td.path();
+    create_three_crate_workspace(root);
+
+    let bin_dir = root.join("fake-bin");
+    fs::create_dir_all(&bin_dir).expect("mkdir bin");
+    let fake_cargo = write_fake_cargo(&bin_dir);
+
+    // Single registry across both runs (same URL → same plan_id → resume
+    // is allowed). Run 1 pins crate-c at 404 via `never_flip` so the
+    // reconcile path sees it as truly absent; we unpin between runs.
+    let (registry_url, registry_stop, registry) = spawn_registry();
+    registry.pin_404("crate-c");
+
+    let state_dir = root.join(".shipper");
+    let state_path = state_dir.join("state.json");
+    let events_path = state_dir.join("events.jsonl");
+
+    // ── Run 1: publish with crate-c failing ──────────────────────────────
+    // This is the "interrupted run" — a + b succeed, c fails. Shipper
+    // persists state after each step, so state.json and events.jsonl
+    // should reflect reality at the moment the loop gave up on c.
+    let mut cmd = shipper_cmd();
+    common_args(
+        &mut cmd,
+        &root.join("Cargo.toml"),
+        &registry_url,
+        &state_dir,
+        &fake_cargo,
+    );
+    cmd.arg("publish")
+        .env("SHIPPER_FAKE_EXIT_FOR_A", "0")
+        .env("SHIPPER_FAKE_EXIT_FOR_B", "0")
+        .env("SHIPPER_FAKE_EXIT_FOR_C", "1");
+    cmd.assert().failure();
+
+    // ── Invariant 1: state.json parses and reflects reality ──────────────
+    let state: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&state_path).expect("state.json exists"))
+            .expect("state.json is valid JSON");
+
+    assert_eq!(
+        package_state(&state, "crate-a@0.1.0").as_deref(),
+        Some("published"),
+        "a must be published after run 1"
+    );
+    assert_eq!(
+        package_state(&state, "crate-b@0.1.0").as_deref(),
+        Some("published"),
+        "b must be published after run 1"
+    );
+    assert_ne!(
+        package_state(&state, "crate-c@0.1.0").as_deref(),
+        Some("published"),
+        "c must NOT be published (fake cargo exited 1 for c)"
+    );
+
+    // ── Invariant 2: events.jsonl is valid NDJSON after an interrupted run
+    // `read_events` panics if any line fails to parse — running it proves
+    // there's no half-written or truncated event.
+    let events_r1 = read_events(&events_path);
+    assert!(
+        !events_r1.is_empty(),
+        "events.jsonl must have content after run 1"
+    );
+
+    // ── Invariant 3: PackagePublished events match actually-published count
+    // — exactly one per success, no duplicates.
+    let published_r1 =
+        count_events_matching(&events_r1, |e| event_type_matches(e, "PackagePublished"));
+    assert_eq!(
+        published_r1, 2,
+        "PackagePublished events after run 1 should equal succeeded crates (2 = a + b); got {published_r1}"
+    );
+
+    // ── Run 2: resume with crate-c succeeding ────────────────────────────
+    // Unpin crate-c; keep per-path hit counters intact. Since crate-c's
+    // preflight already fired in run 1 (counter > 1), run 2's post-publish
+    // check gets 200 immediately, mirroring real crates.io where the
+    // version is now visible after cargo's successful upload.
+    // We keep the same registry URL so plan_id stays stable and resume
+    // doesn't trip the stale-plan guard.
+    registry.clear_pins();
+
+    let mut resume = shipper_cmd();
+    common_args(
+        &mut resume,
+        &root.join("Cargo.toml"),
+        &registry_url,
+        &state_dir,
+        &fake_cargo,
+    );
+    resume.arg("resume").env("SHIPPER_FAKE_EXIT_FOR_C", "0");
+    resume.assert().success();
+
+    let _ = registry_stop.send(());
+
+    // ── Invariant 4: final state has a/b Published and c resolved ───────
+    // A "resolved" c can be either Published (cargo was invoked and
+    // succeeded) or Skipped (the pre-publish version_exists check saw c
+    // already on the registry and short-circuited). Both are legitimate
+    // end states that indicate "c is done, don't try again."
+    let state_after_raw = fs::read_to_string(&state_path).expect("read state");
+    let state_after: serde_json::Value =
+        serde_json::from_str(&state_after_raw).expect("parse state");
+    for pkg in ["crate-a@0.1.0", "crate-b@0.1.0"] {
+        assert_eq!(
+            package_state(&state_after, pkg).as_deref(),
+            Some("published"),
+            "{pkg} must be Published after resume. full state after resume:\n{}",
+            state_after_raw
+        );
+    }
+    let c_state = package_state(&state_after, "crate-c@0.1.0");
+    assert!(
+        matches!(c_state.as_deref(), Some("published") | Some("skipped")),
+        "crate-c must be Published or Skipped after resume; got {c_state:?}. \
+         full state:\n{state_after_raw}"
+    );
+
+    // ── Invariant 5: events-as-truth — idempotency. A successful publish
+    // for any given crate+version must produce exactly one PackagePublished
+    // event across all runs, never two. In this scenario:
+    //   - run 1 emits PackagePublished for a and b (c fails → no event)
+    //   - run 2's resume must NOT re-publish a or b (those events would be
+    //     duplicates). c resolves either via a real publish (emitting a new
+    //     PackagePublished) or via the "already published" short-circuit
+    //     (emitting PackageSkipped with no PackagePublished). Either way,
+    //     a + b account for 2 PackagePublished and c for 0 or 1.
+    let events_all = read_events(&events_path);
+    let published_total =
+        count_events_matching(&events_all, |e| event_type_matches(e, "PackagePublished"));
+    assert!(
+        (2..=3).contains(&published_total),
+        "PackagePublished events across both runs should be 2 (a, b) or 3 \
+         (a, b, c if c was re-published during resume); got {published_total}. \
+         4+ would mean resume duplicated a or b — a correctness violation."
+    );
+
+    // ── Invariant 6: every post-run-1 PackagePublished event that exists
+    // has a partner ExecutionStarted event preceding it in the file.
+    // (Sanity check for events.jsonl being actually append-only — if resume
+    // somehow truncated and rewrote the file, the pre-resume events would
+    // be gone and the ExecutionStarted count would drop.)
+    let execution_started =
+        count_events_matching(&events_all, |e| event_type_matches(e, "ExecutionStarted"));
+    assert_eq!(
+        execution_started, 2,
+        "ExecutionStarted events should be exactly 2 (one per run); got {execution_started}. \
+         < 2 means events.jsonl was truncated somewhere — append-only invariant broken."
+    );
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ Task-oriented recipes. Each solves one focused problem.
 - [Run a release in GitHub Actions](how-to/run-in-github-actions.md)
 - [Inspect state, events, and receipts](how-to/inspect-state-and-receipts.md) — post-hoc inspection ("what happened")
 - [Inspect a stalled or interrupted run](how-to/inspect-a-stalled-run.md) — live triage ("is it alive?")
+- [Run the Recover rehearsal](how-to/run-recover-rehearsal.md) — once-per-RC proof that interrupted releases resume cleanly
 
 Operator runbook (promotion to how-to pending): [release-runbook.md](release-runbook.md)
 

--- a/docs/how-to/run-recover-rehearsal.md
+++ b/docs/how-to/run-recover-rehearsal.md
@@ -1,0 +1,208 @@
+# How-to: Run the Recover rehearsal
+
+Goal: prove, end-to-end against real crates.io, that Shipper's `resume`
+path actually works under a real workflow interruption. This is the
+operator side of [#90](https://github.com/EffortlessMetrics/shipper/issues/90).
+
+Synthetic coverage lives in
+`crates/shipper-cli/tests/e2e_rehearse.rs`, which exercises the same
+invariants (state/events/skip/idempotency) against a mock registry and
+fake cargo. That test runs on every CI commit; the procedure here runs
+**once per release-candidate line** and is what catches bugs the mock
+can't reach (crates.io rate-limit behavior, sparse-index propagation,
+artifact upload on killed runners, etc.).
+
+## Prerequisites
+
+- Admin access to <https://github.com/EffortlessMetrics/shipper>.
+- `CARGO_REGISTRY_TOKEN` with publish scope for all 12 crates already
+  configured (or Trusted Publishing registration complete — see
+  [run-in-github-actions.md](run-in-github-actions.md)).
+- A throwaway version suffix that has not been used. Convention:
+  `v0.3.0-test-resume-<YYYYMMDD>`.
+
+## The rehearsal
+
+### Step 1 — prep the throwaway tag
+
+On a clean `origin/main`:
+
+```bash
+git fetch origin
+git checkout origin/main
+git tag -a v0.3.0-test-resume-$(date +%Y%m%d) -m "recover rehearsal"
+git push origin v0.3.0-test-resume-$(date +%Y%m%d)
+```
+
+> **Do NOT** use a real RC version. Yanking is containment, not undo —
+> a rehearsal tag pollutes crates.io if left unyanked.
+
+### Step 2 — kick off the release workflow
+
+Pushing the tag triggers `.github/workflows/release.yml` →
+`publish-crates-io` job automatically.
+
+Alternatively, dispatch manually:
+
+```bash
+gh workflow run release.yml --ref <tag>
+```
+
+### Step 3 — watch for the mid-run kill point
+
+```bash
+gh run watch --repo EffortlessMetrics/shipper
+```
+
+Once 2–3 crates show as published in the logs (the per-crate
+`PackagePublished` event lines inside `shipper publish` stderr):
+
+```bash
+gh run cancel <run-id> --repo EffortlessMetrics/shipper
+```
+
+The `shipper-state-preflight` and `shipper-state-plan` artifacts will
+already be uploaded. The `shipper-state-final` artifact is uploaded
+`if: always()` so the cancellation itself triggers it — wait ~30s after
+cancelling for the artifact upload to complete.
+
+### Step 4 — collect evidence
+
+```bash
+gh run download <run-id> --repo EffortlessMetrics/shipper
+```
+
+Expect four directories:
+
+- `shipper-state-plan/` — plan stage artifact
+- `shipper-state-preflight/` — post-preflight artifact
+- `shipper-state-final/` — the crucial one. Contains `state.json`,
+  `events.jsonl`, `receipt.json` at the moment of cancellation.
+
+### Step 5 — sanity-check the artifacts
+
+Pull up `shipper-state-final/`:
+
+```bash
+cd shipper-state-final
+# state.json parses; events.jsonl is valid NDJSON
+shipper inspect events      # or: jq -c . events.jsonl | head
+shipper inspect receipt
+```
+
+Expected shape:
+
+- `state.json` has `state_version: "shipper.state.v1"` and a non-empty
+  `plan_id`.
+- Some packages have `state: "published"`; at least one is still
+  `state: "pending"` (or `"uploaded"` / `"failed"`).
+- `events.jsonl` ends with a complete line (no half-written event).
+- `PackagePublished` event count equals the count of `published`
+  packages in state.json — events-as-truth.
+
+### Step 6 — trigger the resume
+
+```bash
+gh workflow run release.yml \
+  --repo EffortlessMetrics/shipper \
+  --ref <same-tag> \
+  --field mode=resume \
+  --field artifact_run_id=<run-id-from-step-3>
+```
+
+### Step 7 — verify the resume
+
+The resume run should:
+
+- Download `shipper-state-final` from the cancelled run into `.shipper/`.
+- Validate `plan_id` matches current workspace plan_id (it should, same
+  tag).
+- Log `already published (skipping)` for each crate that was Published
+  in the downloaded state.
+- Run `cargo publish` **only** for the remaining packages.
+- Produce a final `shipper-state-final` artifact with all 12 packages
+  showing `state: "published"`.
+
+Download the resume's artifact and spot-check:
+
+```bash
+gh run download <resume-run-id> --repo EffortlessMetrics/shipper
+jq '.packages | to_entries | map({name: .key, state: .value.state.state})' \
+    shipper-state-resume-*/state.json
+```
+
+Every entry should be `{"state": "published"}`.
+
+### Step 8 — spot-check crates.io
+
+```bash
+for c in shipper shipper-cli shipper-core shipper-config shipper-types \
+         shipper-duration shipper-retry shipper-encrypt shipper-webhook \
+         shipper-registry shipper-sparse-index shipper-cargo-failure \
+         shipper-output-sanitizer; do
+  echo "- $c:"
+  cargo search --limit 1 "$c" | head -1
+done
+```
+
+Each line should show the rehearsal version.
+
+### Step 9 — yank the rehearsal
+
+```bash
+for c in shipper shipper-cli shipper-core shipper-config shipper-types \
+         shipper-duration shipper-retry shipper-encrypt shipper-webhook \
+         shipper-registry shipper-sparse-index shipper-cargo-failure \
+         shipper-output-sanitizer; do
+  cargo yank --version <rehearsal-version> "$c"
+done
+```
+
+Yanking is containment, not deletion — the bytes remain on crates.io,
+but new resolves skip them.
+
+> Once `shipper yank` / `shipper plan-yank` land (#98 PR2+),
+> this step becomes a single `shipper plan-yank --from-receipt <file>`
+> invocation against the rehearsal's `receipt.json`.
+
+## Pass / fail rubric
+
+The rehearsal passes iff **all** of the following are true:
+
+- [ ] `shipper-state-final` artifact exists after the cancelled run.
+- [ ] `state.json` parses; `plan_id` non-empty.
+- [ ] `events.jsonl` is valid NDJSON (every line parses).
+- [ ] `PackagePublished` event count = published-package count in
+      state.json (events-as-truth).
+- [ ] Resume does not re-`cargo publish` any crate that was already
+      Published (check logs for duplicate `Publishing X@...` lines).
+- [ ] Final state has every package Published.
+- [ ] All crates visible on crates.io from a fresh resolver.
+
+Any `[ ]` → file a bug citing the specific artifact. Don't ship the
+release line the rehearsal was cut from until the regression is fixed
+**and** the rehearsal has been re-run green.
+
+## When to re-run
+
+- Before cutting **every** new release-candidate minor (`v0.3.0-rc.N`,
+  `v0.4.0-rc.N`, ...).
+- After any change to `crates/shipper-core/src/engine/`,
+  `crates/shipper-core/src/state/`, or `crates/shipper-core/src/runtime/`
+  that touches persistence, resumption, or reconciliation.
+- Whenever `.github/workflows/release.yml` changes the dispatch /
+  resume shape.
+
+The synthetic test at `crates/shipper-cli/tests/e2e_rehearse.rs` runs
+on every CI commit and acts as a cheap pre-flight, but it's not a
+substitute for this procedure — the real kill happens on a real runner
+with a real registry.
+
+## See also
+
+- [Inspect a stalled run](inspect-a-stalled-run.md) — what to look for
+  inside `.shipper/` without a rehearsal.
+- [Release runbook](../release-runbook.md) — the production release
+  procedure this rehearsal validates.
+- [#90](https://github.com/EffortlessMetrics/shipper/issues/90) — the
+  issue this procedure closes.


### PR DESCRIPTION
## Summary

Close #90's testing gap in two layers:

1. **Synthetic CI-guard test** — `crates/shipper-cli/tests/e2e_rehearse.rs`.
   Runs on every commit. Proves the write-side invariants (state.json,
   events.jsonl NDJSON integrity, no duplicate publishes on resume) that
   existing `bdd_resume` tests don't cover because they construct state
   by hand rather than running a real publish.
2. **Operator playbook** — `docs/how-to/run-recover-rehearsal.md`.
   Step-by-step for the once-per-RC crates.io-backed rehearsal the
   synthetic can't substitute for (rate limits, sparse-index timing,
   runner kill + artifact upload).

## Why both

The synthetic test catches persistence bugs cheaply and repeatedly.
The real rehearsal catches the things mocks literally can't simulate —
crates.io's per-minute new-crate rate limit, sparse-index propagation
delay, the GitHub Actions \`if: always()\` artifact upload path after a
cancelled job, token/auth edge cases.

Running only one is insufficient:
- Only synthetic → bugs that only manifest against real crates.io slip
  through (see: #87, #88, #89 — all found by CI reality, not mocks).
- Only real → bugs regress between RC rehearsals and waste a tag cycle.

## The synthetic test

`rehearsal_interrupted_publish_then_resume_preserves_invariants`:

- 3-crate fixture with topological deps (c → b → a)
- Mock registry with per-crate 404→200 flip + \`never_flip\` pin so
  crate-c stays unpublished during run 1 even if cargo "exits 0"
  (otherwise the reconcile path would upgrade the simulated failure
  to Published and the scenario becomes meaningless)
- Run 1: a/b succeed, c fails → realistic interrupted state
- Run 2: resume with c succeeding
- Asserts: state.json + events.jsonl coherent; no duplicate
  PackagePublished; events.jsonl append-only (ExecutionStarted count = 2
  confirms run 1's events survived resume)

## The playbook

`docs/how-to/run-recover-rehearsal.md` — 9 steps + pass/fail rubric +
when-to-re-run. Linked from docs/README.md how-to index.

## Findings noted during test development

Two potential improvements surfaced while writing the test, kept out of
scope for this PR:

1. Resume's "already published, skipping" path does NOT emit a
   PackageSkipped event for packages whose state is already Published
   (only emits for packages where \`version_exists\` short-circuits).
   The audit trail is silent on the "state said done, we trusted it"
   decision. Candidate enhancement for an #93 follow-on.
2. In one path tested, the resume logged \`Skipped\` in stdout but
   state.json kept showing \`failed\` for the affected package. Top-level
   \`updated_at\` bumped (state file was re-written) but the package's
   own \`last_updated_at\` didn't. Could indicate update_state not being
   called on the Skipped path for a resumed Failed package — worth a
   closer look.

Both warrant follow-up issues, not blockers here.

## Test plan

- [x] \`cargo test -p shipper-cli --test e2e_rehearse\` passes on Windows.
- [x] \`cargo clippy -p shipper-cli --all-targets --all-features -- -D warnings\` clean.
- [x] \`cargo fmt --all --check\` clean.
- [ ] CI multi-OS green (Linux/macOS fake-cargo script is the \`sh\`
      variant; expect parity but verify).
- [ ] Real rehearsal against a throwaway \`v0.3.0-test-resume-YYYYMMDD\`
      tag (operator action — out of PR scope; see playbook).