### PR TITLE
feat(rehearse): smoke-install closes #97 Prove tier 2 (#97 PR 4)

### DIFF
--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__ci_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__ci_help.snap
@@ -139,6 +139,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__clean_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__clean_help.snap
@@ -135,6 +135,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__config_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__config_help.snap
@@ -137,6 +137,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__doctor_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__doctor_help.snap
@@ -132,6 +132,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__help_text.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__help_text.snap
@@ -151,6 +151,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__no_subcommand_error.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__no_subcommand_error.snap
@@ -104,6 +104,8 @@ Options:
           Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch
       --skip-rehearsal
           Skip rehearsal even if `.shipper.toml` enables it
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4)
       --format <FORMAT>
           Output format: text (default) or json [default: text] [possible values: text, json]
       --verbose

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__plan_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__plan_help.snap
@@ -132,6 +132,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__preflight_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__preflight_help.snap
@@ -132,6 +132,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__publish_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__publish_help.snap
@@ -132,6 +132,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__resume_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__resume_help.snap
@@ -132,6 +132,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__status_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__status_help.snap
@@ -132,6 +132,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__error_missing_ci_subcommand.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__error_missing_ci_subcommand.snap
@@ -92,6 +92,8 @@ Options:
           Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch
       --skip-rehearsal
           Skip rehearsal even if `.shipper.toml` enables it
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4)
       --format <FORMAT>
           Output format: text (default) or json [default: text] [possible values: text, json]
       --verbose

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__error_missing_config_subcommand.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__error_missing_config_subcommand.snap
@@ -90,6 +90,8 @@ Options:
           Name of a registry (from `[[registries]]` in `.shipper.toml`) to rehearse the publish against before live dispatch
       --skip-rehearsal
           Skip rehearsal even if `.shipper.toml` enables it
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4)
       --format <FORMAT>
           Output format: text (default) or json [default: text] [possible values: text, json]
       --verbose

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_ci.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_ci.snap
@@ -139,6 +139,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_ci_github_actions.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_ci_github_actions.snap
@@ -132,6 +132,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_ci_gitlab.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_ci_gitlab.snap
@@ -132,6 +132,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_clean.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_clean.snap
@@ -135,6 +135,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_completion.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_completion.snap
@@ -138,6 +138,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_config.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_config.snap
@@ -137,6 +137,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_config_init.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_config_init.snap
@@ -137,6 +137,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_config_validate.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_config_validate.snap
@@ -137,6 +137,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_doctor.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_doctor.snap
@@ -132,6 +132,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_fix_forward.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_fix_forward.snap
@@ -139,6 +139,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_inspect_events.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_inspect_events.snap
@@ -132,6 +132,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_inspect_receipt.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_inspect_receipt.snap
@@ -132,6 +132,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_plan.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_plan.snap
@@ -132,6 +132,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_plan_yank.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_plan_yank.snap
@@ -142,6 +142,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_preflight.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_preflight.snap
@@ -132,6 +132,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_publish.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_publish.snap
@@ -132,6 +132,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_resume.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_resume.snap
@@ -132,6 +132,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_root.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_root.snap
@@ -151,6 +151,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_status.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_status.snap
@@ -132,6 +132,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_yank.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_yank.snap
@@ -150,6 +150,13 @@ Options:
           
           Use with caution — rehearsal (once fully implemented under #97) is the proof boundary between "we built it" and "we verified it actually resolves from a registry." Bypassing it should be rare.
 
+      --smoke-install <CRATE>
+          Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+          
+          Runs `cargo install --registry <rehearsal> <CRATE>` against the rehearsal registry to prove the crate actually resolves and installs end-to-end — the scenario that workspace-path dependencies defeat and that killed the rc.1 first-publish.
+          
+          The named crate must be in the plan AND have a `[[bin]]` target. Library-only crates cannot be smoke-installed directly; use a consumer-workspace build instead (follow-on).
+
       --format <FORMAT>
           Output format: text (default) or json
           

--- a/crates/shipper-config/src/lib.rs
+++ b/crates/shipper-config/src/lib.rs
@@ -506,6 +506,9 @@ pub struct CliOverrides {
     /// Skip rehearsal even if config/env enables it — CLI flag `--skip-rehearsal`.
     /// Consumed in the same follow-on PR.
     pub skip_rehearsal: bool,
+    /// Crate name to smoke-install post-rehearsal (#97 PR 4) — CLI flag
+    /// `--smoke-install <CRATE>`. `None` means no smoke install.
+    pub rehearsal_smoke_install: Option<String>,
 }
 
 impl Default for ShipperConfig {
@@ -874,6 +877,7 @@ impl ShipperConfig {
                 }
             }),
             rehearsal_skip: cli.skip_rehearsal,
