### PR TITLE
feat(remediate): plan-yank --starting-crate graph mode (#98 PR 4)

### DIFF
--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_plan_yank.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_plan_yank.snap
@@ -18,7 +18,7 @@ Options:
           Path to the receipt to derive the plan from. Defaults to `<state_dir>/receipt.json` when omitted
 
       --compromised-only
-          Restrict the plan to packages whose receipt carries a `compromised_at` marker. Without this, every `Published` package is included (full rollback)
+          Restrict the plan to packages whose receipt carries a `compromised_at` marker. Without this, every `Published` package is included (full rollback). Mutually exclusive with `--starting-crate`
 
       --manifest-path <MANIFEST_PATH>
           Path to the workspace Cargo.toml
@@ -28,8 +28,14 @@ Options:
       --registry <REGISTRY>
           Cargo registry name (default: crates-io)
 
+      --starting-crate <CRATE>
+          **Graph mode** (#98 PR 4). Given a specific broken crate name, walk the workspace's dependency graph to find every crate that transitively depends on it, and emit a yank plan covering only that affected chain (not a full rollback). Resolves the graph from the current workspace's `Cargo.toml` metadata — the receipt supplies the versions and Published-state filter
+
       --api-base <API_BASE>
           Registry API base URL (default: <https://crates.io>)
+
+      --reason <REASON>
+          Per-entry reason to embed in the yank plan (applied to every entry). If omitted, each entry's reason falls back to its receipt-level `compromised_by` field (if set)
 
       --package <PACKAGES>
           Restrict to specific packages (repeatable). If omitted, publishes all publishable workspace members

--- a/crates/shipper/src/cli/mod.rs
+++ b/crates/shipper/src/cli/mod.rs
@@ -306,9 +306,24 @@ enum Commands {
         from_receipt: Option<PathBuf>,
         /// Restrict the plan to packages whose receipt carries a
         /// `compromised_at` marker. Without this, every `Published`
-        /// package is included (full rollback).
-        #[arg(long)]
+        /// package is included (full rollback). Mutually exclusive
+        /// with `--starting-crate`.
+        #[arg(long, conflicts_with = "starting_crate")]
         compromised_only: bool,
+        /// **Graph mode** (#98 PR 4). Given a specific broken crate
+        /// name, walk the workspace's dependency graph to find every
+        /// crate that transitively depends on it, and emit a yank
+        /// plan covering only that affected chain (not a full
+        /// rollback). Resolves the graph from the current workspace's
+        /// `Cargo.toml` metadata — the receipt supplies the versions
+        /// and Published-state filter.
+        #[arg(long, value_name = "CRATE")]
+        starting_crate: Option<String>,
+        /// Per-entry reason to embed in the yank plan (applied to
+        /// every entry). If omitted, each entry's reason falls back
+        /// to its receipt-level `compromised_by` field (if set).
+        #[arg(long, value_name = "REASON")]
+        reason: Option<String>,
     },
     /// Generate a fix-forward supersession plan from a compromised
     /// receipt (#98 PR 3).
@@ -855,6 +870,8 @@ pub fn run() -> Result<()> {
         Commands::PlanYank {
             from_receipt,
             compromised_only,
+            starting_crate,
+            reason,
         } => {
             use crate::engine::plan_yank::{self, PlanYankFilter};
 
@@ -870,13 +887,28 @@ pub fn run() -> Result<()> {
                     .to_string()
             })?;
 
-            let filter = if compromised_only {
-                PlanYankFilter::CompromisedOnly
+            // Three mutually-informative modes:
+            //   --starting-crate <N>   → graph mode (walk dependents)
+            //   --compromised-only     → receipt-filter mode (marker)
+            //   (default)              → receipt-filter mode (all Published)
+            // clap's `conflicts_with` already rejects combinations at parse time.
+            let plan = if let Some(ref starting) = starting_crate {
+                // Graph mode uses the *current workspace's* dependency graph,
+                // read from the planned workspace we already built upstream.
+                plan_yank::build_plan_from_starting_crate(
+                    &receipt,
+                    &planned.plan.dependencies,
+                    starting,
+                    reason.clone(),
+                )?
             } else {
-                PlanYankFilter::AllPublished
+                let filter = if compromised_only {
+                    PlanYankFilter::CompromisedOnly
+                } else {
+                    PlanYankFilter::AllPublished
+                };
+                plan_yank::build_plan(&receipt, filter)
             };
-
-            let plan = plan_yank::build_plan(&receipt, filter);
 
             match cli.format.as_str() {
                 "json" => {

--- a/crates/shipper/src/engine/plan_yank.rs
+++ b/crates/shipper/src/engine/plan_yank.rs
@@ -31,7 +31,9 @@
 //! Keeping this PR to **planning only** matches the staged rollout agreed
 //! in the #98 scope: primitive → plan → execute / fix-forward.
 
-use anyhow::{Context, Result};
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::{Context, Result, bail};
 use shipper_types::{PackageReceipt, PackageState, Receipt};
 
 /// One entry in a reverse-topological yank plan.
@@ -104,6 +106,82 @@ pub fn build_plan(receipt: &Receipt, filter: PlanYankFilter) -> YankPlan {
         },
         entries,
     }
+}
+
+/// Build a reverse-topological yank plan rooted at a specific broken crate
+/// (#98 PR 4). Walks the release plan's dependency graph backwards from
+/// `starting_crate` to enumerate every crate that transitively depends on
+/// it, then orders them dependents-first.
+///
+/// This is the **graph mode** complement to `build_plan`'s receipt-filter
+/// modes. Use when you know exactly which crate is broken (e.g. CVE
+/// targeting `my-lib`) and want containment of only the affected
+/// dependency chain — not a full-release rollback.
+///
+/// `dependency_graph` is `plan.dependencies` from the original
+/// `ReleasePlan` (crate → list of its intra-workspace deps). Not
+/// embedded in `Receipt` because receipts are summaries, not graphs.
+///
+/// Errors if `starting_crate` is not in the receipt.
+pub fn build_plan_from_starting_crate(
+    receipt: &Receipt,
+    dependency_graph: &BTreeMap<String, Vec<String>>,
+    starting_crate: &str,
+    reason: Option<String>,
+) -> Result<YankPlan> {
+    if !receipt.packages.iter().any(|p| p.name == starting_crate) {
+        bail!(
+            "starting crate '{starting_crate}' is not in this receipt; \
+             available packages: {}",
+            receipt
+                .packages
+                .iter()
+                .map(|p| p.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+
+    // Reverse-walk the dependency graph: starting from the broken crate,
+    // collect every crate that (transitively) depends on it.
+    let mut affected: BTreeSet<String> = BTreeSet::new();
+    affected.insert(starting_crate.to_string());
+    let mut frontier: Vec<String> = vec![starting_crate.to_string()];
+    while let Some(current) = frontier.pop() {
+        for (dependent, deps) in dependency_graph.iter() {
+            if deps.iter().any(|d| d == &current) && affected.insert(dependent.clone()) {
+                frontier.push(dependent.clone());
+            }
+        }
+    }
+
+    // receipt.packages is in topological order. Filter to the affected set
+    // and restrict to actually-Published entries (yanking a Failed / never-
+    // shipped entry is a no-op on the registry). Then reverse so
+    // dependents come first.
+    let mut entries: Vec<YankEntry> = receipt
+        .packages
+        .iter()
+        .filter(|p| affected.contains(&p.name))
+        .filter(|p| matches!(p.state, PackageState::Published))
+        .map(|p| YankEntry {
+            name: p.name.clone(),
+            version: p.version.clone(),
+            // Per-entry reason priority:
+            //   1. Operator-supplied `--reason <text>` (applies to all)
+            //   2. Existing `compromised_by` on the receipt entry
+            //   3. None
+            reason: reason.clone().or_else(|| p.compromised_by.clone()),
+        })
+        .collect();
+    entries.reverse();
+
+    Ok(YankPlan {
+        plan_id: receipt.plan_id.clone(),
+        registry: receipt.registry.name.clone(),
+        filter: "starting_crate",
+        entries,
+    })
 }
 
 /// Load a receipt from an arbitrary path (not necessarily inside a state dir).
@@ -266,5 +344,99 @@ mod tests {
             "b must come before a in reverse topo:\n{out}"
         );
         assert!(out.starts_with("# yank plan"));
+    }
+
+    // ── build_plan_from_starting_crate tests (#98 PR 4) ─────────────────
+
+    /// Graph: a (leaf) ← b ← c. Dep map says: b depends on a, c depends
+    /// on b and a. Starting from "a" (the leaf), all three should be in
+    /// the plan, with c yanked first, then b, then a.
+    #[test]
+    fn starting_crate_walks_all_transitive_dependents_in_reverse_topo() {
+        let r = sample_receipt(vec![
+            pkg("a", PackageState::Published, None),
+            pkg("b", PackageState::Published, None),
+            pkg("c", PackageState::Published, None),
+        ]);
+        let mut deps = BTreeMap::new();
+        deps.insert("a".to_string(), vec![]);
+        deps.insert("b".to_string(), vec!["a".to_string()]);
+        deps.insert("c".to_string(), vec!["a".to_string(), "b".to_string()]);
+
+        let plan = build_plan_from_starting_crate(&r, &deps, "a", None).expect("plan");
+        let names: Vec<_> = plan.entries.iter().map(|e| e.name.clone()).collect();
+        assert_eq!(names, vec!["c", "b", "a"]);
+        assert_eq!(plan.filter, "starting_crate");
+    }
+
+    /// Graph: a ← b (b depends on a), plus an unrelated crate z. Starting
+    /// from "a" should yank a and b but NOT z (no dependency edge).
+    #[test]
+    fn starting_crate_ignores_unrelated_crates() {
+        let r = sample_receipt(vec![
+            pkg("a", PackageState::Published, None),
+            pkg("b", PackageState::Published, None),
+            pkg("z", PackageState::Published, None),
+        ]);
+        let mut deps = BTreeMap::new();
+        deps.insert("a".to_string(), vec![]);
+        deps.insert("b".to_string(), vec!["a".to_string()]);
+        deps.insert("z".to_string(), vec![]); // independent
+
+        let plan = build_plan_from_starting_crate(&r, &deps, "a", None).expect("plan");
+        let names: Vec<_> = plan.entries.iter().map(|e| e.name.clone()).collect();
+        assert_eq!(names, vec!["b", "a"]);
+        assert!(!names.contains(&"z".to_string()));
+    }
+
+    #[test]
+    fn starting_crate_skips_non_published_entries() {
+        let r = sample_receipt(vec![
+            pkg("a", PackageState::Published, None),
+            pkg(
+                "b",
+                PackageState::Failed {
+                    class: shipper_types::ErrorClass::Permanent,
+                    message: "nope".into(),
+                },
+                None,
+            ),
+        ]);
+        let mut deps = BTreeMap::new();
+        deps.insert("b".to_string(), vec!["a".to_string()]);
+
+        let plan = build_plan_from_starting_crate(&r, &deps, "a", None).expect("plan");
+        // b is a dependent of a but it Failed to publish — never on
+        // registry — so it's excluded from the yank plan. Only a remains.
+        let names: Vec<_> = plan.entries.iter().map(|e| e.name.clone()).collect();
+        assert_eq!(names, vec!["a"]);
+    }
+
+    #[test]
+    fn starting_crate_applies_explicit_reason_to_every_entry() {
+        let r = sample_receipt(vec![
+            pkg("a", PackageState::Published, None),
+            pkg("b", PackageState::Published, None),
+        ]);
+        let mut deps = BTreeMap::new();
+        deps.insert("b".to_string(), vec!["a".to_string()]);
+
+        let plan =
+            build_plan_from_starting_crate(&r, &deps, "a", Some("CVE-2026-0001".to_string()))
+                .expect("plan");
+        assert_eq!(plan.entries.len(), 2);
+        for entry in &plan.entries {
+            assert_eq!(entry.reason.as_deref(), Some("CVE-2026-0001"));
+        }
+    }
+
+    #[test]
+    fn starting_crate_errors_when_not_in_receipt() {
+        let r = sample_receipt(vec![pkg("a", PackageState::Published, None)]);
+        let deps: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        let err =
+            build_plan_from_starting_crate(&r, &deps, "bogus", None).expect_err("should error");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("not in this receipt"), "err: {msg}");
     }
 }


### PR DESCRIPTION
## Summary

Adds the second \`plan-yank\` selector mode: **given a broken crate name, walk the workspace's dependency graph to find every crate that transitively depends on it, and emit a containment plan scoped to that affected chain.** Complements the existing \`--compromised-only\` receipt-filter mode.

Matches #98's issue spec verbatim:

> \`shipper plan-yank --from-receipt <path> --starting-crate <name> --reason <text>\`

## What's new

- **\`plan_yank::build_plan_from_starting_crate(&receipt, &deps, crate, reason)\`**: reverse-BFS through the dep graph to enumerate transitive dependents, filter the receipt's topo-ordered Published packages, reverse → dependents-first.
- **CLI**: \`--starting-crate <CRATE>\` + \`--reason <TEXT>\` on \`plan-yank\`. clap \`conflicts_with\` rejects combining with \`--compromised-only\` at parse time.

## Algorithm

Reverse BFS: for each reachable crate, scan the dep map for crates whose dep list contains it; add those to the frontier. Final set = starting crate ∪ transitive dependents. Filter receipt.packages (topo order) to that set, keep only \`Published\`, reverse to get dependents-first.

## Example

\`\`\`
\$ shipper plan-yank --from-receipt .shipper/receipt.json \
    --starting-crate my-lib --reason \"CVE-2026-0001\"
# yank plan (reverse topological) — registry=crates-io, plan_id=abc, filter=starting_crate
# 3 entries
  1. shipper yank --crate app    --version 0.1.0 --reason <REASON>  # CVE-2026-0001
  2. shipper yank --crate mid    --version 0.1.0 --reason <REASON>  # CVE-2026-0001
  3. shipper yank --crate my-lib --version 0.1.0 --reason <REASON>  # CVE-2026-0001
\`\`\`

(app depends on mid, mid depends on my-lib)

## Tests

5 new unit tests, 10 total in \`plan_yank::tests\`:

- walks all transitive dependents in reverse topo
- ignores unrelated crates (no edge → not in plan)
- skips non-Published entries
- \`--reason\` applies to every entry (falls back to receipt \`compromised_by\` otherwise)
- errors when starting crate isn't in receipt

## Closes half of #98's remaining gap

Combined with \`--compromised-only\` (#132), plan-yank fully satisfies the graph + receipt-filter modes #98 asks for. Plan execution wrappers for yank/fix-forward are the remaining piece (follow-on PR).

## Test plan

- [x] \`cargo test -p shipper --lib plan_yank\` — 10/10 pass
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [ ] CI multi-OS green