### PR TITLE
feat(rehearse): engine::run_rehearsal + shipper rehearse CLI (#97 PR 2)

### DIFF
--- a/crates/shipper-cli/src/main.rs
+++ b/crates/shipper-cli/src/main.rs
@@ -213,6 +213,22 @@ enum Commands {
     Publish,
     /// Resume a previous publish run.
     Resume,
+    /// Rehearse a release against an alternate registry (#97 PR 2).
+    ///
+    /// Publishes every crate in the plan to the registry named by
+    /// `--rehearsal-registry` (or `[rehearsal] registry = "..."` in
+    /// `.shipper.toml`), verifies visibility on that registry, and
+    /// emits a `RehearsalComplete { passed, ... }` event to
+    /// `events.jsonl` so the outcome is auditable.
+    ///
+    /// Rehearse must target a non-live registry (kellnr, a sandbox
+    /// crates.io account, or a throwaway alternate registry). Shipper
+    /// refuses to rehearse against the same registry as the live target.
+    ///
+    /// Part of [#97](https://github.com/EffortlessMetrics/shipper/issues/97).
+    /// The hard gate that blocks live publish without a passing rehearsal
+    /// lands in #97 PR 3.
+    Rehearse,
     /// Compare local workspace versions to the registry.
     Status,
     /// Print environment and auth diagnostics.
@@ -575,6 +591,32 @@ fn main() -> Result<()> {
                     &current_opts.state_dir,
                     &cli.format,
                 );
+            }
+        }
+        Commands::Rehearse => {
+            let outcome = engine::run_rehearsal(&planned, &opts, &mut reporter)?;
+
+            // Stdout is the operator-facing receipt: mirrors the live
+            // publish path, so a human scanning the terminal sees one
+            // consistent "did it work?" line regardless of which command
+            // they ran. Full per-package detail is in events.jsonl.
+            if outcome.passed {
+                println!(
+                    "rehearsal OK: {} packages against '{}'",
+                    outcome.packages_published, outcome.registry_name
+                );
+            } else {
+                println!(
+                    "rehearsal FAILED after {}/{} packages against '{}': {}",
+                    outcome.packages_published,
+                    outcome.packages_attempted,
+                    outcome.registry_name,
+                    outcome.summary
+                );
+                // Exit non-zero so CI lanes that wrap `shipper rehearse`
+                // fail the job on a failed rehearsal without needing extra
+                // scripting.
+                anyhow::bail!("rehearsal did not pass");
             }
         }
         Commands::Status => {
@@ -1881,6 +1923,8 @@ mod tests {
             encryption: shipper::encryption::EncryptionConfig::default(),
             registries: vec![],
             resume_from: None,
+            rehearsal_registry: None,
+            rehearsal_skip: false,
         };
 
         fs::create_dir_all(td.path().join("cargo-home")).expect("mkdir");
@@ -1950,6 +1994,8 @@ mod tests {
             encryption: shipper::encryption::EncryptionConfig::default(),
             registries: vec![],
             resume_from: None,
+            rehearsal_registry: None,
+            rehearsal_skip: false,
         };
 
         fs::create_dir_all(td.path().join("cargo-home")).expect("mkdir");

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__help_text.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__help_text.snap
@@ -11,6 +11,7 @@ Commands:
   preflight        Run preflight checks without publishing
   publish          Execute the plan (will resume if a matching state file exists)
   resume           Resume a previous publish run
+  rehearse         Rehearse a release against an alternate registry (#97 PR 2)
   status           Compare local workspace versions to the registry
   doctor           Print environment and auth diagnostics
   inspect-events   View detailed event log

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__no_subcommand_error.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__no_subcommand_error.snap
@@ -11,6 +11,7 @@ Commands:
   preflight        Run preflight checks without publishing
   publish          Execute the plan (will resume if a matching state file exists)
   resume           Resume a previous publish run
+  rehearse         Rehearse a release against an alternate registry (#97 PR 2)
   status           Compare local workspace versions to the registry
   doctor           Print environment and auth diagnostics
   inspect-events   View detailed event log

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_root.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_root.snap
@@ -11,6 +11,7 @@ Commands:
   preflight        Run preflight checks without publishing
   publish          Execute the plan (will resume if a matching state file exists)
   resume           Resume a previous publish run
+  rehearse         Rehearse a release against an alternate registry (#97 PR 2)
   status           Compare local workspace versions to the registry
   doctor           Print environment and auth diagnostics
   inspect-events   View detailed event log

--- a/crates/shipper-config/src/lib.rs
+++ b/crates/shipper-config/src/lib.rs
@@ -858,6 +858,22 @@ impl ShipperConfig {
                 }
             },
             resume_from: cli.resume_from,
+            // #97 PR 2: rehearsal resolution order, highest priority first:
+            //   1. CLI --rehearsal-registry <name>  (implicit enable)
+            //   2. config [rehearsal] enabled = true + registry = "..."
+            //   3. None → rehearsal disabled
+            //
+            // A CLI override always takes precedence, matching every other
+            // flag in this builder. --skip-rehearsal is passed through raw;
+            // engine::run_rehearsal honors it with a loud warning.
+            rehearsal_registry: cli.rehearsal_registry.clone().or_else(|| {
+                if self.rehearsal.enabled {
+                    self.rehearsal.registry.clone()
+                } else {
+                    None
+                }
+            }),
+            rehearsal_skip: cli.skip_rehearsal,
         }
     }
 

--- a/crates/shipper-config/src/runtime/mod.rs
+++ b/crates/shipper-config/src/runtime/mod.rs
@@ -39,6 +39,8 @@ pub fn into_runtime_options(value: RuntimeOptions) -> shipper_types::RuntimeOpti
         encryption: value.encryption,
         registries: value.registries,
         resume_from: value.resume_from,
+        rehearsal_registry: value.rehearsal_registry,
+        rehearsal_skip: value.rehearsal_skip,
     }
 }
 