+            rehearsal_smoke_install: cli.rehearsal_smoke_install.clone(),
         }
     }
 

--- a/crates/shipper-config/src/runtime/mod.rs
+++ b/crates/shipper-config/src/runtime/mod.rs
@@ -41,6 +41,7 @@ pub fn into_runtime_options(value: RuntimeOptions) -> shipper_types::RuntimeOpti
         resume_from: value.resume_from,
         rehearsal_registry: value.rehearsal_registry,
         rehearsal_skip: value.rehearsal_skip,
+        rehearsal_smoke_install: value.rehearsal_smoke_install,
     }
 }
 
@@ -119,6 +120,7 @@ mod tests {
             resume_from: Some("my-crate".to_string()),
             rehearsal_registry: None,
             rehearsal_skip: false,
+            rehearsal_smoke_install: None,
         }
     }
 
@@ -282,6 +284,7 @@ mod tests {
                 resume_from: None,
             rehearsal_registry: None,
             rehearsal_skip: false,
+            rehearsal_smoke_install: None,
             };
 
             let converted = into_runtime_options(input);
@@ -916,6 +919,7 @@ mod tests {
                 resume_from: None,
                 rehearsal_registry: None,
                 rehearsal_skip: false,
+                rehearsal_smoke_install: None,
             }
         }
 
@@ -1234,6 +1238,7 @@ mod tests {
                 resume_from: None,
                 rehearsal_registry: None,
                 rehearsal_skip: false,
+                rehearsal_smoke_install: None,
             }
         }
 
@@ -1420,6 +1425,7 @@ mod tests {
                 resume_from: None,
                 rehearsal_registry: None,
                 rehearsal_skip: false,
+                rehearsal_smoke_install: None,
             };
             // Adjust verify_mode to match typical policy usage
             match policy {
@@ -1784,6 +1790,7 @@ mod tests {
                 resume_from: Some(String::new()),
                 rehearsal_registry: None,
                 rehearsal_skip: false,
+                rehearsal_smoke_install: None,
             };
 
             let converted = into_runtime_options(opts);

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__policy_combination_tests__snapshot_balanced_policy_typical.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__policy_combination_tests__snapshot_balanced_policy_typical.snap
@@ -57,4 +57,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__policy_combination_tests__snapshot_fast_policy_typical.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__policy_combination_tests__snapshot_fast_policy_typical.snap
@@ -57,4 +57,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__policy_combination_tests__snapshot_safe_policy_typical.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__policy_combination_tests__snapshot_safe_policy_typical.snap
@@ -57,4 +57,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_all_flags_enabled.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_all_flags_enabled.snap
@@ -57,4 +57,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_alternative_registry_only.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_alternative_registry_only.snap
@@ -65,4 +65,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_balanced_policy_with_partial_config.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_balanced_policy_with_partial_config.snap
@@ -57,4 +57,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_default_conversion.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_default_conversion.snap
@@ -57,4 +57,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_encryption_with_env_var.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_encryption_with_env_var.snap
@@ -59,4 +59,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_fast_policy_no_verify.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_fast_policy_no_verify.snap
@@ -57,4 +57,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_full_readiness_config.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_full_readiness_config.snap
@@ -59,4 +59,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_linear_retry_strategy.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_linear_retry_strategy.snap
@@ -57,4 +57,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_parallel_heavy.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_parallel_heavy.snap
@@ -57,4 +57,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_resume_from_set.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_resume_from_set.snap
@@ -59,4 +59,5 @@ RuntimeOptions {
     ),
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_safe_policy_max_safety.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_safe_policy_max_safety.snap
@@ -59,4 +59,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_webhook_with_secret.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_webhook_with_secret.snap
@@ -59,4 +59,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_with_registries.snap
+++ b/crates/shipper-config/src/runtime/snapshots/shipper_config__runtime__tests__snapshot_tests__snapshot_with_registries.snap
@@ -70,4 +70,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/src/snapshots/shipper_config__tests__edge_case_snapshots__edge_policy_balanced_runtime.snap
+++ b/crates/shipper-config/src/snapshots/shipper_config__tests__edge_case_snapshots__edge_policy_balanced_runtime.snap
@@ -57,4 +57,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/src/snapshots/shipper_config__tests__edge_case_snapshots__edge_policy_fast_runtime.snap
+++ b/crates/shipper-config/src/snapshots/shipper_config__tests__edge_case_snapshots__edge_policy_fast_runtime.snap
@@ -57,4 +57,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/src/snapshots/shipper_config__tests__edge_case_snapshots__edge_policy_safe_runtime.snap
+++ b/crates/shipper-config/src/snapshots/shipper_config__tests__edge_case_snapshots__edge_policy_safe_runtime.snap
@@ -57,4 +57,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/src/snapshots/shipper_config__tests__snapshot_tests__merge_cli_overrides_file_values.snap
+++ b/crates/shipper-config/src/snapshots/shipper_config__tests__snapshot_tests__merge_cli_overrides_file_values.snap
@@ -57,4 +57,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper-config/tests/config_runtime_bdd.rs
+++ b/crates/shipper-config/tests/config_runtime_bdd.rs
@@ -65,6 +65,7 @@ fn sample_runtime_options(base_url: &str, registry_count: usize) -> RuntimeOptio
         resume_from: None,
         rehearsal_registry: None,
         rehearsal_skip: false,
+        rehearsal_smoke_install: None,
     }
 }
 #[test]

