### PR TITLE
fix(resume): silent-skip event + Failed→Skipped regression test (#125, #126)

### DIFF
--- a/crates/shipper/src/engine/mod.rs
+++ b/crates/shipper/src/engine/mod.rs
@@ -605,12 +605,33 @@ pub fn run_publish(
 
         match progress.state.clone() {
             PackageState::Published | PackageState::Skipped { .. } => {
+                let short = short_state(&progress.state);
                 reporter.info(&format!(
                     "{}@{}: already complete ({})",
-                    p.name,
-                    p.version,
-                    short_state(&progress.state)
+                    p.name, p.version, short
                 ));
+                // #125: emit a PackageSkipped event so the audit trail
+                // explicitly records resume's "state already terminal,
+                // trusting it" decision. Without this, events.jsonl is
+                // silent about the skip and an auditor reading only
+                // events can't distinguish "resume recognized and
+                // skipped" from "resume never touched this package."
+                //
+                // Deliberately NOT pushing a PackageReceipt here: the
+                // receipt vector has always excluded already-terminal
+                // packages in the resume path, and callers depend on
+                // that shape (see e.g. `run_resume_runs_publish_when_state_exists`).
+                // The new event is the observable fix; receipt shape
+                // is preserved.
+                event_log.record(PublishEvent {
+                    timestamp: Utc::now(),
+                    event_type: EventType::PackageSkipped {
+                        reason: format!("resume: state already {short}"),
+                    },
+                    package: pkg_label.clone(),
+                });
+                event_log.write_to_file(&events_path)?;
+                event_log.clear();
                 continue;
             }
             PackageState::Uploaded => {
@@ -2257,6 +2278,142 @@ mod tests {
             let state_dir = td.path().join(".shipper");
             assert!(state::state_path(&state_dir).exists());
             assert!(state::receipt_path(&state_dir).exists());
+            server.join();
+        });
+    }
+
+    /// Regression for #125: resume encountering a `Published` state in
+    /// state.json must emit a `PackageSkipped` event, not silently move
+    /// on. events.jsonl is the authoritative audit log; a silent skip
+    /// makes "did resume look at this package at all?" unanswerable from
+    /// the log alone.
+    #[test]
+    #[serial]
+    fn resume_emits_package_skipped_event_for_already_published_state() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        let env_vars = fake_program_env_vars(&bin);
+        temp_env::with_vars(env_vars, || {
+            let server = spawn_registry_server(
+                std::collections::BTreeMap::from([(
+                    "/api/v1/crates/demo/0.1.0".to_string(),
+                    vec![(404, "{}".to_string())],
+                )]),
+                1,
+            );
+            let ws = planned_workspace(td.path(), server.base_url.clone());
+            let state_dir = td.path().join(".shipper");
+
+            // Seed: existing state says demo@0.1.0 is Published. Resume
+            // should recognize it and skip — but crucially, emit the event.
+            let mut packages = BTreeMap::new();
+            packages.insert(
+                "demo@0.1.0".to_string(),
+                PackageProgress {
+                    name: "demo".to_string(),
+                    version: "0.1.0".to_string(),
+                    attempts: 1,
+                    state: PackageState::Published,
+                    last_updated_at: Utc::now(),
+                },
+            );
+            let seeded = ExecutionState {
+                state_version: crate::state::execution_state::CURRENT_STATE_VERSION.to_string(),
+                plan_id: ws.plan.plan_id.clone(),
+                registry: ws.plan.registry.clone(),
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                packages,
+            };
+            state::save_state(&state_dir, &seeded).expect("seed state");
+
+            let opts = default_opts(PathBuf::from(".shipper"));
+            let mut reporter = CollectingReporter::default();
+            let _receipt = run_publish(&ws, &opts, &mut reporter).expect("publish resumes");
+
+            // Read events.jsonl and assert a PackageSkipped event exists.
+            let events_path = events::events_path(&state_dir);
+            let raw = std::fs::read_to_string(&events_path).expect("events.jsonl");
+            let skipped_count = raw
+                .lines()
+                .filter(|l| !l.trim().is_empty())
+                .filter(|l| l.contains(r#""type":"package_skipped""#))
+                .count();
+            assert!(
+                skipped_count >= 1,
+                "expected at least one PackageSkipped event for the already-Published package; \
+                 events.jsonl was:\n{raw}"
+            );
+        });
+    }
+
+    /// Regression for #126: when resume encounters a `Failed` state and
+    /// the registry confirms the version is visible, `state.json` must
+    /// transition that package from Failed to Skipped. A stale `failed`
+    /// flag misleads downstream tools (e.g. plan-yank) into thinking
+    /// remediation is needed when it isn't.
+    #[test]
+    #[serial]
+    fn resume_from_failed_ambiguous_updates_state_to_skipped_when_registry_visible() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        let env_vars = fake_program_env_vars(&bin);
+        temp_env::with_vars(env_vars, || {
+            // Registry returns 200 for the version check — the crate IS
+            // visible, even though run 1 left us with Failed/Ambiguous.
+            let server = spawn_registry_server(
+                std::collections::BTreeMap::from([(
+                    "/api/v1/crates/demo/0.1.0".to_string(),
+                    vec![(200, "{}".to_string())],
+                )]),
+                1,
+            );
+            let ws = planned_workspace(td.path(), server.base_url.clone());
+            let state_dir = td.path().join(".shipper");
+
+            let mut packages = BTreeMap::new();
+            packages.insert(
+                "demo@0.1.0".to_string(),
+                PackageProgress {
+                    name: "demo".to_string(),
+                    version: "0.1.0".to_string(),
+                    attempts: 1,
+                    state: PackageState::Failed {
+                        class: ErrorClass::Ambiguous,
+                        message: "prior run: publish outcome ambiguous".to_string(),
+                    },
+                    last_updated_at: Utc::now(),
+                },
+            );
+            let seeded = ExecutionState {
+                state_version: crate::state::execution_state::CURRENT_STATE_VERSION.to_string(),
+                plan_id: ws.plan.plan_id.clone(),
+                registry: ws.plan.registry.clone(),
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                packages,
+            };
+            state::save_state(&state_dir, &seeded).expect("seed state");
+
+            let opts = default_opts(PathBuf::from(".shipper"));
+            let mut reporter = CollectingReporter::default();
+            let _receipt = run_publish(&ws, &opts, &mut reporter).expect("publish resumes");
+
+            // State.json on disk must now say Skipped, not Failed.
+            let reloaded = state::load_state(&state_dir)
+                .expect("load")
+                .expect("state exists");
+            let pkg_state = &reloaded
+                .packages
+                .get("demo@0.1.0")
+                .expect("package in state")
+                .state;
+            assert!(
+                matches!(pkg_state, PackageState::Skipped { .. }),
+                "expected state.json to show Skipped after resume reconciled against registry; got {pkg_state:?}"
+            );
             server.join();
         });
     }


### PR DESCRIPTION
## Summary

Two trust-core regressions surfaced by the #90 synthetic rehearsal test (PR #124). Both are small, focused fixes — no refactor.

## #125 — Silent resume-skip

**Before:** resume's already-complete match arm (\`Published | Skipped\`) logged a stdout info line and \`continue\`d, without emitting any event. \`events.jsonl\` had no record that resume had looked at the package.

**After:** emit \`PackageSkipped { reason: \"resume: state already <state>\" }\` before continuing. An auditor reading only events.jsonl can now reconstruct resume's decisions for every planned package.

Receipt shape unchanged — already-complete packages still omit from \`receipt.packages\`, matching prior contract (tests \`run_resume_runs_publish_when_state_exists\` et al depend on that emptiness).

## #126 — Failed → Skipped state drift

Investigated. Turned out the current sequential code **already handles** this correctly: when resume sees \`Failed\` state and \`reg.version_exists\` returns true, \`update_state(Skipped)\` is called and flushes to state.json. My targeted regression test passes with zero code changes.

The bad observation reported in the issue likely came from a stale state-dir artifact in the synthetic fixture, not a real bug in this path.

**Keeping the test anyway** as a regression guard: if a future refactor (parallel mode, concurrent writes, state-write reordering) breaks the semantics, the guard fires before the bug hits release CI.

## Tests

Two new \`#[serial]\` tests in \`engine::tests\`:

- \`resume_emits_package_skipped_event_for_already_published_state\` — seeds \`Published\`, runs \`run_publish\`, asserts \`package_skipped\` event appears in events.jsonl.
- \`resume_from_failed_ambiguous_updates_state_to_skipped_when_registry_visible\` — seeds \`Failed{class:Ambiguous}\`, registry returns 200, reloads state.json, asserts \`Skipped\`.

All 49 existing resume/publish tests still pass.

## Test plan

- [x] \`cargo test -p shipper --lib -- run_publish resume_\` — 49/49
- [x] \`cargo clippy -p shipper --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [ ] CI multi-OS green

## Closes

- Closes #125 (with the event emission fix)
- Closes #126 (with regression guard; behavior already correct)