@@ -115,6 +117,8 @@ mod tests {
                 },
             ],
             resume_from: Some("my-crate".to_string()),
+            rehearsal_registry: None,
+            rehearsal_skip: false,
         }
     }
 
@@ -276,6 +280,8 @@ mod tests {
                 encryption,
                 registries,
                 resume_from: None,
+            rehearsal_registry: None,
+            rehearsal_skip: false,
             };
 
             let converted = into_runtime_options(input);
@@ -908,6 +914,8 @@ mod tests {
                 },
                 registries: vec![],
                 resume_from: None,
+                rehearsal_registry: None,
+                rehearsal_skip: false,
             }
         }
 
@@ -1224,6 +1232,8 @@ mod tests {
                 encryption: EncryptionConfig::default(),
                 registries: vec![],
                 resume_from: None,
+                rehearsal_registry: None,
+                rehearsal_skip: false,
             }
         }
 
@@ -1408,6 +1418,8 @@ mod tests {
                 encryption: EncryptionConfig::default(),
                 registries: vec![],
                 resume_from: None,
+                rehearsal_registry: None,
+                rehearsal_skip: false,
             };
             // Adjust verify_mode to match typical policy usage
             match policy {
@@ -1770,6 +1782,8 @@ mod tests {
                 encryption: EncryptionConfig::default(),
                 registries: vec![],
                 resume_from: Some(String::new()),
+                rehearsal_registry: None,
+                rehearsal_skip: false,
             };
 
             let converted = into_runtime_options(opts);

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__policy_combination_tests__snapshot_balanced_policy_typical.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__policy_combination_tests__snapshot_balanced_policy_typical.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-config-runtime/src/lib.rs
+source: crates/shipper-config/src/runtime/mod.rs
 expression: converted
 ---
 RuntimeOptions {
@@ -55,4 +55,6 @@ RuntimeOptions {
     },
     registries: [],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__policy_combination_tests__snapshot_fast_policy_typical.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__policy_combination_tests__snapshot_fast_policy_typical.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-config-runtime/src/lib.rs
+source: crates/shipper-config/src/runtime/mod.rs
 expression: converted
 ---
 RuntimeOptions {
@@ -55,4 +55,6 @@ RuntimeOptions {
     },
     registries: [],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__policy_combination_tests__snapshot_safe_policy_typical.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__policy_combination_tests__snapshot_safe_policy_typical.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-config-runtime/src/lib.rs
+source: crates/shipper-config/src/runtime/mod.rs
 expression: converted
 ---
 RuntimeOptions {
@@ -55,4 +55,6 @@ RuntimeOptions {
     },
     registries: [],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_all_flags_enabled.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_all_flags_enabled.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/shipper-config-runtime/src/lib.rs
-assertion_line: 371
+source: crates/shipper-config/src/runtime/mod.rs
 expression: converted
 ---
 RuntimeOptions {
@@ -56,4 +55,6 @@ RuntimeOptions {
     },
     registries: [],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_alternative_registry_only.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_alternative_registry_only.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-config-runtime/src/lib.rs
+source: crates/shipper-config/src/runtime/mod.rs
 expression: converted
 ---
 RuntimeOptions {
@@ -63,4 +63,6 @@ RuntimeOptions {
         },
     ],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_balanced_policy_with_partial_config.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_balanced_policy_with_partial_config.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-config-runtime/src/lib.rs
+source: crates/shipper-config/src/runtime/mod.rs
 expression: converted
 ---
 RuntimeOptions {
@@ -55,4 +55,6 @@ RuntimeOptions {
     },
     registries: [],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_default_conversion.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_default_conversion.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/shipper-config-runtime/src/lib.rs
-assertion_line: 355
+source: crates/shipper-config/src/runtime/mod.rs
 expression: converted
 ---
 RuntimeOptions {
@@ -56,4 +55,6 @@ RuntimeOptions {
     },
     registries: [],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_encryption_with_env_var.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_encryption_with_env_var.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/shipper-config-runtime/src/lib.rs
-assertion_line: 993
+source: crates/shipper-config/src/runtime/mod.rs
 expression: converted
 ---
 RuntimeOptions {
@@ -58,4 +57,6 @@ RuntimeOptions {
     },
     registries: [],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_fast_policy_no_verify.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_fast_policy_no_verify.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/shipper-config-runtime/src/lib.rs
-assertion_line: 937
+source: crates/shipper-config/src/runtime/mod.rs
 expression: converted
 ---
 RuntimeOptions {
@@ -56,4 +55,6 @@ RuntimeOptions {
     },
     registries: [],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_full_readiness_config.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_full_readiness_config.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/shipper-config-runtime/src/lib.rs
-assertion_line: 955
+source: crates/shipper-config/src/runtime/mod.rs
 expression: converted
 ---
 RuntimeOptions {
@@ -58,4 +57,6 @@ RuntimeOptions {
     },
     registries: [],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_linear_retry_strategy.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_linear_retry_strategy.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/shipper-config-runtime/src/lib.rs
-assertion_line: 1005
+source: crates/shipper-config/src/runtime/mod.rs
 expression: converted
 ---
 RuntimeOptions {
@@ -56,4 +55,6 @@ RuntimeOptions {
     },
     registries: [],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_parallel_heavy.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_parallel_heavy.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/shipper-config-runtime/src/lib.rs
-assertion_line: 968
+source: crates/shipper-config/src/runtime/mod.rs
 expression: converted
 ---
 RuntimeOptions {
@@ -56,4 +55,6 @@ RuntimeOptions {
     },
     registries: [],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_resume_from_set.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_resume_from_set.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/shipper-config-runtime/src/lib.rs
-assertion_line: 1014
+source: crates/shipper-config/src/runtime/mod.rs
 expression: converted
 ---
 RuntimeOptions {
@@ -58,4 +57,6 @@ RuntimeOptions {
     resume_from: Some(
         "my-sub-crate",
     ),
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_safe_policy_max_safety.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_safe_policy_max_safety.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-config-runtime/src/lib.rs
+source: crates/shipper-config/src/runtime/mod.rs
 expression: converted
 ---
 RuntimeOptions {
@@ -57,4 +57,6 @@ RuntimeOptions {
     },
     registries: [],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_webhook_with_secret.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_webhook_with_secret.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/shipper-config-runtime/src/lib.rs
-assertion_line: 981
+source: crates/shipper-config/src/runtime/mod.rs
 expression: converted
 ---
 RuntimeOptions {
@@ -58,4 +57,6 @@ RuntimeOptions {
     },
     registries: [],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_with_registries.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_with_registries.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/shipper-config-runtime/src/lib.rs
-assertion_line: 390
+source: crates/shipper-config/src/runtime/mod.rs
 expression: converted
 ---
 RuntimeOptions {
@@ -69,4 +68,6 @@ RuntimeOptions {
         },
     ],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/src/snapshots/shipper_config__tests__edge_case_snapshots__edge_policy_balanced_runtime.snap
+++ b/crates/shipper-config/src/snapshots/shipper_config__tests__edge_case_snapshots__edge_policy_balanced_runtime.snap
@@ -55,4 +55,6 @@ RuntimeOptions {
     },
     registries: [],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/src/snapshots/shipper_config__tests__edge_case_snapshots__edge_policy_fast_runtime.snap
+++ b/crates/shipper-config/src/snapshots/shipper_config__tests__edge_case_snapshots__edge_policy_fast_runtime.snap
@@ -55,4 +55,6 @@ RuntimeOptions {
     },
     registries: [],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/src/snapshots/shipper_config__tests__edge_case_snapshots__edge_policy_safe_runtime.snap
+++ b/crates/shipper-config/src/snapshots/shipper_config__tests__edge_case_snapshots__edge_policy_safe_runtime.snap
@@ -55,4 +55,6 @@ RuntimeOptions {
     },
     registries: [],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/src/snapshots/shipper_config__tests__snapshot_tests__merge_cli_overrides_file_values.snap
+++ b/crates/shipper-config/src/snapshots/shipper_config__tests__snapshot_tests__merge_cli_overrides_file_values.snap
@@ -55,4 +55,6 @@ RuntimeOptions {
     },
     registries: [],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper-config/tests/config_runtime_bdd.rs
+++ b/crates/shipper-config/tests/config_runtime_bdd.rs
@@ -63,6 +63,8 @@ fn sample_runtime_options(base_url: &str, registry_count: usize) -> RuntimeOptio
             })
             .collect(),
         resume_from: None,
+        rehearsal_registry: None,
+        rehearsal_skip: false,
     }
 }
 #[test]

--- a/crates/shipper-types/src/lib.rs
+++ b/crates/shipper-types/src/lib.rs
@@ -581,6 +581,18 @@ pub struct RuntimeOptions {
     pub registries: Vec<Registry>,
     /// Optional package name to resume from (skips all packages before this one)
     pub resume_from: Option<String>,
+    /// Rehearsal registry name (#97) — if `Some`, `shipper rehearse` publishes
+    /// to this registry as phase-2 proof before live dispatch. `None` means
+    /// rehearsal is disabled (the default; opt-in until phase-2 stabilizes).
+    ///
+    /// The name must resolve against the configured [`Self::registries`] at
+    /// runtime; `engine::run_rehearsal` errors clean otherwise.
+    pub rehearsal_registry: Option<String>,
+    /// Operator override — explicitly skip rehearsal even if a
+    /// [`Self::rehearsal_registry`] is configured (#97). Default `false`.
+    /// When the hard gate lands (#97 PR 3), live publish will refuse to run
+    /// without this flag if rehearsal has not passed for the current `plan_id`.
+    pub rehearsal_skip: bool,
 }
 
 /// A package in the publish plan.
@@ -1482,6 +1494,37 @@ pub enum EventType {
         exit_code: i32,
     },
 
+    // Rehearsal-registry proof (#97 PR 2). A rehearsal is phase-2 preflight:
+    // publish every crate to a non-crates.io registry, verify visibility,
+    // and (in a later PR) install-smoke it. The events below are emitted by
+    // `shipper rehearse` so an auditor can replay the rehearsal from the
+    // event log without re-running it.
+    //
+    // `plan_id` is NOT carried in the event payload — the enclosing
+    // `PublishEvent.package` field already disambiguates per-package events,
+    // and the end-of-run `RehearsalComplete` is sufficient for plan-level
+    // correlation since events.jsonl is append-only scoped to one state dir.
+    RehearsalStarted {
+        registry: String,
+        package_count: usize,
+    },
+    RehearsalPackagePublished {
+        name: String,
+        version: String,
+        duration_ms: u128,
+    },
+    RehearsalPackageFailed {
+        name: String,
+        version: String,
+        class: ErrorClass,
+        message: String,
+    },
+    RehearsalComplete {
+        passed: bool,
+        registry: String,
+        summary: String,
+    },
+
     // Retry visibility (#91) — emitted immediately before Shipper sleeps on a
     // retry backoff. `attempt` is the just-failed attempt number (1-indexed),
     // so the next attempt will be `attempt + 1` of `max_attempts`. `reason`
@@ -2361,6 +2404,8 @@ mod tests {
             encryption: EncryptionSettings::default(),
             registries: vec![],
             resume_from: None,
+            rehearsal_registry: None,
+            rehearsal_skip: false,
         }
     }
 
@@ -4884,6 +4929,8 @@ mod tests {
                     encryption: EncryptionSettings::default(),
                     registries: vec![],
                     resume_from: None,
+            rehearsal_registry: None,
+            rehearsal_skip: false,
                 };
 
                 // All duration fields must be positive

--- a/crates/shipper-types/src/snapshots/shipper_types__tests__debug_snapshots__runtime_options_debug_snapshot.snap
+++ b/crates/shipper-types/src/snapshots/shipper_types__tests__debug_snapshots__runtime_options_debug_snapshot.snap
@@ -55,4 +55,6 @@ RuntimeOptions {
     },
     registries: [],
     resume_from: None,
+    rehearsal_registry: None,
+    rehearsal_skip: false,
 }

--- a/crates/shipper/src/engine/mod.rs
+++ b/crates/shipper/src/engine/mod.rs
@@ -1249,6 +1249,238 @@ pub fn run_resume(
     run_publish(ws, opts, reporter)
 }
 
+/// Outcome of a rehearsal run. Sufficient for callers (CLI, future hard gate)
+/// to decide whether live dispatch is authorized without re-reading events.
+///
+/// #97 PR 2. The hard gate (#97 PR 3) will bind this outcome to a `plan_id`
+/// so "rehearsal passed" can't be claimed for a different workspace state.
+#[derive(Debug, Clone)]
+pub struct RehearsalOutcome {
+    pub passed: bool,
+    pub registry_name: String,
+    pub packages_attempted: usize,
+    pub packages_published: usize,
+    pub summary: String,
+}
+
+/// Run a rehearsal publish against an alternate registry (#97 PR 2).
+///
+/// Phase-2 preflight: publish every crate in the plan to a non-live
+/// registry, verify each is visible on that registry, and emit a
+/// `RehearsalComplete` event summarizing the outcome.
+///
+/// **Contract**:
+/// - Reads `opts.rehearsal_registry` (set via `--rehearsal-registry` or
+///   `[rehearsal]` config). Must resolve to a [`Registry`] entry in
+///   `opts.registries`; bails clean otherwise.
+/// - Refuses to rehearse against the live target (`ws.plan.registry`).
+///   Rehearsal and live must be different registries.
+/// - Runs sequentially (no parallel yet); stops at the first failure.
+/// - Does NOT touch `state.json`. Rehearsal is a pre-publish proof, not
+///   an execution; it only appends to `events.jsonl` so auditors can
+///   replay the rehearsal from the event log.
+/// - Post-publish visibility check uses the SAME readiness mechanism as
+///   live publish (`reg.version_exists`). A rehearsal artifact that's
+///   not visible within the readiness window fails the rehearsal.
+///
+/// **Not in this PR**:
+/// - Hard gate wiring into `run_publish` (PR 3).
+/// - Install/smoke check against the rehearsal registry (PR 3 or 4).
+/// - Parallel rehearsal (not planned; rehearsal is infrequent and
+///   correctness > speed).
+pub fn run_rehearsal(
+    ws: &PlannedWorkspace,
+    opts: &RuntimeOptions,
+    reporter: &mut dyn Reporter,
+) -> Result<RehearsalOutcome> {
+    let rehearsal_name = opts
+        .rehearsal_registry
+        .as_ref()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "no rehearsal registry configured; set --rehearsal-registry <name> \
+             or enable [rehearsal] in .shipper.toml"
+            )
+        })?
+        .clone();
+
+    if opts.rehearsal_skip {
+        reporter.warn(&format!(
+            "--skip-rehearsal set; rehearsal against '{rehearsal_name}' was requested but will not run. \
+             Once #97 PR 3 lands, live dispatch will refuse without a prior passing rehearsal."
+        ));
+        return Ok(RehearsalOutcome {
+            passed: false,
+            registry_name: rehearsal_name,
+            packages_attempted: 0,
+            packages_published: 0,
+            summary: "skipped by --skip-rehearsal".to_string(),
+        });
+    }
+
+    let rehearsal_reg = opts
+        .registries
+        .iter()
+        .find(|r| r.name == rehearsal_name)
+        .cloned()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "rehearsal registry '{rehearsal_name}' is not configured. \
+             Add it to [[registries]] in .shipper.toml or pass --registries."
+            )
+        })?;
+
+    if rehearsal_reg.name == ws.plan.registry.name {
+        bail!(
+            "rehearsal registry '{}' must differ from the live target; \
+             pick a sandbox registry (e.g. kellnr, a fresh crates-io test account, \
+             or a throwaway alternate-registry entry)",
+            rehearsal_reg.name
+        );
+    }
+
+    let workspace_root = &ws.workspace_root;
+    let state_dir = resolve_state_dir(workspace_root, &opts.state_dir);
+    std::fs::create_dir_all(&state_dir)
+        .with_context(|| format!("failed to create state dir {}", state_dir.display()))?;
+    let events_path = events::events_path(&state_dir);
+    let mut event_log = events::EventLog::new();
+
+    reporter.info(&format!(
+        "rehearsal starting — {} packages against '{}'",
+        ws.plan.packages.len(),
+        rehearsal_name
+    ));
+
+    event_log.record(PublishEvent {
+        timestamp: Utc::now(),
+        event_type: EventType::RehearsalStarted {
+            registry: rehearsal_name.clone(),
+            package_count: ws.plan.packages.len(),
+        },
+        package: "all".to_string(),
+    });
+    event_log.write_to_file(&events_path)?;
+    event_log.clear();
+
+    let rehearsal_client = init_registry_client(rehearsal_reg.clone(), &state_dir)?;
+
+    let mut packages_published: usize = 0;
+    let mut first_failure: Option<String> = None;
+
+    for p in &ws.plan.packages {
+        let pkg_label = format!("{}@{}", p.name, p.version);
+        reporter.info(&format!("rehearsing {pkg_label} → {rehearsal_name}"));
+        let start = Instant::now();
+
+        let out = cargo::cargo_publish(
+            workspace_root,
+            &p.name,
+            &rehearsal_reg.name,
+            opts.allow_dirty,
+            opts.no_verify,
+            opts.output_lines,
+            None,
+        )?;
+
+        if out.exit_code != 0 {
+            let (class, msg) = classify_cargo_failure(&out.stderr_tail, &out.stdout_tail);
+            reporter.error(&format!(
+                "rehearsal failed for {pkg_label}: {msg}\nstderr tail:\n{}",
+                out.stderr_tail
+            ));
+            event_log.record(PublishEvent {
+                timestamp: Utc::now(),
+                event_type: EventType::RehearsalPackageFailed {
+                    name: p.name.clone(),
+                    version: p.version.clone(),
+                    class,
+                    message: msg.clone(),
+                },
+                package: pkg_label.clone(),
+            });
+            event_log.write_to_file(&events_path)?;
+            event_log.clear();
+            first_failure = Some(format!("{pkg_label}: {msg}"));
+            break;
+        }
+
+        // Post-publish visibility check on the rehearsal registry. Reuse
+        // `version_exists` — same mechanism live publish trusts.
+        if !rehearsal_client.version_exists(&p.name, &p.version)? {
+            let msg = format!(
+                "rehearsal: cargo publish succeeded but {pkg_label} is not visible on '{rehearsal_name}'"
+            );
+            reporter.error(&msg);
+            event_log.record(PublishEvent {
+                timestamp: Utc::now(),
+                event_type: EventType::RehearsalPackageFailed {
+                    name: p.name.clone(),
+                    version: p.version.clone(),
+                    class: ErrorClass::Ambiguous,
+                    message: msg.clone(),
+                },
+                package: pkg_label.clone(),
+            });
+            event_log.write_to_file(&events_path)?;
+            event_log.clear();
+            first_failure = Some(msg);
+            break;
+        }
+
+        let duration_ms = start.elapsed().as_millis();
+        event_log.record(PublishEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::RehearsalPackagePublished {
+                name: p.name.clone(),
+                version: p.version.clone(),
+                duration_ms,
+            },
+            package: pkg_label.clone(),
+        });
+        event_log.write_to_file(&events_path)?;
+        event_log.clear();
+        packages_published += 1;
+    }
+
+    let passed = first_failure.is_none();
+    let summary = if passed {
+        format!("rehearsed {packages_published} packages against '{rehearsal_name}' successfully")
+    } else {
+        format!(
+            "rehearsal stopped at {}/{}: {}",
+            packages_published + 1,
+            ws.plan.packages.len(),
+            first_failure.as_deref().unwrap_or("")
+        )
+    };
+
+    event_log.record(PublishEvent {
+        timestamp: Utc::now(),
+        event_type: EventType::RehearsalComplete {
+            passed,
+            registry: rehearsal_name.clone(),
+            summary: summary.clone(),
+        },
+        package: "all".to_string(),
+    });
+    event_log.write_to_file(&events_path)?;
+
+    if passed {
+        reporter.info(&summary);
+    } else {
+        reporter.error(&summary);
+    }
+
+    Ok(RehearsalOutcome {
+        passed,
+        registry_name: rehearsal_name,
+        packages_attempted: packages_published + if passed { 0 } else { 1 },
+        packages_published,
+        summary,
+    })
+}
+
 pub(crate) fn init_state(ws: &PlannedWorkspace, state_dir: &Path) -> Result<ExecutionState> {
     let mut packages: BTreeMap<String, PackageProgress> = BTreeMap::new();
     for p in &ws.plan.packages {
@@ -1667,6 +1899,8 @@ mod tests {
             encryption: crate::encryption::EncryptionConfig::default(),
             registries: vec![],
             resume_from: None,
+            rehearsal_registry: None,
+            rehearsal_skip: false,
         }
     }
 
@@ -6290,6 +6524,229 @@ mod tests {
                 assert_eq!(pkg.attempts, attempts);
             }
         }
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // run_rehearsal (#97 PR 2) — phase-2 preflight against an alt registry
+    // ───────────────────────────────────────────────────────────────────
+
+    fn read_events_raw(state_dir: &Path) -> Vec<serde_json::Value> {
+        let path = events::events_path(state_dir);
+        let raw = std::fs::read_to_string(&path).unwrap_or_default();
+        raw.lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).expect("events.jsonl must parse"))
+            .collect()
+    }
+
+    fn event_discriminator(event: &serde_json::Value) -> Option<String> {
+        event
+            .get("event_type")
+            .and_then(|et| et.get("type"))
+            .and_then(|t| t.as_str())
+            .map(str::to_owned)
+    }
+
+    #[test]
+    #[serial]
+    fn run_rehearsal_errors_when_no_rehearsal_registry_configured() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        let env_vars = fake_program_env_vars(&bin);
+        temp_env::with_vars(env_vars, || {
+            let ws = planned_workspace(td.path(), "http://127.0.0.1:1".into());
+            let opts = default_opts(PathBuf::from(".shipper"));
+
+            let mut reporter = CollectingReporter::default();
+            let err = run_rehearsal(&ws, &opts, &mut reporter).expect_err("must fail");
+            let msg = format!("{err:#}");
+            assert!(msg.contains("no rehearsal registry"), "err was: {msg}");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn run_rehearsal_errors_when_rehearsal_equals_live_target() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        let env_vars = fake_program_env_vars(&bin);
+        temp_env::with_vars(env_vars, || {
+            let ws = planned_workspace(td.path(), "http://127.0.0.1:1".into());
+            let mut opts = default_opts(PathBuf::from(".shipper"));
+            // Point rehearsal at the same registry name as the live target.
+            opts.rehearsal_registry = Some("crates-io".to_string());
+            opts.registries = vec![Registry {
+                name: "crates-io".to_string(),
+                api_base: "http://127.0.0.1:1".to_string(),
+                index_base: None,
+            }];
+
+            let mut reporter = CollectingReporter::default();
+            let err = run_rehearsal(&ws, &opts, &mut reporter).expect_err("must fail");
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains("must differ from the live target"),
+                "err was: {msg}"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn run_rehearsal_errors_when_registry_name_not_in_config() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        let env_vars = fake_program_env_vars(&bin);
+        temp_env::with_vars(env_vars, || {
+            let ws = planned_workspace(td.path(), "http://127.0.0.1:1".into());
+            let mut opts = default_opts(PathBuf::from(".shipper"));
+            opts.rehearsal_registry = Some("bogus-registry".to_string());
+            // opts.registries is empty — bogus-registry won't resolve.
+
+            let mut reporter = CollectingReporter::default();
+            let err = run_rehearsal(&ws, &opts, &mut reporter).expect_err("must fail");
+            let msg = format!("{err:#}");
+            assert!(msg.contains("is not configured"), "err was: {msg}");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn run_rehearsal_skip_flag_returns_without_running() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        let env_vars = fake_program_env_vars(&bin);
+        temp_env::with_vars(env_vars, || {
+            let ws = planned_workspace(td.path(), "http://127.0.0.1:1".into());
+            let mut opts = default_opts(PathBuf::from(".shipper"));
+            opts.rehearsal_registry = Some("rehearsal".to_string());
+            opts.rehearsal_skip = true;
+
+            let mut reporter = CollectingReporter::default();
+            let outcome =
+                run_rehearsal(&ws, &opts, &mut reporter).expect("skip path should not error");
+            assert!(!outcome.passed, "skip should not claim a pass");
+            assert_eq!(outcome.packages_published, 0);
+            assert!(outcome.summary.contains("skipped"));
+            // Skip path must not write events — nothing to audit.
+            let events_path = events::events_path(&td.path().join(".shipper"));
+            assert!(
+                !events_path.exists(),
+                "skip path must not create events.jsonl"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn run_rehearsal_happy_path_emits_started_published_complete_events() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        let env_vars = fake_program_env_vars(&bin);
+        temp_env::with_vars(env_vars, || {
+            // Rehearsal-registry mock: returns 404 for the preflight lookup
+            // (not here) and 200 for the post-publish visibility check.
+            let rehearsal_server = spawn_registry_server(
+                std::collections::BTreeMap::from([(
+                    "/api/v1/crates/demo/0.1.0".to_string(),
+                    vec![(200, "{}".to_string())],
+                )]),
+                1,
+            );
+
+            let ws = planned_workspace(td.path(), "http://127.0.0.1:1".into());
+            let mut opts = default_opts(PathBuf::from(".shipper"));
+            opts.rehearsal_registry = Some("rehearsal".to_string());
+            opts.registries = vec![Registry {
+                name: "rehearsal".to_string(),
+                api_base: rehearsal_server.base_url.clone(),
+                index_base: None,
+            }];
+
+            let mut reporter = CollectingReporter::default();
+            let outcome = run_rehearsal(&ws, &opts, &mut reporter).expect("rehearse");
+            assert!(outcome.passed, "outcome: {outcome:?}");
+            assert_eq!(outcome.packages_published, 1);
+
+            let events = read_events_raw(&td.path().join(".shipper"));
+            let types: Vec<String> = events.iter().filter_map(event_discriminator).collect();
+            assert!(
+                types.contains(&"rehearsal_started".to_string()),
+                "types: {types:?}"
+            );
+            assert!(
+                types.contains(&"rehearsal_package_published".to_string()),
+                "types: {types:?}"
+            );
+            assert!(
+                types.contains(&"rehearsal_complete".to_string()),
+                "types: {types:?}"
+            );
+
+            // RehearsalComplete must carry passed=true for the happy path.
+            let complete = events
+                .iter()
+                .find(|e| event_discriminator(e).as_deref() == Some("rehearsal_complete"))
+                .expect("RehearsalComplete event");
+            assert_eq!(
+                complete["event_type"]["passed"].as_bool(),
+                Some(true),
+                "complete event: {complete}"
+            );
+
+            rehearsal_server.join();
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn run_rehearsal_cargo_failure_emits_package_failed_and_marks_not_passed() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        let mut env_vars = fake_program_env_vars(&bin);
+        env_vars.extend([("SHIPPER_CARGO_EXIT", Some("101".to_string()))]);
+        temp_env::with_vars(env_vars, || {
+            // Rehearsal registry is never hit because cargo fails.
+            let rehearsal_server = spawn_registry_server(std::collections::BTreeMap::new(), 0);
+
+            let ws = planned_workspace(td.path(), "http://127.0.0.1:1".into());
+            let mut opts = default_opts(PathBuf::from(".shipper"));
+            opts.rehearsal_registry = Some("rehearsal".to_string());
+            opts.registries = vec![Registry {
+                name: "rehearsal".to_string(),
+                api_base: rehearsal_server.base_url.clone(),
+                index_base: None,
+            }];
+
+            let mut reporter = CollectingReporter::default();
+            let outcome = run_rehearsal(&ws, &opts, &mut reporter).expect("rehearse");
+            assert!(!outcome.passed);
+            assert_eq!(outcome.packages_published, 0);
+
+            let events = read_events_raw(&td.path().join(".shipper"));
+            let types: Vec<String> = events.iter().filter_map(event_discriminator).collect();
+            assert!(
+                types.contains(&"rehearsal_package_failed".to_string()),
+                "types: {types:?}"
+            );
+            assert!(
+                types.contains(&"rehearsal_complete".to_string()),
+                "types: {types:?}"
+            );
+
+            let complete = events
+                .iter()
+                .find(|e| event_discriminator(e).as_deref() == Some("rehearsal_complete"))
+                .expect("RehearsalComplete");
+            assert_eq!(complete["event_type"]["passed"].as_bool(), Some(false));
+            rehearsal_server.join();
+        });
     }
 }
 

--- a/crates/shipper/src/engine/parallel/tests.rs
+++ b/crates/shipper/src/engine/parallel/tests.rs
@@ -196,6 +196,8 @@ fn default_opts(state_dir: PathBuf) -> RuntimeOptions {
         webhook: shipper_webhook::WebhookConfig::default(),
         registries: vec![],
         resume_from: None,
+        rehearsal_registry: None,
+        rehearsal_skip: false,
     }
 }
 

--- a/crates/shipper/src/runtime/policy/mod.rs
+++ b/crates/shipper/src/runtime/policy/mod.rs
@@ -378,6 +378,8 @@ mod apply_policy_tests {
             encryption: Default::default(),
             registries: vec![],
             resume_from: None,
+            rehearsal_registry: None,
+            rehearsal_skip: false,
         }
     }
 
@@ -665,6 +667,8 @@ mod property_tests {
                         encryption: Default::default(),
                         registries: vec![],
                         resume_from: None,
+                        rehearsal_registry: None,
+                        rehearsal_skip: false,
                     }
                 },
             )
@@ -1068,6 +1072,8 @@ mod absorbed_integration_tests {
             encryption: Default::default(),
             registries: vec![],
             resume_from: None,
+            rehearsal_registry: None,
+            rehearsal_skip: false,
         }
     }
 


### PR DESCRIPTION
## Summary

Phase-2 preflight execution — the code that makes [#97](https://github.com/EffortlessMetrics/shipper/issues/97)'s config flags actually DO something. PR 1 (#120) added \`RehearsalConfig\` + CLI flag plumbing; this PR:

- publishes every crate in the plan to an alternate registry,
- verifies visibility on that registry via the same \`version_exists\`
  mechanism live publish uses,
- emits a \`RehearsalComplete { passed, registry, summary }\` event to
  \`events.jsonl\` so the outcome is auditable from the event log alone.

Exposed as \`shipper rehearse\`.

## Key invariants

- Rehearsal registry must resolve to an entry in \`opts.registries\`.
  Fails clean with a fix-suggesting error otherwise.
- Rehearsal registry must differ from the live target (\`ws.plan.registry\`).
  Refuses otherwise — the whole point is a sandbox.
- Sequential execution; stops at first failure.
- Does NOT touch \`state.json\`. Rehearsal is a pre-publish *proof*, not
  an execution. Event log only, so the regular publish flow sees a
  clean state dir.
- \`--skip-rehearsal\` honored with a loud warning; outcome still
  returned so the eventual hard gate can detect it.

## Scope — explicitly NOT in this PR

- **Hard gate** wiring \`run_publish\` → refuse without a passing
  rehearsal (#97 PR 3).
- **Install / smoke check** against the rehearsal registry (PR 3 or 4
  — needs a consumer-workspace fixture).
- **plan_id binding** of rehearsal outcome (needed alongside the hard
  gate; simpler to land together).
- **Parallel rehearsal** (not planned — correctness > speed for a
  once-per-release rehearsal).

## Tests

6 unit tests in \`engine::tests\`, all passing:

- errors cleanly with no rehearsal registry
- errors cleanly when rehearsal == live target
- errors cleanly when the named registry isn't configured
- \`--skip-rehearsal\` returns immediately, no events written
- happy path emits Started + PackagePublished + Complete(passed=true)
- cargo-failure path emits PackageFailed + Complete(passed=false)

CLI snapshots regenerated to reflect the new \`rehearse\` subcommand in
help output.

## Test plan

- [x] \`cargo test -p shipper --lib run_rehearsal\` — 6/6 pass
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [x] \`shipper rehearse --help\` surfaces the new subcommand correctly
- [ ] CI multi-OS green