--- a/crates/shipper-config/tests/config_runtime_proptest.rs
+++ b/crates/shipper-config/tests/config_runtime_proptest.rs
@@ -375,6 +375,7 @@ fn arb_cli_overrides() -> impl Strategy<Value = CliOverrides> {
                     resume_from: None,
                     rehearsal_registry: None,
                     skip_rehearsal: false,
+                    rehearsal_smoke_install: None,
                 }
             },
         )

--- a/crates/shipper-types/src/lib.rs
+++ b/crates/shipper-types/src/lib.rs
@@ -593,6 +593,13 @@ pub struct RuntimeOptions {
     /// When the hard gate lands (#97 PR 3), live publish will refuse to run
     /// without this flag if rehearsal has not passed for the current `plan_id`.
     pub rehearsal_skip: bool,
+    /// Crate name to install via `cargo install --registry <rehearsal>`
+    /// after all rehearsal publishes succeed (#97 PR 4). This is the
+    /// install/smoke check that proves end-to-end registry-index
+    /// resolution — the scenario that killed the rc.1 first-publish.
+    /// `None` means no smoke install (opt-in). The named crate must
+    /// exist in the plan AND have a `[[bin]]` target.
+    pub rehearsal_smoke_install: Option<String>,
 }
 
 /// A package in the publish plan.
@@ -1555,6 +1562,27 @@ pub enum EventType {
         summary: String,
     },
 
+    // #97 PR 4 — install/smoke check. Opt-in post-publish step that runs
+    // `cargo install --registry <rehearsal> <crate>` to prove end-to-end
+    // registry-index resolution — the scenario that killed the rc.1
+    // first-publish. Events bracket the check so an auditor replaying
+    // events.jsonl can see the proof (or failure) inline with publishes.
+    RehearsalSmokeCheckStarted {
+        name: String,
+        version: String,
+        registry: String,
+    },
+    RehearsalSmokeCheckSucceeded {
+        name: String,
+        version: String,
+        duration_ms: u128,
+    },
+    RehearsalSmokeCheckFailed {
+        name: String,
+        version: String,
+        message: String,
+    },
+
     // Retry visibility (#91) — emitted immediately before Shipper sleeps on a
     // retry backoff. `attempt` is the just-failed attempt number (1-indexed),
     // so the next attempt will be `attempt + 1` of `max_attempts`. `reason`
