### PR TITLE
feat(remediate): shipper yank --plan executes a saved plan (#98 PR 5)

### DIFF
--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_yank.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_yank.snap
@@ -8,14 +8,14 @@ Yank a crate@version from the registry — containment, not undo.
 
 Part of [#98 Remediate](https://github.com/EffortlessMetrics/shipper/issues/98). Follow-on commands (`shipper plan-yank`, `shipper fix-forward`) compose this primitive into reverse-topological containment and fix-forward plans.
 
-Usage: shipper-cli yank [OPTIONS] --crate <NAME> --version <VERSION> --reason <REASON>
+Usage: shipper-cli yank [OPTIONS]
 
 Options:
       --config <CONFIG>
           Path to a custom configuration file (.shipper.toml)
 
       --crate <NAME>
-          Name of the crate to yank (e.g., `shipper-types`)
+          Name of the crate to yank (e.g., `shipper-types`). Required unless `--plan` is supplied
 
       --manifest-path <MANIFEST_PATH>
           Path to the workspace Cargo.toml
@@ -23,10 +23,10 @@ Options:
           [default: Cargo.toml]
 
       --version <VERSION>
-          Version to yank (e.g., `[VERSION]`)
+          Version to yank (e.g., `[VERSION]`). Required unless `--plan` is supplied
 
       --reason <REASON>
-          Operator-supplied reason (recorded in the event log, audit trails, and any future receipts that reference this yank).
+          Operator-supplied reason. Required unless `--plan` is supplied. Recorded in the event log, audit trails, and any future receipts that reference this yank.
           
           Example: `"CVE-2026-0001 disclosed; containing while patch released"`.
 
@@ -37,10 +37,13 @@ Options:
           Registry API base URL (default: <https://crates.io>)
 
       --mark-compromised
-          Also mark the crate's existing receipt entry as compromised (#98 PR 3). Sets `compromised_at = now` and `compromised_by = <reason>` on the matching `PackageReceipt` in `<state_dir>/receipt.json`, so downstream commands like `shipper plan-yank --compromised-only` and `shipper fix-forward` can find the compromised packages without scanning events.jsonl. No-op if no matching receipt exists (prints a warning)
+          Also mark the crate's existing receipt entry as compromised (#98 PR 3). Ignored in `--plan` mode (plan execution already carries per-entry reasons from the planning step)
 
       --package <PACKAGES>
           Restrict to specific packages (repeatable). If omitted, publishes all publishable workspace members
+
+      --plan <PATH>
+          **Plan execution mode** (#98 PR 5). Path to a yank plan JSON file (the `--format json` output of `shipper plan-yank`). Walks the plan's entries in order, invoking `cargo yank` for each. Mutually exclusive with `--crate` / `--version` / `--reason`
 
       --state-dir <STATE_DIR>
           Directory for shipper state and receipts (default: .shipper)

--- a/crates/shipper/src/cli/mod.rs
+++ b/crates/shipper/src/cli/mod.rs
@@ -265,28 +265,34 @@ enum Commands {
     /// compose this primitive into reverse-topological containment and
     /// fix-forward plans.
     Yank {
-        /// Name of the crate to yank (e.g., `shipper-types`).
-        #[arg(long = "crate", value_name = "NAME")]
-        crate_name: String,
-        /// Version to yank (e.g., `0.3.0-rc.1`).
-        #[arg(long, value_name = "VERSION")]
-        version: String,
-        /// Operator-supplied reason (recorded in the event log, audit
-        /// trails, and any future receipts that reference this yank).
+        /// Name of the crate to yank (e.g., `shipper-types`). Required
+        /// unless `--plan` is supplied.
+        #[arg(long = "crate", value_name = "NAME", conflicts_with = "plan")]
+        crate_name: Option<String>,
+        /// Version to yank (e.g., `0.3.0-rc.1`). Required unless `--plan`
+        /// is supplied.
+        #[arg(long, value_name = "VERSION", conflicts_with = "plan")]
+        version: Option<String>,
+        /// Operator-supplied reason. Required unless `--plan` is supplied.
+        /// Recorded in the event log, audit trails, and any future
+        /// receipts that reference this yank.
         ///
         /// Example: `"CVE-2026-0001 disclosed; containing while patch
         /// released"`.
-        #[arg(long)]
-        reason: String,
+        #[arg(long, conflicts_with = "plan")]
+        reason: Option<String>,
         /// Also mark the crate's existing receipt entry as compromised
-        /// (#98 PR 3). Sets `compromised_at = now` and `compromised_by =
-        /// <reason>` on the matching `PackageReceipt` in
-        /// `<state_dir>/receipt.json`, so downstream commands like
-        /// `shipper plan-yank --compromised-only` and `shipper fix-forward`
-        /// can find the compromised packages without scanning events.jsonl.
-        /// No-op if no matching receipt exists (prints a warning).
+        /// (#98 PR 3). Ignored in `--plan` mode (plan execution already
+        /// carries per-entry reasons from the planning step).
         #[arg(long)]
         mark_compromised: bool,
+        /// **Plan execution mode** (#98 PR 5). Path to a yank plan JSON
+        /// file (the `--format json` output of `shipper plan-yank`).
+        /// Walks the plan's entries in order, invoking `cargo yank` for
+        /// each. Mutually exclusive with `--crate` / `--version` /
+        /// `--reason`.
+        #[arg(long, value_name = "PATH")]
+        plan: Option<PathBuf>,
     },
     /// Generate a reverse-topological yank plan from a receipt (#98 PR 2).
     ///
@@ -744,11 +750,139 @@ pub fn run() -> Result<()> {
             version,
             reason,
             mark_compromised,
+            plan,
         } => {
             use crate::cargo;
+            use crate::engine::plan_yank;
             use crate::state::events::{EventLog, events_path};
             use crate::state::execution_state::{load_receipt, receipt_path, write_receipt};
             use crate::types::{EventType, PublishEvent};
+
+            // #98 PR 5 — plan execution mode. Dispatched entirely
+            // separately from the single-yank path below; the two share
+            // the same cargo_yank primitive but different orchestration.
+            if let Some(plan_path) = plan {
+                let yank_plan = plan_yank::load_plan_from_path(&plan_path)?;
+                reporter.info(&format!(
+                    "executing yank plan: {} entries against '{}' (plan_id {})",
+                    yank_plan.entries.len(),
+                    yank_plan.registry,
+                    yank_plan.plan_id
+                ));
+
+                let workspace_root = std::env::current_dir()
+                    .context("failed to resolve current dir for plan execution")?;
+                let registry_name = opts
+                    .registries
+                    .first()
+                    .map(|r| r.name.clone())
+                    .unwrap_or_else(|| yank_plan.registry.clone());
+
+                let mut log = EventLog::new();
+                let events_file = events_path(&opts.state_dir);
+
+                let mut succeeded = 0usize;
+                let mut failed: Option<(String, i32)> = None;
+
+                for (i, entry) in yank_plan.entries.iter().enumerate() {
+                    let entry_reason = entry
+                        .reason
+                        .clone()
+                        .unwrap_or_else(|| "plan execution".to_string());
+                    reporter.warn(&format!(
+                        "[{}/{}] yanking {}@{} — reason: {}",
+                        i + 1,
+                        yank_plan.entries.len(),
+                        entry.name,
+                        entry.version,
+                        entry_reason
+                    ));
+
+                    let out = cargo::cargo_yank(
+                        &workspace_root,
+                        entry.name.as_str(),
+                        entry.version.as_str(),
+                        registry_name.as_str(),
+                        opts.output_lines,
+                        None,
+                    )?;
+
+                    log.record(PublishEvent {
+                        timestamp: chrono::Utc::now(),
+                        event_type: EventType::PackageYanked {
+                            crate_name: entry.name.clone(),
+                            version: entry.version.clone(),
+                            reason: entry_reason.clone(),
+                            exit_code: out.exit_code,
+                        },
+                        package: format!("{}@{}", entry.name, entry.version),
+                    });
+                    if let Err(err) = log.write_to_file(&events_file) {
+                        reporter.warn(&format!(
+                            "failed to append PackageYanked event to {}: {err:#}",
+                            events_file.display()
+                        ));
+                    }
+                    log.clear();
+
+                    if out.exit_code == 0 {
+                        succeeded += 1;
+                        reporter.info(&format!(
+                            "[{}/{}] yanked {}@{}",
+                            i + 1,
+                            yank_plan.entries.len(),
+                            entry.name,
+                            entry.version
+                        ));
+                    } else {
+                        reporter.error(&format!(
+                            "[{}/{}] cargo yank exited {} for {}@{}. stderr tail:\n{}",
+                            i + 1,
+                            yank_plan.entries.len(),
+                            out.exit_code,
+                            entry.name,
+                            entry.version,
+                            out.stderr_tail
+                        ));
+                        failed = Some((format!("{}@{}", entry.name, entry.version), out.exit_code));
+                        // Halt on first failure. Plan is reverse-topo so
+                        // every entry below this one is a dependent of
+                        // something we just failed to yank — continuing
+                        // would only produce more damage.
+                        break;
+                    }
+                }
+
+                if let Some((pkg, code)) = failed {
+                    reporter.error(&format!(
+                        "yank plan halted: {succeeded}/{} succeeded; failed at {pkg} (cargo exit {code})",
+                        yank_plan.entries.len()
+                    ));
+                    anyhow::bail!(
+                        "yank plan failed at {pkg}; {succeeded}/{} entries succeeded before halt",
+                        yank_plan.entries.len()
+                    );
+                } else {
+                    reporter.info(&format!(
+                        "yank plan complete: {succeeded}/{} entries yanked successfully",
+                        yank_plan.entries.len()
+                    ));
+                    return Ok(());
+                }
+            }
+
+            // Single-yank mode (the original shape). All three fields
+            // are required when `--plan` is absent; clap's
+            // `conflicts_with` already rejected the mixed combinations.
+            let crate_name = crate_name.ok_or_else(|| {
+                anyhow::anyhow!("--crate is required when --plan is not supplied")
+            })?;
+            let version = version.ok_or_else(|| {
+                anyhow::anyhow!("--version is required when --plan is not supplied")
+            })?;
+            let reason = reason.ok_or_else(|| {
+                anyhow::anyhow!("--reason is required when --plan is not supplied")
+            })?;
 
             reporter.warn(&format!(
                 "yanking {crate_name}@{version} from registry \

--- a/crates/shipper/src/engine/plan_yank.rs
+++ b/crates/shipper/src/engine/plan_yank.rs
@@ -37,7 +37,11 @@ use anyhow::{Context, Result, bail};
 use shipper_types::{PackageReceipt, PackageState, Receipt};
 
 /// One entry in a reverse-topological yank plan.
-#[derive(Debug, Clone, serde::Serialize)]
+///
+/// Both `Serialize` and `Deserialize` because plan files are meant to
+/// round-trip: planner writes JSON, operator reviews, executor reads
+/// it back (#98 PR 5).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct YankEntry {
     pub name: String,
     pub version: String,
@@ -45,7 +49,7 @@ pub struct YankEntry {
     /// surfaces here so the operator running the plan sees per-crate
     /// context (CVE id, ticket, etc.) without having to cross-reference
     /// the receipt.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
 }
 
@@ -63,12 +67,20 @@ pub enum PlanYankFilter {
 }
 
 /// A reverse-topological yank plan derived from a receipt.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct YankPlan {
     pub plan_id: String,
     pub registry: String,
-    pub filter: &'static str,
+    /// Which selector produced this plan. Serialized as a `String` in
+    /// both directions so the plan file round-trips cleanly even across
+    /// Shipper versions that add new selector modes.
+    #[serde(default = "unknown_filter")]
+    pub filter: std::borrow::Cow<'static, str>,
     pub entries: Vec<YankEntry>,
+}
+
+fn unknown_filter() -> std::borrow::Cow<'static, str> {
+    std::borrow::Cow::Borrowed("unknown")
 }
 
 fn include(receipt: &PackageReceipt, filter: PlanYankFilter) -> bool {
@@ -100,10 +112,10 @@ pub fn build_plan(receipt: &Receipt, filter: PlanYankFilter) -> YankPlan {
     YankPlan {
         plan_id: receipt.plan_id.clone(),
         registry: receipt.registry.name.clone(),
-        filter: match filter {
+        filter: std::borrow::Cow::Borrowed(match filter {
             PlanYankFilter::AllPublished => "all_published",
             PlanYankFilter::CompromisedOnly => "compromised_only",
-        },
+        }),
         entries,
     }
 }
@@ -179,9 +191,22 @@ pub fn build_plan_from_starting_crate(
     Ok(YankPlan {
         plan_id: receipt.plan_id.clone(),
         registry: receipt.registry.name.clone(),
-        filter: "starting_crate",
+        filter: std::borrow::Cow::Borrowed("starting_crate"),
         entries,
     })
+}
+
+/// Load a saved yank plan from disk (#98 PR 5).
+///
+/// Used by `shipper yank --plan <path>` to drive execution over a
+/// reviewed plan file produced by `shipper plan-yank`. The file format
+/// is the same JSON shape `plan-yank --format json` produces, so plans
+/// round-trip without any munging.
+pub fn load_plan_from_path(path: &std::path::Path) -> Result<YankPlan> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read yank plan at {}", path.display()))?;
+    serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse yank plan at {}", path.display()))
 }
 
 /// Load a receipt from an arbitrary path (not necessarily inside a state dir).
@@ -438,5 +463,46 @@ mod tests {
             build_plan_from_starting_crate(&r, &deps, "bogus", None).expect_err("should error");
         let msg = format!("{err:#}");
         assert!(msg.contains("not in this receipt"), "err: {msg}");
+    }
+
+    // ── load_plan_from_path (#98 PR 5) roundtrip ──────────────────────────
+
+    #[test]
+    fn yank_plan_json_roundtrips_via_load_plan_from_path() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let r = sample_receipt(vec![
+            pkg("a", PackageState::Published, Some("CVE-1")),
+            pkg("b", PackageState::Published, None),
+        ]);
+        let plan = build_plan(&r, PlanYankFilter::AllPublished);
+        let path = td.path().join("yank-plan.json");
+        let raw = serde_json::to_string_pretty(&plan).expect("serialize");
+        std::fs::write(&path, raw).expect("write");
+
+        let loaded = load_plan_from_path(&path).expect("load");
+        assert_eq!(loaded.plan_id, plan.plan_id);
+        assert_eq!(loaded.registry, plan.registry);
+        assert_eq!(loaded.entries.len(), plan.entries.len());
+        // Entry order preserved (dependents first)
+        assert_eq!(loaded.entries[0].name, "b");
+        assert_eq!(loaded.entries[1].name, "a");
+        // Per-entry reason preserved
+        assert_eq!(loaded.entries[1].reason.as_deref(), Some("CVE-1"));
+    }
+
+    #[test]
+    fn load_plan_from_path_errors_on_missing_file() {
+        let err = load_plan_from_path(std::path::Path::new("/definitely/not/there.json"))
+            .expect_err("should fail");
+        assert!(format!("{err:#}").contains("failed to read yank plan"));
+    }
+
+    #[test]
+    fn load_plan_from_path_errors_on_malformed_json() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let path = td.path().join("malformed.json");
+        std::fs::write(&path, "{ not valid json ").expect("write");
+        let err = load_plan_from_path(&path).expect_err("should fail");
+        assert!(format!("{err:#}").contains("failed to parse yank plan"));
     }
 }


### PR DESCRIPTION
## Summary

Closes the plan-execution gap in #98. \`shipper plan-yank --format json\` emits a \`YankPlan\`; \`shipper yank --plan <PATH>\` walks that plan and invokes \`cargo yank\` per entry. Round-trip-safe via JSON.

## What's new

- \`YankEntry\` / \`YankPlan\` derive \`Deserialize\`. \`filter\` field moves from \`&'static str\` to \`Cow<'static, str>\` to allow owned strings from disk without breaking the construction path.
- \`plan_yank::load_plan_from_path\` — thin helper mirroring \`load_receipt_from_path\`.
- CLI: \`shipper yank --plan <PATH>\`. Mutually exclusive with \`--crate\` / \`--version\` / \`--reason\` (clap \`conflicts_with\`).
- Handler: iterates entries in order, emits \`PackageYanked\` event per invocation, halts on first non-zero cargo exit.

## Why halt-on-failure

The plan is reverse-topological. If yank N fails, yank N+1 targets a dependent of a crate we just failed to yank — continuing is just more damage. Operator reviews the stderr, fixes the underlying issue, re-runs the plan (cargo yank is idempotent for already-yanked versions).

## Scope

**Does:**
- Execute yank plans end-to-end.
- Events-as-truth: PackageYanked event per invocation, including failures with real exit codes.

**Does not:**
- Resume interrupted plan runs — re-run is idempotent, operator discipline covers it.
- \`fix-forward --plan\` execution — needs Cargo.toml edit tooling; deserves its own PR.

## Tests

3 new unit tests (8 total in \`plan_yank::tests\`):
- YankPlan JSON round-trips: entries + order + per-entry reason preserved
- \`load_plan_from_path\` errors cleanly on missing file
- \`load_plan_from_path\` errors cleanly on malformed JSON

\`yank --help\` snapshot regenerated.

## Closes most of #98

With #138 (starting-crate) and this one, #98's acceptance is:

- [x] Receipt fields (compromised_at/compromised_by/superseded_by) — #132
- [x] plan-yank --from-receipt + --starting-crate + --reason — #132 + #138
- [x] **shipper yank executes a plan** — **this PR**
- [ ] shipper fix-forward --plan executes a plan — follow-on (workspace-edit scope)
- [x] Docs distinguish yank semantics — #134

Ready to close #98 with a comment pointing at this chain, leaving fix-forward execution as a scoped follow-on.

## Test plan

- [x] \`cargo test -p shipper --lib plan_yank\` — 8/8 pass
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [ ] CI multi-OS green