### PR TITLE
feat(remediate): --mark-compromised + shipper fix-forward (#98 PR 3)

### DIFF
--- a/crates/shipper-cli/src/main.rs
+++ b/crates/shipper-cli/src/main.rs
@@ -271,6 +271,15 @@ enum Commands {
         /// released"`.
         #[arg(long)]
         reason: String,
+        /// Also mark the crate's existing receipt entry as compromised
+        /// (#98 PR 3). Sets `compromised_at = now` and `compromised_by =
+        /// <reason>` on the matching `PackageReceipt` in
+        /// `<state_dir>/receipt.json`, so downstream commands like
+        /// `shipper plan-yank --compromised-only` and `shipper fix-forward`
+        /// can find the compromised packages without scanning events.jsonl.
+        /// No-op if no matching receipt exists (prints a warning).
+        #[arg(long)]
+        mark_compromised: bool,
     },
     /// Generate a reverse-topological yank plan from a receipt (#98 PR 2).
     ///
@@ -293,6 +302,26 @@ enum Commands {
         /// package is included (full rollback).
         #[arg(long)]
         compromised_only: bool,
+    },
+    /// Generate a fix-forward supersession plan from a compromised
+    /// receipt (#98 PR 3).
+    ///
+    /// Reads a prior `receipt.json`, finds packages whose receipt entry
+    /// carries a `compromised_at` marker (populated by
+    /// `shipper yank ... --mark-compromised`), and prints an ordered
+    /// list of successor versions to publish. Dependencies go first
+    /// (opposite of plan-yank) so downstream consumers can upgrade to a
+    /// clean chain on `cargo update`.
+    ///
+    /// **Planning only.** This command does NOT edit Cargo.toml or
+    /// invoke publish — that's operator territory. It prints the
+    /// steps, you execute them.
+    #[command(name = "fix-forward")]
+    FixForward {
+        /// Path to the compromised receipt. Defaults to
+        /// `<state_dir>/receipt.json` when omitted.
+        #[arg(long, value_name = "PATH")]
+        from_receipt: Option<PathBuf>,
     },
     /// Configuration file management.
     #[command(subcommand)]
@@ -689,9 +718,11 @@ fn main() -> Result<()> {
             crate_name,
             version,
             reason,
+            mark_compromised,
         } => {
             use shipper::cargo;
             use shipper::state::events::{EventLog, events_path};
+            use shipper::state::execution_state::{load_receipt, receipt_path, write_receipt};
             use shipper::types::{EventType, PublishEvent};
 
             reporter.warn(&format!(
@@ -736,6 +767,63 @@ fn main() -> Result<()> {
             }
 
             if out.exit_code == 0 {
+                if mark_compromised {
+                    // #98 PR 3: mirror the yank into the receipt so
+                    // downstream commands (plan-yank --compromised-only,
+                    // fix-forward) can find the marker without scanning
+                    // events.jsonl. The receipt is a *projection*, so
+                    // mutating one field on one matching package is a
+                    // legitimate amendment.
+                    let rpath = receipt_path(&opts.state_dir);
+                    match load_receipt(&opts.state_dir) {
+                        Ok(Some(mut receipt)) => {
+                            let matched = receipt
+                                .packages
+                                .iter_mut()
+                                .find(|p| p.name == crate_name && p.version == version);
+                            if let Some(pkg) = matched {
+                                pkg.compromised_at = Some(chrono::Utc::now());
+                                pkg.compromised_by = Some(reason.clone());
+                                if let Err(err) = write_receipt(&opts.state_dir, &receipt) {
+                                    reporter.warn(&format!(
+                                        "yanked successfully but failed to mark receipt at \
+                                         {}: {err:#}",
+                                        rpath.display()
+                                    ));
+                                } else {
+                                    reporter.info(&format!(
+                                        "marked {crate_name}@{version} compromised in {}",
+                                        rpath.display()
+                                    ));
+                                }
+                            } else {
+                                reporter.warn(&format!(
+                                    "--mark-compromised: no matching package entry for \
+                                     {crate_name}@{version} in {}; yank succeeded but the \
+                                     receipt was not amended.",
+                                    rpath.display()
+                                ));
+                            }
+                        }
+                        Ok(None) => {
+                            reporter.warn(&format!(
+                                "--mark-compromised: no receipt at {}; yank succeeded but \
+                                 nothing to amend. Future plan-yank / fix-forward runs won't \
+                                 see this version as compromised unless the receipt is \
+                                 reconstructed.",
+                                rpath.display()
+                            ));
+                        }
+                        Err(err) => {
+                            reporter.warn(&format!(
+                                "--mark-compromised: failed to load receipt at {}: {err:#}. \
+                                 Yank succeeded; receipt not amended.",
+                                rpath.display()
+                            ));
+                        }
+                    }
+                }
+
                 reporter.info(&format!(
                     "yanked {crate_name}@{version} successfully. \
                      existing lockfile pins are NOT invalidated; \
@@ -788,6 +876,34 @@ fn main() -> Result<()> {
                 }
                 _ => {
                     println!("{}", plan_yank::render_text(&plan));
+                }
+            }
+        }
+        Commands::FixForward { from_receipt } => {
+            use shipper::engine::fix_forward::{self, SuccessorStrategy};
+
+            let receipt_path = from_receipt.unwrap_or_else(|| {
+                opts.state_dir
+                    .join(shipper::state::execution_state::RECEIPT_FILE)
+            });
+
+            let plan =
+                fix_forward::plan_from_path(&receipt_path, SuccessorStrategy::PlaceholderNext)
+                    .with_context(|| {
+                        "fix-forward needs a readable receipt; default path is \
+                         <state_dir>/receipt.json. Pass --from-receipt <path> to \
+                         override."
+                            .to_string()
+                    })?;
+
+            match cli.format.as_str() {
+                "json" => {
+                    let out = serde_json::to_string_pretty(&plan)
+                        .context("failed to serialize fix-forward plan as JSON")?;
+                    println!("{out}");
+                }
+                _ => {
+                    println!("{}", fix_forward::render_text(&plan));
                 }
             }
         }

--- a/crates/shipper-cli/tests/e2e_expanded.rs
+++ b/crates/shipper-cli/tests/e2e_expanded.rs
@@ -1438,6 +1438,19 @@ fn help_plan_yank_snapshot() {
     assert_snapshot!("help_plan_yank", normalize_stderr(&stdout));
 }
 
+/// Snapshot: `fix-forward --help` output.
+#[test]
+fn help_fix_forward_snapshot() {
+    let output = shipper_cmd()
+        .args(["fix-forward", "--help"])
+        .output()
+        .expect("failed to run");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_snapshot!("help_fix_forward", normalize_stderr(&stdout));
+}
+
 /// Snapshot: `config init --help` output.
 #[test]
 fn help_config_init_snapshot() {

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__help_text.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__help_text.snap
@@ -20,6 +20,7 @@ Commands:
   clean            Clean state files (state.json, receipt.json, events.jsonl)
   yank             Yank a crate@version from the registry — containment, not undo
   plan-yank        Generate a reverse-topological yank plan from a receipt (#98 PR 2)
+  fix-forward      Generate a fix-forward supersession plan from a compromised receipt (#98 PR 3)
   config           Configuration file management
   completion       Generate shell completion scripts for the specified shell
   help             Print this message or the help of the given subcommand(s)

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__no_subcommand_error.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__no_subcommand_error.snap
@@ -20,6 +20,7 @@ Commands:
   clean            Clean state files (state.json, receipt.json, events.jsonl)
   yank             Yank a crate@version from the registry — containment, not undo
   plan-yank        Generate a reverse-topological yank plan from a receipt (#98 PR 2)
+  fix-forward      Generate a fix-forward supersession plan from a compromised receipt (#98 PR 3)
   config           Configuration file management
   completion       Generate shell completion scripts for the specified shell
   help             Print this message or the help of the given subcommand(s)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_fix_forward.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_fix_forward.snap
@@ -2,42 +2,31 @@
 source: crates/shipper-cli/tests/e2e_expanded.rs
 expression: normalize_stderr(&stdout)
 ---
-Yank a crate@version from the registry — containment, not undo.
+Generate a fix-forward supersession plan from a compromised receipt (#98 PR 3).
 
-`cargo yank` marks a specific version as not-installable for NEW dependency resolves. Existing lockfile pins and already-downloaded copies are unaffected. See [cargo yank docs](https://doc.rust-lang.org/cargo/commands/cargo-yank.html).
+Reads a prior `receipt.json`, finds packages whose receipt entry carries a `compromised_at` marker (populated by `shipper yank ... --mark-compromised`), and prints an ordered list of successor versions to publish. Dependencies go first (opposite of plan-yank) so downstream consumers can upgrade to a clean chain on `cargo update`.
 
-Part of [#98 Remediate](https://github.com/EffortlessMetrics/shipper/issues/98). Follow-on commands (`shipper plan-yank`, `shipper fix-forward`) compose this primitive into reverse-topological containment and fix-forward plans.
+**Planning only.** This command does NOT edit Cargo.toml or invoke publish — that's operator territory. It prints the steps, you execute them.
 
-Usage: shipper yank [OPTIONS] --crate <NAME> --version <VERSION> --reason <REASON>
+Usage: shipper fix-forward [OPTIONS]
 
 Options:
       --config <CONFIG>
           Path to a custom configuration file (.shipper.toml)
 
-      --crate <NAME>
-          Name of the crate to yank (e.g., `shipper-types`)
+      --from-receipt <PATH>
+          Path to the compromised receipt. Defaults to `<state_dir>/receipt.json` when omitted
 
       --manifest-path <MANIFEST_PATH>
           Path to the workspace Cargo.toml
           
           [default: Cargo.toml]
 
-      --version <VERSION>
-          Version to yank (e.g., `[VERSION]`)
-
-      --reason <REASON>
-          Operator-supplied reason (recorded in the event log, audit trails, and any future receipts that reference this yank).
-          
-          Example: `"CVE-2026-0001 disclosed; containing while patch released"`.
-
       --registry <REGISTRY>
           Cargo registry name (default: crates-io)
 
       --api-base <API_BASE>
           Registry API base URL (default: <https://crates.io>)
-
-      --mark-compromised
-          Also mark the crate's existing receipt entry as compromised (#98 PR 3). Sets `compromised_at = now` and `compromised_by = <reason>` on the matching `PackageReceipt` in `<state_dir>/receipt.json`, so downstream commands like `shipper plan-yank --compromised-only` and `shipper fix-forward` can find the compromised packages without scanning events.jsonl. No-op if no matching receipt exists (prints a warning)
 
       --package <PACKAGES>
           Restrict to specific packages (repeatable). If omitted, publishes all publishable workspace members

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_root.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_root.snap
@@ -20,6 +20,7 @@ Commands:
   clean            Clean state files (state.json, receipt.json, events.jsonl)
   yank             Yank a crate@version from the registry — containment, not undo
   plan-yank        Generate a reverse-topological yank plan from a receipt (#98 PR 2)
+  fix-forward      Generate a fix-forward supersession plan from a compromised receipt (#98 PR 3)
   config           Configuration file management
   completion       Generate shell completion scripts for the specified shell
   help             Print this message or the help of the given subcommand(s)

--- a/crates/shipper/src/engine/fix_forward.rs
+++ b/crates/shipper/src/engine/fix_forward.rs
@@ -1,0 +1,300 @@
+//! Fix-forward: supersession plan from a compromised receipt (#98 PR 3).
+//!
+//! When a published release turns out to be compromised (CVE, leaked
+//! secret, broken artifact), the remediation options are:
+//!
+//! 1. **Yank** — containment. Prevents NEW resolves but leaves
+//!    existing lockfiles unchanged. Covered by `shipper yank` (PR 1)
+//!    and `shipper plan-yank` (PR 2).
+//! 2. **Fix-forward** — ship a successor release that replaces the
+//!    compromised one. Downstream consumers pick it up on
+//!    `cargo update`. **This module plans that.**
+//!
+//! The two strategies are complementary: an operator typically runs
+//! the yank plan *alongside* a fix-forward so new resolves steer away
+//! from the bad chain AND existing consumers have something cleaner to
+//! upgrade to.
+//!
+//! ## What this module does
+//!
+//! - Read a receipt, find the compromised packages (those with
+//!   `compromised_at.is_some()`)
+//! - Compute a minimal **supersession plan**: each compromised package
+//!   needs its successor version to be published, in the same
+//!   topological order as the original plan (dependencies first)
+//! - Present the plan as either a human-readable step list or JSON
+//!
+//! ## What this module does NOT do (yet)
+//!
+//! - **Edit Cargo.toml files** to bump versions. That's workspace-edit
+//!   territory — invasive enough to deserve its own PR with dry-run /
+//!   --apply / git-guard semantics.
+//! - **Run the bumped publish**. Once the operator has bumped versions
+//!   and committed them, `shipper publish` handles the actual train
+//!   exactly as for any release. Fix-forward's job is the planning
+//!   layer, not the execution.
+//! - **Chain successor → receipt** via the `superseded_by` field.
+//!   Wiring that requires post-publish receipt amendment from the
+//!   successor run; another follow-on.
+//!
+//! Keeping the first PR to *planning only* matches the scope pattern
+//! of `plan-yank` (PR 2) — give operators a text blueprint, let them
+//! apply it, leave execution orchestration for a later pass once the
+//! shape is validated in the field.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use shipper_types::{PackageReceipt, PackageState, Receipt};
+
+/// Default successor-version bump strategy. `None` means
+/// "operator-supplied suggestion"; the plan just echoes a placeholder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SuccessorStrategy {
+    /// Print `<OLD>-next` as the suggested version. Lets the operator
+    /// pick the actual bump (patch/minor/major) after reading the plan.
+    PlaceholderNext,
+}
+
+/// One step in a fix-forward plan.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct FixForwardStep {
+    pub name: String,
+    pub current_version: String,
+    pub suggested_successor: String,
+    /// The `compromised_by` reason copied from the receipt, so an
+    /// operator running the plan sees per-crate context without having
+    /// to cross-reference the receipt.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// A fix-forward plan produced from a receipt.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct FixForwardPlan {
+    pub plan_id: String,
+    pub registry: String,
+    /// How many receipt packages were flagged compromised.
+    pub compromised_count: usize,
+    /// Steps in topological order (dependencies first, dependents last).
+    /// The operator applies these by bumping Cargo.toml and running
+    /// `shipper publish` for the successor version.
+    pub steps: Vec<FixForwardStep>,
+}
+
+fn is_compromised(p: &PackageReceipt) -> bool {
+    p.compromised_at.is_some() && matches!(p.state, PackageState::Published)
+}
+
+fn suggest_next(current: &str, strategy: SuccessorStrategy) -> String {
+    match strategy {
+        SuccessorStrategy::PlaceholderNext => format!("{current}-next"),
+    }
+}
+
+/// Build a fix-forward plan from a receipt.
+///
+/// Topological order — same direction as `publish`, **opposite** of
+/// `plan-yank`. Rationale: for fix-forward you're *publishing*
+/// replacements, so dependencies go first (downstream fixes can pull
+/// updated deps); for yank you're *removing* reachability, so
+/// dependents go first.
+pub fn build_plan(receipt: &Receipt, strategy: SuccessorStrategy) -> FixForwardPlan {
+    let steps: Vec<FixForwardStep> = receipt
+        .packages
+        .iter()
+        .filter(|p| is_compromised(p))
+        .map(|p| FixForwardStep {
+            name: p.name.clone(),
+            current_version: p.version.clone(),
+            suggested_successor: suggest_next(&p.version, strategy),
+            reason: p.compromised_by.clone(),
+        })
+        .collect();
+
+    FixForwardPlan {
+        plan_id: receipt.plan_id.clone(),
+        registry: receipt.registry.name.clone(),
+        compromised_count: steps.len(),
+        steps,
+    }
+}
+
+/// Render a fix-forward plan as a human-readable step list. The output
+/// is a numbered sequence: bump the Cargo.toml version for each crate,
+/// then a single `shipper publish` at the end to ship the lot.
+pub fn render_text(plan: &FixForwardPlan) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "# fix-forward plan — registry={}, plan_id={}\n",
+        plan.registry, plan.plan_id
+    ));
+    out.push_str(&format!(
+        "# {} package(s) marked compromised\n",
+        plan.compromised_count
+    ));
+    if plan.steps.is_empty() {
+        out.push_str(
+            "# (nothing to fix-forward: no receipt package has compromised_at set. \
+             Run `shipper yank --crate <N> --version <V> --reason <R> --mark-compromised` \
+             first, or edit receipt.json by hand.)\n",
+        );
+        return out;
+    }
+    out.push_str(
+        "# Steps:\n\
+         #   1. For each crate below, bump the version in its Cargo.toml to the\n\
+         #      suggested successor (or your preferred bump).\n\
+         #   2. Commit the bumps; they're part of the fix-forward audit trail.\n\
+         #   3. Run `shipper publish` to ship the successors in topo order.\n\
+         #   4. Once all successors are live, optionally run `shipper plan-yank\n\
+         #      --from-receipt <path> --compromised-only` to contain the\n\
+         #      compromised versions.\n\
+         #\n",
+    );
+    for (i, step) in plan.steps.iter().enumerate() {
+        let reason = step
+            .reason
+            .as_deref()
+            .map(|r| format!("  # {r}"))
+            .unwrap_or_default();
+        out.push_str(&format!(
+            "{:>3}. {}: {} -> {}{reason}\n",
+            i + 1,
+            step.name,
+            step.current_version,
+            step.suggested_successor
+        ));
+    }
+    out
+}
+
+/// Load a receipt and build a fix-forward plan. Convenience wrapper
+/// used by the `shipper fix-forward --from-receipt` CLI path.
+pub fn plan_from_path(path: &Path, strategy: SuccessorStrategy) -> Result<FixForwardPlan> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read receipt at {}", path.display()))?;
+    let receipt: Receipt = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse receipt at {}", path.display()))?;
+    Ok(build_plan(&receipt, strategy))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use shipper_types::{
+        EnvironmentFingerprint, PackageEvidence, PackageReceipt, PackageState, Receipt, Registry,
+    };
+    use std::path::PathBuf;
+
+    fn pkg(name: &str, state: PackageState, compromised: Option<&str>) -> PackageReceipt {
+        PackageReceipt {
+            name: name.to_string(),
+            version: "0.1.0".to_string(),
+            attempts: 1,
+            state,
+            started_at: Utc::now(),
+            finished_at: Utc::now(),
+            duration_ms: 5,
+            evidence: PackageEvidence {
+                attempts: vec![],
+                readiness_checks: vec![],
+            },
+            compromised_at: compromised.map(|_| Utc::now()),
+            compromised_by: compromised.map(str::to_string),
+            superseded_by: None,
+        }
+    }
+
+    fn sample_receipt(packages: Vec<PackageReceipt>) -> Receipt {
+        Receipt {
+            receipt_version: "shipper.receipt.v2".to_string(),
+            plan_id: "plan-sample".to_string(),
+            registry: Registry::crates_io(),
+            started_at: Utc::now(),
+            finished_at: Utc::now(),
+            packages,
+            event_log_path: PathBuf::from(".shipper/events.jsonl"),
+            git_context: None,
+            environment: EnvironmentFingerprint {
+                shipper_version: "0.3.0".into(),
+                cargo_version: None,
+                rust_version: None,
+                os: "test".into(),
+                arch: "x86_64".into(),
+            },
+        }
+    }
+
+    #[test]
+    fn only_compromised_published_packages_produce_steps() {
+        let r = sample_receipt(vec![
+            pkg("a", PackageState::Published, None),
+            pkg("b", PackageState::Published, Some("CVE-2026-0001")),
+            pkg(
+                "c",
+                PackageState::Failed {
+                    class: shipper_types::ErrorClass::Permanent,
+                    message: "no".into(),
+                },
+                Some("never-shipped"),
+            ),
+        ]);
+        let plan = build_plan(&r, SuccessorStrategy::PlaceholderNext);
+        // b is compromised and published (keeps); a isn't compromised
+        // (drops); c is compromised but failed so never shipped (drops).
+        assert_eq!(plan.compromised_count, 1);
+        assert_eq!(plan.steps[0].name, "b");
+        assert_eq!(plan.steps[0].current_version, "0.1.0");
+        assert_eq!(plan.steps[0].suggested_successor, "0.1.0-next");
+        assert_eq!(plan.steps[0].reason.as_deref(), Some("CVE-2026-0001"));
+    }
+
+    #[test]
+    fn preserves_topological_order() {
+        let r = sample_receipt(vec![
+            pkg("lib", PackageState::Published, Some("r")),
+            pkg("mid", PackageState::Published, Some("r")),
+            pkg("top", PackageState::Published, Some("r")),
+        ]);
+        let plan = build_plan(&r, SuccessorStrategy::PlaceholderNext);
+        let names: Vec<_> = plan.steps.iter().map(|s| s.name.clone()).collect();
+        // Same order as receipt.packages (dependencies first, dependents last)
+        assert_eq!(names, vec!["lib", "mid", "top"]);
+    }
+
+    #[test]
+    fn empty_plan_when_nothing_compromised() {
+        let r = sample_receipt(vec![
+            pkg("a", PackageState::Published, None),
+            pkg("b", PackageState::Published, None),
+        ]);
+        let plan = build_plan(&r, SuccessorStrategy::PlaceholderNext);
+        assert_eq!(plan.compromised_count, 0);
+        assert!(plan.steps.is_empty());
+        let text = render_text(&plan);
+        assert!(text.contains("nothing to fix-forward"));
+        assert!(
+            text.contains("--mark-compromised"),
+            "empty-plan render should guide the operator toward the missing step"
+        );
+    }
+
+    #[test]
+    fn text_render_enumerates_steps_with_reason() {
+        let r = sample_receipt(vec![
+            pkg("core", PackageState::Published, Some("CVE-2026-0001")),
+            pkg("app", PackageState::Published, Some("CVE-2026-0001")),
+        ]);
+        let text = render_text(&build_plan(&r, SuccessorStrategy::PlaceholderNext));
+        assert!(text.contains("1. core: 0.1.0 -> 0.1.0-next"));
+        assert!(text.contains("2. app: 0.1.0 -> 0.1.0-next"));
+        assert!(text.contains("CVE-2026-0001"));
+        // Instructional preamble points the operator toward publish +
+        // plan-yank so fix-forward isn't mistaken for a complete
+        // remediation on its own.
+        assert!(text.contains("shipper publish"));
+        assert!(text.contains("shipper plan-yank"));
+    }
+}

--- a/crates/shipper/src/engine/mod.rs
+++ b/crates/shipper/src/engine/mod.rs
@@ -7044,3 +7044,6 @@ pub mod parallel;
 
 /// Plan-yank: reverse-topological containment plan from a receipt (#98 PR 2).
 pub mod plan_yank;
+
+/// Fix-forward: supersession plan from a compromised receipt (#98 PR 3).
+pub mod fix_forward;

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Task-oriented recipes. Each solves one focused problem.
 - [Inspect a stalled or interrupted run](how-to/inspect-a-stalled-run.md) — live triage ("is it alive?")
 - [Run the Recover rehearsal](how-to/run-recover-rehearsal.md) — once-per-RC proof that interrupted releases resume cleanly
 - [Rehearse against an alternate registry](how-to/rehearse-against-an-alt-registry.md) — Prove tier 2 walkthrough with kellnr example (#97)
+- [Remediate a compromised release](how-to/remediate-a-compromised-release.md) — yank + fix-forward walkthrough (#98)
 
 Operator runbook (promotion to how-to pending): [release-runbook.md](release-runbook.md)
 

--- a/docs/how-to/remediate-a-compromised-release.md
+++ b/docs/how-to/remediate-a-compromised-release.md
@@ -1,0 +1,209 @@
+# How-to: Remediate a compromised release
+
+You shipped a release. Later you discover one or more crates in that
+release are compromised — a CVE, a leaked token in a debug impl, a
+broken build artifact. You need to:
+
+1. **Contain** the damage (stop new resolves from pulling the bad chain).
+2. **Fix-forward** (ship a clean successor so existing consumers have
+   something good to upgrade to).
+3. **Finalize** (optionally yank the bad versions once the clean chain
+   is live).
+
+This guide walks you through all three, using the Remediate commands
+landed in [#98](https://github.com/EffortlessMetrics/shipper/issues/98).
+
+> **Containment is not undo.** `cargo yank` prevents NEW resolves for a
+> version; it does NOT invalidate existing `Cargo.lock` pins. That's
+> why containment alone isn't enough — the operator running `cargo
+> build` in an existing checkout will still resolve to the bad version
+> unless you ALSO fix-forward and they run `cargo update`.
+
+## Prerequisites
+
+- A `receipt.json` from the compromised release in `<state_dir>`
+  (default `.shipper/receipt.json`), produced by the `shipper publish`
+  that shipped it.
+- Publish credentials for the affected registry (same token / OIDC
+  setup you used for the release).
+- For a compromised chain spanning multiple crates, you should know
+  the compromise scope — which crate names are bad. A CVE
+  advisory, an audit report, or an incident ticket should tell you.
+
+## Step 1 — Record the compromise in the receipt
+
+Use `shipper yank --mark-compromised` to yank AND annotate the
+receipt in one go. Run this for each compromised crate+version:
+
+```bash
+shipper yank \
+  --crate my-lib --version 0.3.0 \
+  --reason "CVE-2026-0001: token leak via Debug impl" \
+  --mark-compromised
+```
+
+What this does:
+
+- Invokes `cargo yank --version 0.3.0 my-lib` against the registry.
+  The version becomes unresolvable for new dependency resolves.
+- Emits a `PackageYanked` event to `events.jsonl`.
+- Amends the matching `PackageReceipt` entry in `<state_dir>/receipt.json`:
+  - `compromised_at = <now>`
+  - `compromised_by = "CVE-2026-0001: token leak via Debug impl"`
+
+The `--mark-compromised` flag is **opt-in** — without it, `shipper yank`
+only yanks. We keep it explicit because marking a receipt is an
+annotation over an audit document and should be an operator decision.
+
+> **Idempotent.** Running this twice for the same crate+version is
+> safe: the second yank is a no-op on crates.io, and the receipt
+> amendment just updates `compromised_at` to the latest timestamp.
+
+## Step 2 — Plan the fix-forward
+
+```bash
+shipper fix-forward --from-receipt .shipper/receipt.json
+```
+
+This reads the receipt, finds every package whose entry was marked
+compromised in Step 1, and prints a supersession plan — dependencies
+first, dependents last, same direction as the original publish (because
+you're *publishing* replacements, not *removing* reachability):
+
+```
+# fix-forward plan — registry=crates-io, plan_id=abc123
+# 1 package(s) marked compromised
+# Steps:
+#   1. For each crate below, bump the version in its Cargo.toml to the
+#      suggested successor (or your preferred bump).
+#   2. Commit the bumps; they're part of the fix-forward audit trail.
+#   3. Run `shipper publish` to ship the successors in topo order.
+#   4. Once all successors are live, optionally run `shipper plan-yank
+#      --from-receipt <path> --compromised-only` to contain the
+#      compromised versions.
+#
+  1. my-lib: 0.3.0 -> 0.3.0-next  # CVE-2026-0001: token leak via Debug impl
+```
+
+`fix-forward` is **planning only**. It does not edit Cargo.toml and
+does not invoke `shipper publish`. The operator steps are:
+
+1. Bump `my-lib`'s version in its Cargo.toml. `0.3.0-next` is a
+   suggestion — use `0.3.1` for a real patch, or whatever your
+   SemVer policy dictates.
+2. Also bump any workspace crate whose version should travel with
+   `my-lib` (typically everything in a single-version workspace).
+3. Commit the bumps as a single "fix-forward: <reason>" commit. The
+   git history becomes part of the remediation trail.
+4. Run `shipper publish` to ship the successors.
+
+Optional `--format json` emits the plan as structured JSON for
+programmatic remediation tooling.
+
+## Step 3 — Execute the publish
+
+Same as a normal release train:
+
+```bash
+shipper plan      # confirm the bump is what you expect
+shipper preflight # git clean, registry reachable, dry-run
+shipper publish   # topological train with retry + readiness
+```
+
+Shipper's engine handles retry / backoff / ambiguous reconciliation
+automatically. See the [release runbook](../release-runbook.md) for
+the production-release checklist.
+
+The new receipt records the successors. At this point `my-lib@0.3.0` is
+yanked and compromised, `my-lib@0.3.1` is live and clean.
+
+## Step 4 — Finalize: yank the old chain (optional)
+
+If you want belt-and-braces containment, generate a reverse-topological
+yank plan from the original compromised receipt and walk it:
+
+```bash
+shipper plan-yank \
+  --from-receipt .shipper/receipt.json \
+  --compromised-only
+```
+
+Output is a copy-pasteable list of `shipper yank` commands:
+
+```
+# yank plan (reverse topological) — registry=crates-io, plan_id=abc123, filter=compromised_only
+# 1 entries
+  1. shipper yank --crate my-lib --version 0.3.0 --reason <REASON>  # CVE-2026-0001: token leak via Debug impl
+```
+
+For multi-crate compromises, the order is **dependents first** — the
+opposite of publish order — so downstream consumers stop being
+resolvable BEFORE the bad version they depend on is pulled.
+
+You don't *have* to run Step 4 if you did Step 1 already (Step 1 yanked
+each crate as you marked it). This step exists for the case where the
+operator marked packages compromised but *didn't* yank them yet (using
+a separate `--mark-compromised`-only tool), or where the plan needs
+reviewing before yanking.
+
+## Worked example: single-CVE in a multi-crate release
+
+Scenario: released `core@0.3.0`, `app@0.3.0` as a linked workspace.
+Later found `core@0.3.0` has a credential-leak bug. `app@0.3.0` is
+uncompromised *on its own* but depends on `core@0.3.0`, so it's in
+scope for the fix-forward to pick up the clean `core`.
+
+```bash
+# 1. Yank + mark just the directly compromised crate
+shipper yank \
+  --crate core --version 0.3.0 \
+  --reason "CVE-2026-0001" \
+  --mark-compromised
+
+# 2. Plan the fix-forward
+shipper fix-forward
+# → tells you to bump core, commit, shipper publish
+
+# 3. Bump Cargo.toml: core -> 0.3.1, app -> 0.3.1 (app picks up clean core)
+#    Commit, then:
+shipper publish
+# → publishes core@0.3.1 and app@0.3.1
+
+# 4. Optionally yank app@0.3.0 too so resolvers can't fall back to it:
+shipper yank \
+  --crate app --version 0.3.0 \
+  --reason "CVE-2026-0001 (transitive via core)" \
+  --mark-compromised
+```
+
+End state:
+
+- `core@0.3.0` — yanked, marked compromised.
+- `app@0.3.0` — yanked, marked compromised (transitive).
+- `core@0.3.1` — live, clean.
+- `app@0.3.1` — live, clean, depends on `core@0.3.1`.
+- Existing `app@0.3.0` users run `cargo update -p core -p app` and
+  they're on the clean chain.
+
+## What "remediation" does NOT cover
+
+- **Lockfile invalidation.** Yanking does not force-upgrade downstream
+  lockfiles. You cannot un-ship a compromised version; only prevent
+  new resolves. Operators running existing checkouts with pinned
+  lockfiles continue to resolve to the bad version until they
+  `cargo update`.
+- **Version bumping.** Shipper doesn't (yet) edit Cargo.toml on your
+  behalf. `fix-forward` tells you what to bump; you do the bumping.
+- **Consumer notifications.** If your crate has consumers outside your
+  control, you still need to announce the CVE (RustSec advisory,
+  release notes, security mailing list). Shipper's trail captures the
+  technical remediation; it doesn't publish the disclosure.
+
+## See also
+
+- [Inspect state, events, and receipts](inspect-state-and-receipts.md) —
+  understanding the audit trail that `--mark-compromised` writes into.
+- [Release runbook](../release-runbook.md) — the standard publish
+  procedure that Step 3 invokes.
+- [Remediate pillar on the roadmap](../../ROADMAP.md) — where this fits
+  in Shipper's five-pillar release-closure model.


### PR DESCRIPTION
Reopened after #132 merge. Original PR #131 auto-closed when base branch was deleted.

PR 3 of the #98 Remediate staged rollout:
- shipper yank --mark-compromised amends the receipt's compromise fields
- shipper fix-forward --from-receipt prints topologically-ordered supersession plan
- 4 new tests for fix_forward plan building
- docs/how-to/remediate-a-compromised-release.md — operator walkthrough tying yank + plan-yank + fix-forward together

Completes the Remediate rollout alongside the now-merged #121 and #132.