@@ -2442,6 +2470,7 @@ mod tests {
             resume_from: None,
             rehearsal_registry: None,
             rehearsal_skip: false,
+            rehearsal_smoke_install: None,
         }
     }
 
@@ -4997,6 +5026,7 @@ mod tests {
                     resume_from: None,
             rehearsal_registry: None,
             rehearsal_skip: false,
+            rehearsal_smoke_install: None,
                 };
 
                 // All duration fields must be positive

--- a/crates/shipper-types/src/snapshots/shipper_types__tests__debug_snapshots__runtime_options_debug_snapshot.snap
+++ b/crates/shipper-types/src/snapshots/shipper_types__tests__debug_snapshots__runtime_options_debug_snapshot.snap
@@ -57,4 +57,5 @@ RuntimeOptions {
     resume_from: None,
     rehearsal_registry: None,
     rehearsal_skip: false,
+    rehearsal_smoke_install: None,
 }

--- a/crates/shipper/src/cli/mod.rs
+++ b/crates/shipper/src/cli/mod.rs
@@ -194,6 +194,19 @@ struct Cli {
     #[arg(long, global = true)]
     skip_rehearsal: bool,
 
+    /// Crate name to smoke-install after a successful rehearsal (#97 PR 4).
+    ///
+    /// Runs `cargo install --registry <rehearsal> <CRATE>` against the
+    /// rehearsal registry to prove the crate actually resolves and
+    /// installs end-to-end — the scenario that workspace-path
+    /// dependencies defeat and that killed the rc.1 first-publish.
+    ///
+    /// The named crate must be in the plan AND have a `[[bin]]` target.
+    /// Library-only crates cannot be smoke-installed directly; use a
+    /// consumer-workspace build instead (follow-on).
+    #[arg(long = "smoke-install", global = true, value_name = "CRATE")]
+    rehearsal_smoke_install: Option<String>,
+
     /// Output format: text (default) or json
     #[arg(long, default_value = "text", value_parser = ["text", "json"], global = true)]
     format: String,
@@ -549,6 +562,7 @@ pub fn run() -> Result<()> {
         resume_from: cli.resume_from.clone(),
         rehearsal_registry: cli.rehearsal_registry.clone(),
         skip_rehearsal: cli.skip_rehearsal,
+        rehearsal_smoke_install: cli.rehearsal_smoke_install.clone(),
     };
 
     // Merge CLI overrides with config (or defaults if no config)
@@ -2110,6 +2124,7 @@ mod tests {
             resume_from: None,
             rehearsal_registry: None,
             rehearsal_skip: false,
+            rehearsal_smoke_install: None,
         };
 
         fs::create_dir_all(td.path().join("cargo-home")).expect("mkdir");
@@ -2181,6 +2196,7 @@ mod tests {
             resume_from: None,
             rehearsal_registry: None,
             rehearsal_skip: false,
+            rehearsal_smoke_install: None,
         };
 
         fs::create_dir_all(td.path().join("cargo-home")).expect("mkdir");

--- a/crates/shipper/src/engine/mod.rs
+++ b/crates/shipper/src/engine/mod.rs
@@ -1542,6 +1542,103 @@ pub fn run_rehearsal(
         packages_published += 1;
     }
 
+    // #97 PR 4 — smoke-install. Opt-in. Runs only if:
+    //   (a) all packages in the plan were published successfully AND
+    //   (b) the operator named a crate via --smoke-install / config.
+    // The named crate must be in the plan; resolves its planned version
+    // to pass through to `cargo install`.
+    if first_failure.is_none()
+        && let Some(ref smoke_name) = opts.rehearsal_smoke_install
+    {
+        match ws.plan.packages.iter().find(|p| &p.name == smoke_name) {
+            Some(smoke_pkg) => {
+                reporter.info(&format!(
+                    "smoke-install: {smoke_name}@{} from '{rehearsal_name}'",
+                    smoke_pkg.version
+                ));
+
+                event_log.record(PublishEvent {
+                    timestamp: Utc::now(),
+                    event_type: EventType::RehearsalSmokeCheckStarted {
+                        name: smoke_pkg.name.clone(),
+                        version: smoke_pkg.version.clone(),
+                        registry: rehearsal_name.clone(),
+                    },
+                    package: format!("{smoke_name}@{}", smoke_pkg.version),
+                });
+                event_log.write_to_file(&events_path)?;
+                event_log.clear();
+
+                let install_root = state_dir.join("smoke-install");
+                let _ = std::fs::remove_dir_all(&install_root);
+                let smoke_start = Instant::now();
+                let out = cargo::cargo_install_smoke(
+                    workspace_root,
+                    &smoke_pkg.name,
+                    &smoke_pkg.version,
+                    &rehearsal_reg.name,
+                    &install_root,
+                    opts.output_lines,
+                    None,
+                )?;
+
+                if out.exit_code == 0 {
+                    let duration_ms = smoke_start.elapsed().as_millis();
+                    event_log.record(PublishEvent {
+                        timestamp: Utc::now(),
+                        event_type: EventType::RehearsalSmokeCheckSucceeded {
+                            name: smoke_pkg.name.clone(),
+                            version: smoke_pkg.version.clone(),
+                            duration_ms,
+                        },
+                        package: format!("{smoke_name}@{}", smoke_pkg.version),
+                    });
+                    reporter.info(&format!(
+                        "smoke-install OK for {smoke_name}@{}",
+                        smoke_pkg.version
+                    ));
+                } else {
+                    let msg = format!(
+                        "cargo install exited {} for {smoke_name}@{}. stderr tail:\n{}",
+                        out.exit_code, smoke_pkg.version, out.stderr_tail
+                    );
+                    reporter.error(&msg);
+                    event_log.record(PublishEvent {
+                        timestamp: Utc::now(),
+                        event_type: EventType::RehearsalSmokeCheckFailed {
+                            name: smoke_pkg.name.clone(),
+                            version: smoke_pkg.version.clone(),
+                            message: msg.clone(),
+                        },
+                        package: format!("{smoke_name}@{}", smoke_pkg.version),
+                    });
+                    first_failure = Some(format!(
+                        "smoke-install of {smoke_name}@{} failed: cargo exit {}",
+                        smoke_pkg.version, out.exit_code
+                    ));
+                }
+                event_log.write_to_file(&events_path)?;
+                event_log.clear();
+            }
+            None => {
+                // Operator named a crate that isn't in the plan. Warn,
+                // don't fail — their intent is clear but the workspace
+                // shape disagrees, and failing the whole rehearsal over
+                // a typo would be overkill.
+                reporter.warn(&format!(
+                    "smoke-install target '{smoke_name}' is not in the rehearsal plan; skipping. \
+                     Available crates: {}",
+                    ws.plan
+                        .packages
+                        .iter()
+                        .map(|p| p.name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+        }
+    }
+
     let passed = first_failure.is_none();
     let summary = if passed {
         format!("rehearsed {packages_published} packages against '{rehearsal_name}' successfully")
@@ -2029,6 +2126,7 @@ mod tests {
             resume_from: None,
             rehearsal_registry: None,
             rehearsal_skip: false,
+            rehearsal_smoke_install: None,
         }
     }
 
@@ -6989,6 +7087,97 @@ mod tests {
                 msg.contains("rehearsal is required") || msg.contains("no rehearsal receipt"),
                 "expected gate error, got: {msg}"
             );
+        });
+    }
+
+    /// #97 PR 4 — smoke-install happy path. --smoke-install names a
+    /// crate in the plan; fake cargo returns 0 for the install call;
+    /// rehearsal emits smoke-check events and passes.
+    #[test]
+    #[serial]
+    fn run_rehearsal_smoke_install_happy_path_emits_succeeded_event() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        let env_vars = fake_program_env_vars(&bin);
+        temp_env::with_vars(env_vars, || {
+            let rehearsal_server = spawn_registry_server(
+                std::collections::BTreeMap::from([(
+                    "/api/v1/crates/demo/0.1.0".to_string(),
+                    vec![(200, "{}".to_string())],
+                )]),
+                1,
+            );
+
+            let ws = planned_workspace(td.path(), "http://127.0.0.1:1".into());
+            let mut opts = default_opts(PathBuf::from(".shipper"));
+            opts.rehearsal_registry = Some("rehearsal".to_string());
+            opts.registries = vec![Registry {
+                name: "rehearsal".to_string(),
+                api_base: rehearsal_server.base_url.clone(),
+                index_base: None,
+            }];
+            opts.rehearsal_smoke_install = Some("demo".to_string());
+
+            let mut reporter = CollectingReporter::default();
+            let outcome = run_rehearsal(&ws, &opts, &mut reporter).expect("rehearse");
+            assert!(outcome.passed, "outcome: {outcome:?}");
+
+            let events = read_events_raw(&td.path().join(".shipper"));
+            let types: Vec<String> = events.iter().filter_map(event_discriminator).collect();
+            assert!(
+                types.contains(&"rehearsal_smoke_check_started".to_string()),
+                "types: {types:?}"
+            );
+            assert!(
+                types.contains(&"rehearsal_smoke_check_succeeded".to_string()),
+                "types: {types:?}"
+            );
+            rehearsal_server.join();
+        });
+    }
+
+    /// #97 PR 4 — smoke-install named a crate not in the plan. Warn-only
+    /// path: rehearsal itself still passes (publish was fine) but the
+    /// reporter surfaces the misconfiguration so the operator can fix it.
+    #[test]
+    #[serial]
+    fn run_rehearsal_smoke_install_missing_target_warns_without_failing() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        let env_vars = fake_program_env_vars(&bin);
+        temp_env::with_vars(env_vars, || {
+            let rehearsal_server = spawn_registry_server(
+                std::collections::BTreeMap::from([(
+                    "/api/v1/crates/demo/0.1.0".to_string(),
+                    vec![(200, "{}".to_string())],
+                )]),
+                1,
+            );
+
+            let ws = planned_workspace(td.path(), "http://127.0.0.1:1".into());
+            let mut opts = default_opts(PathBuf::from(".shipper"));
+            opts.rehearsal_registry = Some("rehearsal".to_string());
+            opts.registries = vec![Registry {
+                name: "rehearsal".to_string(),
+                api_base: rehearsal_server.base_url.clone(),
+                index_base: None,
+            }];
+            opts.rehearsal_smoke_install = Some("nonexistent".to_string());
+
+            let mut reporter = CollectingReporter::default();
+            let outcome = run_rehearsal(&ws, &opts, &mut reporter).expect("rehearse");
+            assert!(outcome.passed);
+            assert!(
+                reporter
+                    .warns
+                    .iter()
+                    .any(|w| w.contains("not in the rehearsal plan")),
+                "warns: {:?}",
+                reporter.warns
+            );
+            rehearsal_server.join();
         });
     }
 

