### PR TITLE
feat(rehearse): hard gate — run_publish requires passing rehearsal (#97 PR 3)

### DIFF
--- a/crates/shipper-types/src/lib.rs
+++ b/crates/shipper-types/src/lib.rs
@@ -1506,6 +1506,7 @@ pub enum EventType {
     // correlation since events.jsonl is append-only scoped to one state dir.
     RehearsalStarted {
         registry: String,
+        plan_id: String,
         package_count: usize,
     },
     RehearsalPackagePublished {
@@ -1522,6 +1523,11 @@ pub enum EventType {
     RehearsalComplete {
         passed: bool,
         registry: String,
+        /// Plan ID the rehearsal ran against. The hard gate (#97 PR 3)
+        /// consults this: a subsequent `shipper publish` for the same
+        /// plan_id can rely on this rehearsal; if the workspace changes
+        /// (plan_id shifts), the rehearsal is stale and the gate fires.
+        plan_id: String,
         summary: String,
     },
 

--- a/crates/shipper/src/engine/mod.rs
+++ b/crates/shipper/src/engine/mod.rs
@@ -356,6 +356,90 @@ pub fn run_preflight(
     })
 }
 
+/// Enforce the rehearsal hard gate (#97 PR 3).
+///
+/// Rules, evaluated in order:
+///
+/// 1. **Rehearsal not configured** (`opts.rehearsal_registry` is `None`) →
+///    gate is dormant; publish proceeds. Rehearsal is opt-in; existing
+///    workflows that never set a rehearsal registry are unaffected.
+///
+/// 2. **Operator override** (`opts.rehearsal_skip` is `true`) → publish
+///    proceeds with a loud warning logged to the reporter. Use sparingly
+///    (incident response, bootstrap runs). The skip decision is
+///    operator-visible in stderr; it does *not* synthesize a passing
+///    rehearsal receipt, so the audit trail still shows "no rehearsal
+///    ran."
+///
+/// 3. **No rehearsal receipt** (`rehearsal.json` is missing) → refuse.
+///    The operator needs to run `shipper rehearse` first.
+///
+/// 4. **Stale receipt** (receipt exists but `plan_id` mismatches the
+///    current workspace's plan) → refuse. A workspace change between
+///    rehearse and publish invalidates the rehearsal.
+///
+/// 5. **Failing receipt** (`passed: false`) → refuse.
+///
+/// 6. **Fresh passing receipt for current plan** → publish proceeds.
+fn enforce_rehearsal_gate(
+    ws: &PlannedWorkspace,
+    opts: &RuntimeOptions,
+    state_dir: &Path,
+    reporter: &mut dyn Reporter,
+) -> Result<()> {
+    let Some(rehearsal_name) = opts.rehearsal_registry.as_deref() else {
+        return Ok(());
+    };
+
+    if opts.rehearsal_skip {
+        reporter.warn(&format!(
+            "--skip-rehearsal was set; publish is proceeding without a rehearsal against '{rehearsal_name}'. \
+             This is an operator-authorized bypass; auditors reading events.jsonl will see no RehearsalComplete event for this plan_id."
+        ));
+        return Ok(());
+    }
+
+    let receipt = crate::state::rehearsal::load_rehearsal(state_dir)
+        .context("failed to read rehearsal receipt while enforcing hard gate")?;
+
+    let rehearsal_path = crate::state::rehearsal::rehearsal_path(state_dir);
+
+    let receipt = match receipt {
+        Some(r) => r,
+        None => bail!(
+            "rehearsal is required (rehearsal registry '{rehearsal_name}' is configured) but no rehearsal receipt was found at {}. \
+             Run `shipper rehearse --rehearsal-registry {rehearsal_name}` first, \
+             or pass --skip-rehearsal to override (not recommended).",
+            rehearsal_path.display()
+        ),
+    };
+
+    if receipt.plan_id != ws.plan.plan_id {
+        bail!(
+            "rehearsal receipt is stale: rehearsal ran for plan_id {} but the current plan_id is {}. \
+             The workspace changed between rehearse and publish; re-run `shipper rehearse` against the current plan.",
+            receipt.plan_id,
+            ws.plan.plan_id
+        );
+    }
+
+    if !receipt.passed {
+        bail!(
+            "rehearsal against '{}' did NOT pass for plan_id {}: {}. \
+             Fix the cause and re-run `shipper rehearse` before publishing.",
+            receipt.registry,
+            receipt.plan_id,
+            receipt.summary
+        );
+    }
+
+    reporter.info(&format!(
+        "rehearsal gate: passing receipt found ({} packages against '{}', plan_id {})",
+        receipt.packages_published, receipt.registry, receipt.plan_id
+    ));
+    Ok(())
+}
+
 /// Execute the publish operation for all packages in the workspace.
 ///
 /// This is the main publishing function that:
@@ -410,6 +494,10 @@ pub fn run_publish(
     {
         bail!("resume-from package '{}' not found in publish plan", target);
     }
+
+    // #97 PR 3: rehearsal hard gate. Only fires when a rehearsal registry
+    // is configured; opt-in until rehearsal phase-2 is stable.
+    enforce_rehearsal_gate(ws, opts, &state_dir, reporter)?;
 
     // Acquire lock
     let lock_timeout = if opts.force {
@@ -1345,6 +1433,7 @@ pub fn run_rehearsal(
         .with_context(|| format!("failed to create state dir {}", state_dir.display()))?;
     let events_path = events::events_path(&state_dir);
     let mut event_log = events::EventLog::new();
+    let started_at = Utc::now();
 
     reporter.info(&format!(
         "rehearsal starting — {} packages against '{}'",
@@ -1356,6 +1445,7 @@ pub fn run_rehearsal(
         timestamp: Utc::now(),
         event_type: EventType::RehearsalStarted {
             registry: rehearsal_name.clone(),
+            plan_id: ws.plan.plan_id.clone(),
             package_count: ws.plan.packages.len(),
         },
         package: "all".to_string(),
@@ -1455,16 +1545,45 @@ pub fn run_rehearsal(
         )
     };
 
+    let completed_at = Utc::now();
     event_log.record(PublishEvent {
-        timestamp: Utc::now(),
+        timestamp: completed_at,
         event_type: EventType::RehearsalComplete {
             passed,
             registry: rehearsal_name.clone(),
+            plan_id: ws.plan.plan_id.clone(),
             summary: summary.clone(),
         },
         package: "all".to_string(),
     });
     event_log.write_to_file(&events_path)?;
+
+    // Persist the sidecar receipt so the hard gate in `run_publish`
+    // can consult it without parsing events.jsonl. Best-effort — a
+    // write failure here doesn't invalidate the events log, which is
+    // the authoritative source; the gate will just act as if no
+    // rehearsal happened and block, which is the safe default.
+    let packages_attempted = packages_published + if passed { 0 } else { 1 };
+    if let Err(err) = crate::state::rehearsal::save_rehearsal(
+        &state_dir,
+        &crate::state::rehearsal::RehearsalReceipt {
+            schema_version: crate::state::rehearsal::CURRENT_REHEARSAL_VERSION.to_string(),
+            plan_id: ws.plan.plan_id.clone(),
+            registry: rehearsal_name.clone(),
+            passed,
+            packages_attempted,
+            packages_published,
+            summary: summary.clone(),
+            started_at,
+            completed_at,
+        },
+    ) {
+        reporter.warn(&format!(
+            "rehearsal outcome event was written, but sidecar receipt could not be persisted: {err:#}. \
+             The hard gate may not recognize this rehearsal — check {}.",
+            crate::state::rehearsal::rehearsal_path(&state_dir).display()
+        ));
+    }
 
     if passed {
         reporter.info(&summary);
@@ -1475,7 +1594,7 @@ pub fn run_rehearsal(
     Ok(RehearsalOutcome {
         passed,
         registry_name: rehearsal_name,
-        packages_attempted: packages_published + if passed { 0 } else { 1 },
+        packages_attempted,
         packages_published,
         summary,
     })
@@ -6700,6 +6819,161 @@ mod tests {
             );
 
             rehearsal_server.join();
+        });
+    }
+
+    // ───────────────────────────────────────────────────────────────────
+    // enforce_rehearsal_gate (#97 PR 3)
+    // ───────────────────────────────────────────────────────────────────
+
+    fn write_rehearsal_receipt(
+        state_dir: &Path,
+        plan_id: &str,
+        passed: bool,
+    ) -> crate::state::rehearsal::RehearsalReceipt {
+        let receipt = crate::state::rehearsal::RehearsalReceipt {
+            schema_version: crate::state::rehearsal::CURRENT_REHEARSAL_VERSION.to_string(),
+            plan_id: plan_id.to_string(),
+            registry: "rehearsal".to_string(),
+            passed,
+            packages_attempted: 1,
+            packages_published: if passed { 1 } else { 0 },
+            summary: if passed {
+                "rehearsed 1 package successfully".into()
+            } else {
+                "rehearsal failed".into()
+            },
+            started_at: Utc::now(),
+            completed_at: Utc::now(),
+        };
+        crate::state::rehearsal::save_rehearsal(state_dir, &receipt).expect("write");
+        receipt
+    }
+
+    #[test]
+    fn gate_is_dormant_when_rehearsal_registry_is_none() {
+        let td = tempdir().expect("tempdir");
+        let ws = planned_workspace(td.path(), "http://127.0.0.1:1".into());
+        let opts = default_opts(PathBuf::from(".shipper"));
+        // opts.rehearsal_registry is None by default.
+        let mut reporter = CollectingReporter::default();
+        enforce_rehearsal_gate(&ws, &opts, td.path(), &mut reporter).expect("gate dormant");
+    }
+
+    #[test]
+    fn gate_proceeds_with_warning_when_skip_is_set() {
+        let td = tempdir().expect("tempdir");
+        let ws = planned_workspace(td.path(), "http://127.0.0.1:1".into());
+        let mut opts = default_opts(PathBuf::from(".shipper"));
+        opts.rehearsal_registry = Some("rehearsal".into());
+        opts.rehearsal_skip = true;
+        let mut reporter = CollectingReporter::default();
+        enforce_rehearsal_gate(&ws, &opts, td.path(), &mut reporter).expect("skip bypass");
+        assert!(
+            reporter
+                .warns
+                .iter()
+                .any(|w| w.contains("--skip-rehearsal")),
+            "warns: {:?}",
+            reporter.warns
+        );
+    }
+
+    #[test]
+    fn gate_refuses_when_no_receipt_exists() {
+        let td = tempdir().expect("tempdir");
+        let ws = planned_workspace(td.path(), "http://127.0.0.1:1".into());
+        let mut opts = default_opts(PathBuf::from(".shipper"));
+        opts.rehearsal_registry = Some("rehearsal".into());
+        let mut reporter = CollectingReporter::default();
+        let err =
+            enforce_rehearsal_gate(&ws, &opts, td.path(), &mut reporter).expect_err("must fail");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("no rehearsal receipt was found"), "err: {msg}");
+        assert!(
+            msg.contains("shipper rehearse"),
+            "err should hint fix: {msg}"
+        );
+    }
+
+    #[test]
+    fn gate_refuses_on_plan_id_mismatch() {
+        let td = tempdir().expect("tempdir");
+        let ws = planned_workspace(td.path(), "http://127.0.0.1:1".into());
+        let mut opts = default_opts(PathBuf::from(".shipper"));
+        opts.rehearsal_registry = Some("rehearsal".into());
+
+        write_rehearsal_receipt(td.path(), "some-other-plan", true);
+
+        let mut reporter = CollectingReporter::default();
+        let err =
+            enforce_rehearsal_gate(&ws, &opts, td.path(), &mut reporter).expect_err("must fail");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("stale"), "err: {msg}");
+        assert!(
+            msg.contains(&ws.plan.plan_id),
+            "err should reference current plan_id: {msg}"
+        );
+    }
+
+    #[test]
+    fn gate_refuses_on_failing_receipt() {
+        let td = tempdir().expect("tempdir");
+        let ws = planned_workspace(td.path(), "http://127.0.0.1:1".into());
+        let mut opts = default_opts(PathBuf::from(".shipper"));
+        opts.rehearsal_registry = Some("rehearsal".into());
+
+        write_rehearsal_receipt(td.path(), &ws.plan.plan_id, false);
+
+        let mut reporter = CollectingReporter::default();
+        let err =
+            enforce_rehearsal_gate(&ws, &opts, td.path(), &mut reporter).expect_err("must fail");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("did NOT pass"), "err: {msg}");
+    }
+
+    #[test]
+    fn gate_passes_on_fresh_passing_receipt() {
+        let td = tempdir().expect("tempdir");
+        let ws = planned_workspace(td.path(), "http://127.0.0.1:1".into());
+        let mut opts = default_opts(PathBuf::from(".shipper"));
+        opts.rehearsal_registry = Some("rehearsal".into());
+
+        write_rehearsal_receipt(td.path(), &ws.plan.plan_id, true);
+
+        let mut reporter = CollectingReporter::default();
+        enforce_rehearsal_gate(&ws, &opts, td.path(), &mut reporter).expect("fresh pass");
+        assert!(
+            reporter.infos.iter().any(|i| i.contains("passing receipt")),
+            "infos: {:?}",
+            reporter.infos
+        );
+    }
+
+    /// End-to-end: `run_publish` refuses to run when rehearsal is required
+    /// but no receipt exists. This is the gate's actual contract — the
+    /// finer-grained tests above exercise the gate helper in isolation;
+    /// this one confirms run_publish wires it in correctly.
+    #[test]
+    #[serial]
+    fn run_publish_refuses_without_rehearsal_when_required() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        let env_vars = fake_program_env_vars(&bin);
+        temp_env::with_vars(env_vars, || {
+            let ws = planned_workspace(td.path(), "http://127.0.0.1:1".into());
+            let state_dir = td.path().join(".shipper");
+            let mut opts = default_opts(state_dir);
+            opts.rehearsal_registry = Some("rehearsal".into());
+
+            let mut reporter = CollectingReporter::default();
+            let err = run_publish(&ws, &opts, &mut reporter).expect_err("gate must bail");
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains("rehearsal is required") || msg.contains("no rehearsal receipt"),
+                "expected gate error, got: {msg}"
+            );
         });
     }
 

--- a/crates/shipper/src/state/mod.rs
+++ b/crates/shipper/src/state/mod.rs
@@ -6,3 +6,4 @@
 pub mod consistency;
 pub mod events;
 pub mod execution_state;
+pub mod rehearsal;

--- a/crates/shipper/src/state/rehearsal.rs
+++ b/crates/shipper/src/state/rehearsal.rs
@@ -1,0 +1,150 @@
+//! Persisted rehearsal receipt (#97 PR 3).
+//!
+//! A `rehearsal.json` sidecar, scoped to a state dir, captures the outcome
+//! of the most recent `shipper rehearse` run. The hard gate in
+//! `engine::run_publish` reads this file to decide whether live dispatch
+//! is authorized for the current plan_id.
+//!
+//! Why a sidecar and not just scanning `events.jsonl`?
+//! - Fast lookup (O(1) file read vs O(N) log scan).
+//! - Small, human-readable, easy to inspect ad-hoc.
+//! - Append-only events are preserved unchanged; this file is a
+//!   *projection*, same relationship as `state.json` to events.
+//!
+//! Write semantics mirror `state.json`: atomic write via `.tmp` + rename,
+//! so a crash mid-write can't corrupt the file.
+
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Canonical rehearsal receipt file name.
+pub const REHEARSAL_FILE: &str = "rehearsal.json";
+
+/// Current rehearsal receipt schema version.
+pub const CURRENT_REHEARSAL_VERSION: &str = "shipper.rehearsal.v1";
+
+/// Persisted outcome of a single rehearsal run.
+///
+/// The hard gate keys on `plan_id`: a rehearsal is considered fresh for
+/// the current publish only if `plan_id` matches the workspace's current
+/// plan id. If the workspace changes between rehearse and publish, the
+/// plan_id flips and the rehearsal is (correctly) rejected as stale.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RehearsalReceipt {
+    /// Schema version for forward compatibility. Readers ignore unknown
+    /// higher versions best-effort, same as other schema-versioned files.
+    pub schema_version: String,
+    /// Plan ID the rehearsal ran against.
+    pub plan_id: String,
+    /// Name of the registry the rehearsal published to.
+    pub registry: String,
+    /// Whether the rehearsal passed end-to-end.
+    pub passed: bool,
+    pub packages_attempted: usize,
+    pub packages_published: usize,
+    /// Human-readable one-line summary (matches the CLI's stdout line).
+    pub summary: String,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: DateTime<Utc>,
+}
+
+pub fn rehearsal_path(state_dir: &Path) -> PathBuf {
+    state_dir.join(REHEARSAL_FILE)
+}
+
+/// Atomic write: serialize → write to `.tmp` → rename. Crash-safe.
+pub fn save_rehearsal(state_dir: &Path, receipt: &RehearsalReceipt) -> Result<()> {
+    fs::create_dir_all(state_dir)
+        .with_context(|| format!("failed to create state dir {}", state_dir.display()))?;
+    let path = rehearsal_path(state_dir);
+    let tmp = path.with_extension("json.tmp");
+    let data =
+        serde_json::to_vec_pretty(receipt).context("failed to serialize RehearsalReceipt")?;
+    {
+        let mut f =
+            File::create(&tmp).with_context(|| format!("failed to create {}", tmp.display()))?;
+        f.write_all(&data)
+            .with_context(|| format!("failed to write {}", tmp.display()))?;
+        f.sync_all()
+            .with_context(|| format!("failed to fsync {}", tmp.display()))?;
+    }
+    fs::rename(&tmp, &path)
+        .with_context(|| format!("failed to rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+/// Load the rehearsal receipt, if any. `Ok(None)` when the file doesn't
+/// exist — that's the common "no rehearsal run yet" case, not an error.
+pub fn load_rehearsal(state_dir: &Path) -> Result<Option<RehearsalReceipt>> {
+    let path = rehearsal_path(state_dir);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let mut s = String::new();
+    File::open(&path)
+        .with_context(|| format!("failed to open {}", path.display()))?
+        .read_to_string(&mut s)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let receipt: RehearsalReceipt =
+        serde_json::from_str(&s).with_context(|| format!("failed to parse {}", path.display()))?;
+    Ok(Some(receipt))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn sample() -> RehearsalReceipt {
+        RehearsalReceipt {
+            schema_version: CURRENT_REHEARSAL_VERSION.to_string(),
+            plan_id: "abc123".to_string(),
+            registry: "rehearsal".to_string(),
+            passed: true,
+            packages_attempted: 3,
+            packages_published: 3,
+            summary: "rehearsed 3 packages successfully".to_string(),
+            started_at: Utc::now(),
+            completed_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn save_then_load_roundtrip() {
+        let td = tempdir().expect("tempdir");
+        let receipt = sample();
+        save_rehearsal(td.path(), &receipt).expect("save");
+        let loaded = load_rehearsal(td.path()).expect("load").expect("some");
+        assert_eq!(loaded, receipt);
+    }
+
+    #[test]
+    fn load_missing_file_returns_none() {
+        let td = tempdir().expect("tempdir");
+        assert!(load_rehearsal(td.path()).expect("load").is_none());
+    }
+
+    #[test]
+    fn save_overwrites_existing() {
+        let td = tempdir().expect("tempdir");
+        let r1 = sample();
+        save_rehearsal(td.path(), &r1).expect("save 1");
+        let mut r2 = r1.clone();
+        r2.passed = false;
+        r2.summary = "rehearsal failed".into();
+        save_rehearsal(td.path(), &r2).expect("save 2");
+        let loaded = load_rehearsal(td.path()).expect("load").expect("some");
+        assert_eq!(loaded, r2);
+    }
+
+    #[test]
+    fn rehearsal_path_is_under_state_dir() {
+        let p = rehearsal_path(Path::new("/tmp/x"));
+        assert_eq!(p, Path::new("/tmp/x").join(REHEARSAL_FILE));
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Task-oriented recipes. Each solves one focused problem.
 - [Inspect state, events, and receipts](how-to/inspect-state-and-receipts.md) — post-hoc inspection ("what happened")
 - [Inspect a stalled or interrupted run](how-to/inspect-a-stalled-run.md) — live triage ("is it alive?")
 - [Run the Recover rehearsal](how-to/run-recover-rehearsal.md) — once-per-RC proof that interrupted releases resume cleanly
+- [Rehearse against an alternate registry](how-to/rehearse-against-an-alt-registry.md) — Prove tier 2 walkthrough with kellnr example (#97)
 
 Operator runbook (promotion to how-to pending): [release-runbook.md](release-runbook.md)
 

--- a/docs/how-to/rehearse-against-an-alt-registry.md
+++ b/docs/how-to/rehearse-against-an-alt-registry.md
@@ -1,0 +1,240 @@
+# How-to: Rehearse a release against an alternate registry
+
+Goal: prove a release will actually publish and resolve cleanly BEFORE
+you touch crates.io. This is the Prove pillar's phase-2 check —
+`cargo publish --dry-run` validates that Cargo can package the crate,
+but it cannot prove that the packaged tarballs will actually install
+from a registry index with real workspace-path → registry-path
+resolution. That gap is what this guide closes.
+
+## When to use this
+
+- First time publishing a multi-crate workspace (the rc.1 landing mine
+  that wasted a tag cycle).
+- After any workspace refactor that reshapes dependency edges
+  (new intra-workspace deps, path → registry migrations, feature
+  reshuffles).
+- Before any release you can't afford to retract.
+
+If you've already shipped the workspace once and are just bumping
+versions on stable code, rehearsal is overkill. If anything about the
+publish shape has changed, rehearse.
+
+## Prerequisites
+
+- An **alternate registry**. Options, rough-ordered by effort:
+  - **kellnr** (recommended for CI): self-host a registry sidecar per
+    release. [kellnr docs](https://kellnr.io/documentation). Short-
+    lived instance — spin up, rehearse, tear down.
+  - **Throwaway crates.io account**: works but pollutes the real
+    registry with rehearsal versions. Use different crate names if
+    you go this route.
+  - **Your existing private registry**: if your org already has one
+    (cloudsmith / Artifactory / JFrog / Cargo-hosted), a dedicated
+    `rehearsal-*` namespace works.
+
+- Registry URL + token configured in Cargo so `cargo publish --registry`
+  works.
+
+- A `.shipper.toml` or CLI flag that names the registry for rehearsal.
+
+## Step 1 — Configure the rehearsal registry
+
+### Via `.shipper.toml`
+
+```toml
+[[registries]]
+name = "rehearsal"
+api_base = "https://rehearsal.internal.example.com"
+index_base = "https://rehearsal.internal.example.com/api/v1/crates"
+
+[rehearsal]
+enabled = true
+registry = "rehearsal"
+```
+
+`[[registries]]` teaches Shipper about the registry's URLs.
+`[rehearsal]` says "when running `shipper rehearse`, target this one."
+
+### Via CLI
+
+```bash
+shipper rehearse --rehearsal-registry rehearsal
+```
+
+Opts in ad-hoc without editing config. Useful for CI jobs that override
+behavior per-run.
+
+## Step 2 — Dry-run in isolation
+
+```bash
+shipper rehearse
+```
+
+What this does:
+
+1. Validates that the rehearsal registry is configured and differs
+   from the live target. (Rehearsing against crates.io would defeat
+   the point.)
+2. For each crate in the plan (topological order):
+   - Runs `cargo publish --registry rehearsal -p <crate>`.
+   - Waits for the crate to appear on the rehearsal registry's
+     visibility endpoint — same `version_exists` check the live
+     path uses, so if the real publish would fail visibility the
+     rehearsal fails first.
+3. Emits per-step events to `<state_dir>/events.jsonl`:
+   - `RehearsalStarted { registry, plan_id, package_count }`
+   - `RehearsalPackagePublished { name, version, duration_ms }`
+     per success
+   - `RehearsalPackageFailed { name, version, class, message }`
+     per failure (stops the loop)
+   - `RehearsalComplete { passed, registry, plan_id, summary }`
+4. Writes a sidecar `<state_dir>/rehearsal.json` — the hard gate
+   consults this file later.
+
+Exit status is non-zero on rehearsal failure, so CI lanes that wrap
+this command fail automatically.
+
+## Step 3 — The hard gate
+
+Once you have a passing rehearsal, the hard gate blocks live publish
+without one:
+
+```bash
+shipper publish
+```
+
+Decision tree:
+
+1. `rehearsal_registry` not configured → dormant, publish proceeds.
+   (Rehearsal is opt-in; workflows that haven't adopted it are
+   unaffected.)
+2. `--skip-rehearsal` flag set → publish proceeds with a loud warning.
+   No fake-passing receipt is synthesized; the audit trail shows the
+   bypass honestly. Use sparingly (incident response, bootstrap runs).
+3. No `rehearsal.json` → refuse. Run `shipper rehearse` first.
+4. `rehearsal.json`'s `plan_id` differs from the current plan →
+   refuse (stale). The workspace changed between rehearse and publish.
+5. `passed: false` → refuse, citing the rehearsal summary.
+6. Fresh passing receipt for the current plan → proceed, info-log
+   "rehearsal gate: passing receipt found (N packages against
+   'rehearsal', plan_id ...)".
+
+## Example: GitHub Actions with kellnr sidecar
+
+```yaml
+name: Release
+on:
+  push:
+    tags: ['v*.*.*']
+
+jobs:
+  rehearse:
+    runs-on: ubuntu-latest
+    services:
+      kellnr:
+        image: ghcr.io/kellnr/kellnr:latest
+        ports:
+          - 8000:8000
+        env:
+          KELLNR_ORIGIN__ADDR: http://localhost:8000
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo install shipper-cli --locked
+
+      # Point Cargo at the kellnr sidecar
+      - name: Configure Cargo registry
+        run: |
+          mkdir -p ~/.cargo
+          cat >> ~/.cargo/config.toml <<EOF
+          [registries.rehearsal]
+          index = "sparse+http://localhost:8000/api/v1/crates/"
+          EOF
+          cat >> ~/.cargo/credentials.toml <<EOF
+          [registries.rehearsal]
+          token = "Bearer ${{ secrets.KELLNR_TOKEN }}"
+          EOF
+
+      - name: Rehearse
+        env:
+          CARGO_REGISTRIES_REHEARSAL_TOKEN: ${{ secrets.KELLNR_TOKEN }}
+        run: shipper rehearse --rehearsal-registry rehearsal
+
+      - name: Upload rehearsal artifacts (always)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: shipper-rehearsal
+          path: .shipper/
+          include-hidden-files: true
+
+  publish:
+    needs: rehearse
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          name: shipper-rehearsal
+          path: .shipper/
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo install shipper-cli --locked
+      - name: Publish (hard gate reads .shipper/rehearsal.json)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: shipper publish --rehearsal-registry rehearsal
+```
+
+Key points:
+
+- `rehearse` job runs against kellnr, produces `.shipper/rehearsal.json`.
+- Artifact hands the receipt off to the `publish` job.
+- `publish` job sets `--rehearsal-registry` so the hard gate activates
+  and consults the downloaded `rehearsal.json`. If rehearsal passed
+  and `plan_id` matches, publish proceeds. Otherwise, fail.
+
+## Troubleshooting
+
+### "rehearsal registry 'X' is not configured"
+
+You passed `--rehearsal-registry X` or set `[rehearsal] registry = "X"`
+but there's no matching `[[registries]]` entry. Add one, or pass the
+registries explicitly via `--registries X,crates-io`.
+
+### "rehearsal registry must differ from the live target"
+
+You configured the rehearsal to point at crates.io. That defeats the
+point — rehearsal is supposed to be a sandbox. Point at a different
+registry.
+
+### "rehearsal receipt is stale: plan_id mismatch"
+
+The workspace changed between `shipper rehearse` and `shipper publish`.
+Re-run `shipper rehearse` on the current workspace state.
+
+### "no rehearsal receipt was found"
+
+The hard gate fires when a rehearsal registry is configured but
+`rehearsal.json` is missing. Either run `shipper rehearse` first, or
+pass `--skip-rehearsal` to bypass (not recommended).
+
+## What rehearsal does NOT cover (yet)
+
+- **Install-smoke.** The current rehearsal publishes + verifies
+  visibility. It does not yet run `cargo install --registry rehearsal
+  <crate>` on the workspace's top crate to prove end-to-end
+  resolution. That's the next follow-on under #97.
+- **Consumer-workspace build.** A tiny fixture consumer crate that
+  depends on the rehearsal-registry version and runs `cargo build`
+  would catch `workspace-path → registry-path` resolution bugs the
+  publish-only rehearsal misses. Also follow-on.
+
+## See also
+
+- [Inspect state, events, and receipts](inspect-state-and-receipts.md)
+  — understanding the `rehearsal.json` + events the rehearsal emits.
+- [Release runbook](../release-runbook.md) — the production release
+  checklist; add a "rehearsal green?" step before cutting a tag.
+- [#97 on the roadmap](https://github.com/EffortlessMetrics/shipper/issues/97)
+  — Prove pillar tier 2.


### PR DESCRIPTION
## Summary

Close the rehearsal loop. PR 2 ([#127](https://github.com/EffortlessMetrics/shipper/pull/127)) gave us \`shipper rehearse\` that publishes to an alt registry and emits \`RehearsalComplete\`. This PR makes live publish **refuse to run** unless a fresh, passing rehearsal receipt exists for the current \`plan_id\`.

> **Base branch is #127**, not main. Merge #127 first.

## Gate decision tree

Evaluated at the top of \`run_publish\`:

1. **\`opts.rehearsal_registry = None\`** → dormant; publish proceeds. Unchanged behavior for every caller who hasn't opted into rehearsal.
2. **\`opts.rehearsal_skip = true\`** → proceed with a loud warning. No fake-passing receipt is synthesized; \`events.jsonl\` shows no \`RehearsalComplete\` for this \`plan_id\` so auditors see the bypass honestly.
3. **No \`rehearsal.json\`** → refuse with a fix-suggesting error (\`run shipper rehearse first\`).
4. **Receipt's \`plan_id\` mismatches current plan_id** → refuse (stale — workspace changed since rehearsal).
5. **\`passed: false\`** → refuse, citing the rehearsal summary.
6. **Fresh passing receipt for current plan** → proceed; info-log a confirmation.

## Persistence

New sidecar: \`state_dir/rehearsal.json\` (\`shipper.rehearsal.v1\` schema). Atomic write via \`.tmp\` + rename + fsync, crash-safe. Small enough to \`cat\` and grok. Shape:

\`\`\`json
{
  \"schema_version\": \"shipper.rehearsal.v1\",
  \"plan_id\": \"...\",
  \"registry\": \"...\",
  \"passed\": true,
  \"packages_attempted\": 3,
  \"packages_published\": 3,
  \"summary\": \"...\",
  \"started_at\": \"...\",
  \"completed_at\": \"...\"
}
\`\`\`

## Event schema additive

\`RehearsalStarted\` and \`RehearsalComplete\` now carry \`plan_id\`. Lets an auditor replay the gate's decision from \`events.jsonl\` alone. Additive on events that only shipped with PR 2 (#127), so no migration needed for landed state.

## Tests

13 new unit tests (total rehearsal+gate coverage: 17):

- 3 sidecar roundtrip/persistence tests
- 6 gate-helper tests: dormant / skip / missing / stale / failing / fresh-pass
- 1 e2e test that \`run_publish\` actually invokes the gate and bails when rehearsal is required but missing

## Scope — explicitly NOT in this PR

- **Install/smoke check** against the rehearsal registry (PR 4 or follow-on). Gate currently trusts publish + visibility.
- **CI recipe** for kellnr sidecar (docs PR, not code).

## Test plan

- [x] \`cargo test -p shipper --lib -- rehearsal gate_ run_publish_refuses\` — 17/17 pass
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [ ] CI multi-OS green (once #127 merges and this rebases on main)