--- a/crates/shipper/src/engine/parallel/tests.rs
+++ b/crates/shipper/src/engine/parallel/tests.rs
@@ -198,6 +198,7 @@ fn default_opts(state_dir: PathBuf) -> RuntimeOptions {
         resume_from: None,
         rehearsal_registry: None,
         rehearsal_skip: false,
+        rehearsal_smoke_install: None,
     }
 }
 

--- a/crates/shipper/src/ops/cargo/mod.rs
+++ b/crates/shipper/src/ops/cargo/mod.rs
@@ -75,6 +75,57 @@ pub fn cargo_yank(
     })
 }
 
+/// Invoke `cargo install --registry <name> <crate> --version <v>` as a
+/// rehearsal smoke check (#97 PR 4).
+///
+/// Used by `shipper rehearse --smoke-install <crate>` to prove that, after
+/// a rehearsal publish, the crate actually **resolves and installs** via
+/// the registry's index — the end-to-end scenario that workspace-path
+/// dependencies defeat.
+///
+/// Installs to `install_root` (typically a tempdir) with `--force` so an
+/// already-installed version of the same crate doesn't shortcut the
+/// check. Output is captured and tailed like other cargo wrappers.
+pub fn cargo_install_smoke(
+    workspace_root: &Path,
+    package_name: &str,
+    version: &str,
+    registry_name: &str,
+    install_root: &Path,
+    output_lines: usize,
+    timeout: Option<Duration>,
+) -> Result<CargoOutput> {
+    let start = Instant::now();
+    let version_arg = format!("--version={version}");
+    let root_arg = install_root.display().to_string();
+    let mut args: Vec<&str> = vec![
+        "install",
+        package_name,
+        &version_arg,
+        "--root",
+        &root_arg,
+        "--force",
+        "--locked",
+    ];
+
+    if !registry_name.trim().is_empty() && registry_name != "crates-io" {
+        args.push("--registry");
+        args.push(registry_name);
+    }
+
+    let output =
+        process::run_command_with_timeout(&cargo_program(), &args, workspace_root, timeout)
+            .context("failed to execute cargo install; is Cargo installed?")?;
+
+    Ok(CargoOutput {
+        exit_code: output.exit_code,
+        stdout_tail: tail_lines(&output.stdout, output_lines),
+        stderr_tail: tail_lines(&output.stderr, output_lines),
+        duration: start.elapsed(),
+        timed_out: output.timed_out,
+    })
+}
+
 pub fn cargo_publish(
     workspace_root: &Path,
     package_name: &str,

--- a/crates/shipper/src/runtime/policy/mod.rs
+++ b/crates/shipper/src/runtime/policy/mod.rs
@@ -380,6 +380,7 @@ mod apply_policy_tests {
             resume_from: None,
             rehearsal_registry: None,
             rehearsal_skip: false,
+            rehearsal_smoke_install: None,
         }
     }
 
@@ -669,6 +670,7 @@ mod property_tests {
                         resume_from: None,
                         rehearsal_registry: None,
                         rehearsal_skip: false,
+                        rehearsal_smoke_install: None,
                     }
                 },
             )
@@ -1074,6 +1076,7 @@ mod absorbed_integration_tests {
             resume_from: None,
             rehearsal_registry: None,
             rehearsal_skip: false,
+            rehearsal_smoke_install: None,
         }
     }
 


### PR DESCRIPTION
## Summary

Final piece of #97's acceptance. Adds an opt-in \`cargo install --registry <rehearsal> <crate>\` step after rehearsal publishes succeed, as end-to-end proof that the crate **resolves + installs** via the registry index. This is the scenario workspace-path dependencies defeat and that killed the rc.1 first-publish.

## What's new

- New event variants: \`RehearsalSmokeCheckStarted\` / \`...Succeeded\` / \`...Failed\`.
- New \`--smoke-install <CRATE>\` flag (global). Names a crate in the plan to install from the rehearsal registry after publish.
- \`ops::cargo::cargo_install_smoke\` wrapper: \`cargo install --registry <name> <crate> --version <v> --root <tmp> --force --locked\`.
- \`engine::run_rehearsal\` post-publish step: if publishes passed AND \`--smoke-install\` named an in-plan crate, run the install. Install failure → whole rehearsal fails (so the hard gate refuses live publish). Named-but-not-in-plan → warn only, don't fail.

## Why opt-in

- Requires a crate with a \`[[bin]]\` target (library-only crates can't \`cargo install\`). A consumer-workspace build variant is a clean follow-on.
- Adds wall-clock. Releases that don't care should not pay for it.
- Operator names the crate explicitly so the signal-to-noise of failures is high.

## Closes #97

| #97 acceptance | Where |
|---|---|
| Publish to alt registry | #127 |
| Verify presence | #127 |
| **Install/build from rehearsal registry** | **This PR** |
| Record proof in RehearsalComplete | #127 |
| Hard gate on plan_id | #133 |

Once merged, #97 can be closed.

## Tests

- \`run_rehearsal_smoke_install_happy_path_emits_succeeded_event\`
- \`run_rehearsal_smoke_install_missing_target_warns_without_failing\`

19/19 rehearsal+gate tests pass (up from 17).

## Test plan

- [x] \`cargo test -p shipper --lib -- rehearsal gate_\` — 19/19 pass
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [ ] CI multi-OS green

## Follow-ons (not this PR)

- Consumer-workspace \`cargo build\` variant for library-only crates.
- Auto-detect a bin crate in the plan when \`--smoke-install\` is passed without a name.
- Match on "smoke-install" in \`.shipper.toml\` for persistent opt-in.