### PR TITLE
feat(packaging): shrink shipper to install façade (#95 PR 3)

### DIFF
--- a/crates/shipper/CLAUDE.md
+++ b/crates/shipper/CLAUDE.md
@@ -1,13 +1,36 @@
 # CLAUDE.md
 
-This file provides agent-specific guidance for working in crate shipper.
+This file provides agent-specific guidance for working in crate `shipper`.
 
-## Scope
+## Role
 
-- Crate: shipper
-- Path: crates/shipper
-- Workspace root: h:\Code\Rust\shipper
-- Primary entry: src/lib.rs
+`shipper` is the **install face** of the product, not the engine.
+
+- Binary: `src/bin/shipper.rs` — 3 lines, forwards to `shipper_cli::run()`.
+- Library: `src/lib.rs` — curated re-export of `shipper-core`'s public
+  surface for drivers that prefer the product name.
+- Engine: lives in `shipper-core`.
+- CLI: lives in `shipper-cli`.
+
+```text
+shipper (this crate)       install target + curated re-export
+  -> shipper-cli           clap parsing, subcommand dispatch, output
+       -> shipper-core     engine (plan, preflight, publish, resume, …)
+```
+
+Behavior changes belong in `shipper-core` (or `shipper-cli` for
+CLI-surface changes). This crate's surface should move rarely — it
+exists to be a stable "install me" handle.
+
+## Curated re-exports
+
+`src/lib.rs` re-exports: `config`, `engine`, `plan`, `state`, `store`,
+`types`. These are the modules a programmatic driver would reach for.
+
+Engine internals (`auth`, `cargo`, `encryption`, `git`, `lock`,
+`registry`, `retry`, `runtime`, `webhook`, `cargo_failure`) are
+intentionally not re-exported. Reach for them through `shipper-core`
+directly if you're embedding.
 
 ## Useful commands
 
@@ -17,13 +40,23 @@ cargo test -p shipper
 cargo test -p shipper --all-features
 cargo fmt -p shipper
 cargo clippy -p shipper --all-targets --all-features -- -D warnings
+
+# Build + sanity-check the installable binary
+cargo build -p shipper --release
+./target/release/shipper --help
 ```
 
 ## Context
 
-- Keep changes small and targeted to the crate’s existing abstractions.
-- Preserve public API compatibility unless the request explicitly asks for breaking changes.
-- When touching serialization or state formats, update tests and related snapshots in the same crate.
-- Prefer using existing fixtures and helpers rather than introducing inline test data.
+- Keep changes small. Most real work should happen in `shipper-core`
+  or `shipper-cli`, not here.
+- Preserve public API compatibility on the curated re-exports. If a
+  driver imports `shipper::engine::run_publish`, that path must keep
+  working.
+- Don't add CLI dependencies (`clap`, `indicatif`, shell completions)
+  — those belong in `shipper-cli`.
+- Don't add new engine modules here — those belong in `shipper-core`.
+- If tests in `tests/` reach beyond the curated façade, update them
+  to import from `shipper_core::X` instead (and note it in the PR).
 
 For full workspace guidance, see [../../CLAUDE.md](H:\Code\Rust\shipper\CLAUDE.md).

--- a/crates/shipper/Cargo.toml
+++ b/crates/shipper/Cargo.toml
@@ -36,7 +36,10 @@ workspace = true
 
 [dev-dependencies]
 # Integration tests exercise the re-exported surface but also reach
-# directly into the types microcrate for constructing fixtures.
+# directly into `shipper-core` (for engine internals like `runtime::`
+# that aren't part of the curated façade) and `shipper-types` (for
+# constructing fixtures).
+shipper-core.workspace = true
 shipper-types.workspace = true
 
 tempfile = "3.26.0"

--- a/crates/shipper/README.md
+++ b/crates/shipper/README.md
@@ -1,78 +1,79 @@
-# shipper (library)
+# shipper
 
-`shipper` is the core library for reliable, resumable Rust workspace publishing.
-It powers `shipper-cli` and is useful when you want to embed publish orchestration
-into custom release tooling.
+Reliable, resumable `cargo publish` for Rust workspaces.
 
-## What this crate does
-
-- Builds deterministic publish plans from workspace metadata.
-- Runs preflight checks (git state, publishability, registry visibility, ownership checks).
-- Executes publish flows with retry and backoff.
-- Verifies registry visibility and readiness between dependency levels.
-- Persists state, receipts, and event logs for resumable execution.
-- Supports sequential and parallel publishing engines.
-
-## Public API map
-
-- `plan::build_plan` - build the dependency-first publish plan.
-- `engine::run_preflight` - run checks without publishing.
-- `engine::run_publish` - execute publish with state persistence.
-- `engine::run_resume` - continue interrupted runs.
-- `engine::parallel::run_publish_parallel` - publish dependency levels concurrently.
-- `config` - load and merge `.shipper.toml` settings.
-- `types` - domain types for plans, options, state, events, and receipts.
-
-## Minimal integration example
-
-```rust,no_run
-use anyhow::Result;
-use shipper::config::{CliOverrides, ShipperConfig};
-use shipper::engine::{self, Reporter};
-use shipper::plan;
-use shipper::types::{Registry, ReleaseSpec};
-
-struct StdReporter;
-
-impl Reporter for StdReporter {
-    fn info(&mut self, msg: &str) {
-        eprintln!("[info] {msg}");
-    }
-
-    fn warn(&mut self, msg: &str) {
-        eprintln!("[warn] {msg}");
-    }
-
-    fn error(&mut self, msg: &str) {
-        eprintln!("[error] {msg}");
-    }
-}
-
-fn main() -> Result<()> {
-    let spec = ReleaseSpec {
-        manifest_path: "Cargo.toml".into(),
-        registry: Registry::crates_io(),
-        selected_packages: None,
-    };
-
-    let planned = plan::build_plan(&spec)?;
-    let opts = ShipperConfig::default().build_runtime_options(CliOverrides::default());
-    let mut reporter = StdReporter;
-
-    let report = engine::run_preflight(&planned, &opts, &mut reporter)?;
-    println!("Finishability: {:?}", report.finishability);
-    Ok(())
-}
+```text
+cargo install shipper --locked
 ```
 
-## Not in scope
+Shipper runs a multi-crate workspace release to crates.io (or any
+Cargo-compatible registry) with the safety guarantees that `cargo
+publish` alone can't give you:
 
-`shipper` does not decide version numbers, generate changelogs, tag releases,
-or create GitHub releases. Pair it with your preferred versioning/release
-workflow and use this crate to make publishing reliable.
+- **Resumable** — if a publish is interrupted (CI timeout, rate limit,
+  network blip), `shipper resume` picks up from exactly where it
+  stopped. Already-published crates are skipped; ambiguous crates
+  reconcile against the registry first.
+- **Backoff-aware** — 429s and transient network errors retry with
+  jittered exponential backoff. Permanent failures fail fast.
+- **Events-as-truth** — every step writes to `.shipper/events.jsonl`.
+  `state.json` is a projection, `receipt.json` is a summary. When the
+  three disagree, events win.
+- **Prove before publish** — optional rehearsal against an alternate
+  registry (`shipper rehearse`) that packages, verifies, and
+  install-smokes every crate before touching crates.io.
+- **Contain damage** — receipt-driven `shipper yank`, reverse-topological
+  yank plans, and fix-forward planning for partial or compromised
+  releases.
+- **Trusted Publishing** — OIDC authentication against crates.io in CI
+  via GitHub's `rust-lang/crates-io-auth-action`, no long-lived tokens
+  required.
 
-## More documentation
+## Architecture
 
-- Project overview: <https://github.com/EffortlessMetrics/shipper#readme>
-- Configuration reference: <https://github.com/EffortlessMetrics/shipper/blob/main/docs/configuration.md>
-- Failure modes: <https://github.com/EffortlessMetrics/shipper/blob/main/docs/failure-modes.md>
+```text
+shipper (this crate — install face)
+  -> shipper-cli (CLI adapter: clap parsing, dispatch, output)
+       -> shipper-core (engine: plan, preflight, publish, resume, …)
+```
+
+Three crates, one product. You install `shipper`. If you're embedding
+the engine in your own Rust tool, depend on
+[`shipper-core`](https://crates.io/crates/shipper-core) directly — it
+has no CLI dependencies (no `clap`, no `indicatif`).
+
+## Quick start
+
+```bash
+# In a Rust workspace with crates you want to publish
+cargo install shipper --locked
+
+# Preview the plan + preflight
+shipper preflight
+
+# Publish (writes receipt, events, state to .shipper/)
+shipper publish
+
+# If interrupted, continue from where it stopped
+shipper resume
+```
+
+See [the how-to guides](https://github.com/EffortlessMetrics/shipper/tree/main/docs/how-to)
+for rehearsal against an alternate registry, remediating a compromised
+release, and running recovery drills.
+
+## Scope
+
+Shipper **does** handle publishing, retrying, resuming, rehearsing,
+yanking, and fix-forward planning. It **does not** decide version
+numbers, generate changelogs, tag releases, or create GitHub
+releases — pair it with your preferred versioning/release workflow.
+
+## Stability
+
+Pre-1.0. Breaking changes are called out in
+[`CHANGELOG.md`](https://github.com/EffortlessMetrics/shipper/blob/main/CHANGELOG.md).
+
+## License
+
+MIT OR Apache-2.0.

--- a/crates/shipper/src/lib.rs
+++ b/crates/shipper/src/lib.rs
@@ -5,12 +5,12 @@
 //! This is the crate you install with `cargo install shipper --locked`.
 //! It ships the `shipper` binary, which delegates to the CLI adapter in
 //! [`shipper-cli`](https://crates.io/crates/shipper-cli) — which in turn
-//! calls the engine in [`shipper_core`].
+//! calls the engine in [`shipper-core`](https://crates.io/crates/shipper-core).
 //!
 //! ## Architecture
 //!
 //! ```text
-//! shipper (this crate — install façade)
+//! shipper (this crate — install façade, curated re-export)
 //!   -> shipper-cli (CLI adapter: clap parsing, dispatch, output)
 //!        -> shipper-core (engine: plan, preflight, publish, resume, …)
 //! ```
@@ -23,14 +23,26 @@
 //!
 //! ## Embedding
 //!
-//! For programmatic use without CLI dependencies (`clap`, `indicatif`),
-//! depend on [`shipper-core`](https://crates.io/crates/shipper-core)
-//! directly. This crate re-exports its public module surface below so
-//! `shipper::engine::*`, `shipper::plan::*`, etc. keep resolving for
-//! callers that prefer the product name — but new programmatic
-//! consumers should target `shipper_core::*`.
+//! For programmatic use — driving a publish from your own Rust code
+//! without a CLI dependency graph (no `clap`, no `indicatif`) — depend
+//! on [`shipper-core`](https://crates.io/crates/shipper-core) directly.
+//! That crate is the stable embedding surface.
+//!
+//! This crate re-exports a **curated** set of `shipper-core` modules
+//! for convenience so `shipper::engine`, `shipper::plan`, etc. keep
+//! resolving for drivers that prefer the product name:
+//!
+//! - [`engine`] — preflight, publish, resume, rehearsal
+//! - [`plan`] — build a deterministic publish plan
+//! - [`types`] — domain types (specs, receipts, state, events)
+//! - [`config`] — load and merge `.shipper.toml`
+//! - [`state`] — read persisted execution state and events
+//! - [`store`] — the `StateStore` trait and filesystem implementation
+//!
+//! Engine internals (`auth`, `cargo`, `encryption`, `git`, `lock`,
+//! `registry`, `retry`, `runtime`, `webhook`, `cargo_failure`) are
+//! intentionally not re-exported here. Reach for them through
+//! `shipper-core` directly — that's a signal you're embedding, not
+//! driving.
 
-pub use shipper_core::{
-    auth, cargo, cargo_failure, config, encryption, engine, git, lock, plan, registry, retry,
-    runtime, state, store, types, webhook,
-};
+pub use shipper_core::{config, engine, plan, state, store, types};

--- a/crates/shipper/tests/cross_crate_integration.rs
+++ b/crates/shipper/tests/cross_crate_integration.rs
@@ -268,7 +268,7 @@ fn auth_resolve_then_registry_version_check() {
         index_base: None,
     };
 
-    let client = shipper::registry::RegistryClient::new(reg).expect("build registry client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("build registry client");
 
     // Check version exists
     let exists = client
@@ -297,7 +297,7 @@ fn registry_reports_missing_version() {
         api_base,
         index_base: None,
     };
-    let client = shipper::registry::RegistryClient::new(reg).expect("build registry client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("build registry client");
 
     let exists = client
         .version_exists("nonexistent", "9.9.9")
@@ -357,7 +357,7 @@ fn config_to_plan_to_registry_version_check() {
         api_base,
         index_base: None,
     };
-    let client = shipper::registry::RegistryClient::new(reg).expect("build registry client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("build registry client");
 
     // Verify none of the planned packages are published yet
     for pkg in &ws.plan.packages {
@@ -904,7 +904,7 @@ fn registry_version_check_errors_on_500() {
         api_base,
         index_base: None,
     };
-    let client = shipper::registry::RegistryClient::new(reg).expect("client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("client");
 
     let err = client
         .version_exists("some-crate", "1.0.0")
@@ -936,7 +936,7 @@ fn registry_crate_exists_errors_on_503() {
         api_base,
         index_base: None,
     };
-    let client = shipper::registry::RegistryClient::new(reg).expect("client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("client");
 
     let err = client
         .crate_exists("some-crate")
@@ -968,7 +968,7 @@ fn registry_list_owners_errors_on_429() {
         api_base,
         index_base: None,
     };
-    let client = shipper::registry::RegistryClient::new(reg).expect("client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("client");
 
     let err = client
         .list_owners("some-crate", "token")
@@ -1515,34 +1515,36 @@ fn lock_acquire_set_plan_id_release_sequence() {
     let state_dir = td.path();
 
     // Acquire lock
-    let mut lock = shipper::lock::LockFile::acquire(state_dir, None).expect("acquire lock");
+    let mut lock = shipper_core::lock::LockFile::acquire(state_dir, None).expect("acquire lock");
 
     // Lock should exist
-    assert!(shipper::lock::LockFile::is_locked(state_dir, None).expect("check"));
+    assert!(shipper_core::lock::LockFile::is_locked(state_dir, None).expect("check"));
 
     // Read lock info
-    let info = shipper::lock::LockFile::read_lock_info(state_dir, None).expect("read info");
+    let info = shipper_core::lock::LockFile::read_lock_info(state_dir, None).expect("read info");
     assert_eq!(info.pid, std::process::id());
     assert!(info.plan_id.is_none());
 
     // Update plan_id
     lock.set_plan_id("lock-test-plan-123").expect("set plan_id");
     let updated_info =
-        shipper::lock::LockFile::read_lock_info(state_dir, None).expect("read updated");
+        shipper_core::lock::LockFile::read_lock_info(state_dir, None).expect("read updated");
     assert_eq!(updated_info.plan_id.as_deref(), Some("lock-test-plan-123"));
 
     // Second acquire should fail
-    let err =
-        shipper::lock::LockFile::acquire(state_dir, None).expect_err("double acquire should fail");
+    let err = shipper_core::lock::LockFile::acquire(state_dir, None)
+        .expect_err("double acquire should fail");
     assert!(err.to_string().contains("lock already held"));
 
     // Release lock
     lock.release().expect("release lock");
-    assert!(!shipper::lock::LockFile::is_locked(state_dir, None).expect("check after release"));
+    assert!(
+        !shipper_core::lock::LockFile::is_locked(state_dir, None).expect("check after release")
+    );
 
     // Re-acquire should succeed after release
     let _lock2 =
-        shipper::lock::LockFile::acquire(state_dir, None).expect("re-acquire after release");
+        shipper_core::lock::LockFile::acquire(state_dir, None).expect("re-acquire after release");
 }
 
 // ===========================================================================
@@ -1660,7 +1662,7 @@ fn registry_error_propagates_with_context() {
         api_base,
         index_base: None,
     };
-    let client = shipper::registry::RegistryClient::new(reg).expect("client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("client");
 
     // version_exists should error
     let ver_err = client

--- a/crates/shipper/tests/execution_bdd.rs
+++ b/crates/shipper/tests/execution_bdd.rs
@@ -1,10 +1,10 @@
-//! BDD tests for `shipper::runtime::execution` (absorbed from the former
+//! BDD tests for `shipper_core::runtime::execution` (absorbed from the former
 //! `shipper-execution-core` crate's `tests/execution_core_bdd.rs`).
 
 use chrono::Utc;
 use std::collections::BTreeMap;
 
-use shipper::runtime::execution;
+use shipper_core::runtime::execution;
 use shipper_types::{ExecutionState, PackageProgress, PackageState, Registry};
 
 #[test]

--- a/crates/shipper/tests/facade_integration.rs
+++ b/crates/shipper/tests/facade_integration.rs
@@ -719,10 +719,10 @@ fn auth_token_resolved_from_env_for_crates_io() {
             ("CARGO_HOME", Some("__nonexistent_cargo_home__")),
         ],
         || {
-            let token = shipper::auth::resolve_token("crates-io").expect("resolve");
+            let token = shipper_core::auth::resolve_token("crates-io").expect("resolve");
             assert_eq!(token.as_deref(), Some("test-token-abc"));
 
-            let auth_type = shipper::auth::detect_auth_type("crates-io").expect("detect");
+            let auth_type = shipper_core::auth::detect_auth_type("crates-io").expect("detect");
             assert_eq!(auth_type, Some(AuthType::Token));
         },
     );
@@ -738,7 +738,7 @@ fn auth_token_resolved_from_named_registry_env() {
             ("CARGO_HOME", Some("__nonexistent_cargo_home__")),
         ],
         || {
-            let token = shipper::auth::resolve_token("my-reg").expect("resolve");
+            let token = shipper_core::auth::resolve_token("my-reg").expect("resolve");
             assert_eq!(token.as_deref(), Some("private-token-xyz"));
         },
     );
@@ -754,10 +754,10 @@ fn auth_returns_none_when_no_token_configured() {
             ("CARGO_HOME", Some("__nonexistent_cargo_home__")),
         ],
         || {
-            let token = shipper::auth::resolve_token("crates-io").expect("resolve");
+            let token = shipper_core::auth::resolve_token("crates-io").expect("resolve");
             assert!(token.is_none());
 
-            let auth_type = shipper::auth::detect_auth_type("crates-io").expect("detect");
+            let auth_type = shipper_core::auth::detect_auth_type("crates-io").expect("detect");
             assert!(auth_type.is_none());
         },
     );
@@ -792,7 +792,7 @@ fn registry_crate_exists_with_mock() {
         api_base,
         index_base: None,
     };
-    let client = shipper::registry::RegistryClient::new(reg).expect("client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("client");
 
     let exists = client.crate_exists("existing-crate").expect("check");
     assert!(exists);
@@ -818,7 +818,7 @@ fn registry_check_new_crate_returns_true_for_404() {
         api_base,
         index_base: None,
     };
-    let client = shipper::registry::RegistryClient::new(reg).expect("client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("client");
 
     let is_new = client.check_new_crate("brand-new-crate").expect("check");
     assert!(is_new, "404 should mean it's a new crate");
@@ -855,7 +855,7 @@ fn registry_list_owners_with_mock() {
         api_base,
         index_base: None,
     };
-    let client = shipper::registry::RegistryClient::new(reg).expect("client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("client");
 
     let owners = client
         .list_owners("my-crate", "fake-token")
@@ -912,7 +912,7 @@ fn registry_multi_version_check_for_planned_packages() {
         api_base,
         index_base: None,
     };
-    let client = shipper::registry::RegistryClient::new(reg).expect("client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("client");
 
     let mut published = vec![];
     let mut unpublished = vec![];
@@ -1139,7 +1139,7 @@ api_base = "https://my-registry.example.com"
             ("CARGO_HOME", Some("__nonexistent_cargo_home__")),
         ],
         || {
-            let token = shipper::auth::resolve_token("my-private").expect("resolve");
+            let token = shipper_core::auth::resolve_token("my-private").expect("resolve");
             assert_eq!(token.as_deref(), Some("private-tok-123"));
         },
     );
@@ -1167,7 +1167,7 @@ fn registry_verify_ownership_handles_forbidden() {
         api_base,
         index_base: None,
     };
-    let client = shipper::registry::RegistryClient::new(reg).expect("client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("client");
 
     let owned = client
         .verify_ownership("some-crate", "bad-token")
@@ -1377,8 +1377,8 @@ fn lock_acquire_publish_release_sequence() {
     fs::create_dir_all(&state_dir).expect("mkdir");
 
     // Step 1: Acquire lock
-    let mut lock = shipper::lock::LockFile::acquire(&state_dir, None).expect("acquire");
-    assert!(shipper::lock::LockFile::is_locked(&state_dir, None).expect("locked"));
+    let mut lock = shipper_core::lock::LockFile::acquire(&state_dir, None).expect("acquire");
+    assert!(shipper_core::lock::LockFile::is_locked(&state_dir, None).expect("locked"));
 
     // Step 2: Set plan_id (simulating engine linking the plan to the lock)
     lock.set_plan_id("facade-lock-plan").expect("set plan_id");
@@ -1400,7 +1400,7 @@ fn lock_acquire_publish_release_sequence() {
 
     // Step 5: Release lock
     lock.release().expect("release");
-    assert!(!shipper::lock::LockFile::is_locked(&state_dir, None).expect("unlocked"));
+    assert!(!shipper_core::lock::LockFile::is_locked(&state_dir, None).expect("unlocked"));
 
     // Verify state and receipt are accessible after lock release
     let loaded_state = state::load_state(&state_dir)
@@ -1501,7 +1501,7 @@ fn registry_server_error_propagates_through_version_check() {
         api_base,
         index_base: None,
     };
-    let client = shipper::registry::RegistryClient::new(reg).expect("client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("client");
 
     // The error should propagate through the version check
     let err = client
@@ -1535,7 +1535,7 @@ fn registry_server_error_propagates_through_crate_check() {
         api_base,
         index_base: None,
     };
-    let client = shipper::registry::RegistryClient::new(reg).expect("client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("client");
 
     let err = client
         .crate_exists("some-crate")
@@ -1983,7 +1983,7 @@ fn readiness_version_visible_after_publish_mock() {
         api_base,
         index_base: None,
     };
-    let client = shipper::registry::RegistryClient::new(reg).expect("client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("client");
 
     // First check: not visible
     let visible1 = client.version_exists("my-crate", "0.2.0").expect("check 1");
@@ -2379,20 +2379,20 @@ fn lock_double_acquire_fails() {
     let state_dir = td.path().join(".shipper");
     fs::create_dir_all(&state_dir).expect("mkdir");
 
-    let mut lock = shipper::lock::LockFile::acquire(&state_dir, None).expect("first acquire");
-    assert!(shipper::lock::LockFile::is_locked(&state_dir, None).expect("locked"));
+    let mut lock = shipper_core::lock::LockFile::acquire(&state_dir, None).expect("first acquire");
+    assert!(shipper_core::lock::LockFile::is_locked(&state_dir, None).expect("locked"));
 
     // Second acquire should fail
-    let result = shipper::lock::LockFile::acquire(&state_dir, None);
+    let result = shipper_core::lock::LockFile::acquire(&state_dir, None);
     assert!(result.is_err(), "double acquire should fail");
 
     // Release first lock
     lock.release().expect("release");
-    assert!(!shipper::lock::LockFile::is_locked(&state_dir, None).expect("unlocked"));
+    assert!(!shipper_core::lock::LockFile::is_locked(&state_dir, None).expect("unlocked"));
 
     // Now a new acquire should succeed
-    let mut lock2 = shipper::lock::LockFile::acquire(&state_dir, None).expect("re-acquire");
-    assert!(shipper::lock::LockFile::is_locked(&state_dir, None).expect("locked again"));
+    let mut lock2 = shipper_core::lock::LockFile::acquire(&state_dir, None).expect("re-acquire");
+    assert!(shipper_core::lock::LockFile::is_locked(&state_dir, None).expect("locked again"));
     lock2.release().expect("release2");
 }
 
@@ -2566,7 +2566,7 @@ fn registry_multi_crate_ownership_check_mock() {
         api_base,
         index_base: None,
     };
-    let client = shipper::registry::RegistryClient::new(reg).expect("client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("client");
 
     // First crate: ownership verified
     let owned = client

--- a/crates/shipper/tests/pipeline_integration.rs
+++ b/crates/shipper/tests/pipeline_integration.rs
@@ -330,7 +330,7 @@ fn registry_timeout_error_captured_in_state_and_events() {
         api_base,
         index_base: None,
     };
-    let client = shipper::registry::RegistryClient::new(reg).expect("client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("client");
 
     // Registry check fails
     let err = client
@@ -397,12 +397,13 @@ fn lock_contention_second_acquire_fails() {
     fs::create_dir_all(&state_dir).expect("mkdir");
 
     // First process acquires the lock
-    let mut lock1 = shipper::lock::LockFile::acquire(&state_dir, None).expect("acquire lock 1");
-    assert!(shipper::lock::LockFile::is_locked(&state_dir, None).expect("check locked"));
+    let mut lock1 =
+        shipper_core::lock::LockFile::acquire(&state_dir, None).expect("acquire lock 1");
+    assert!(shipper_core::lock::LockFile::is_locked(&state_dir, None).expect("check locked"));
 
     // Second attempt should fail
-    let err =
-        shipper::lock::LockFile::acquire(&state_dir, None).expect_err("second acquire should fail");
+    let err = shipper_core::lock::LockFile::acquire(&state_dir, None)
+        .expect_err("second acquire should fail");
     let msg = format!("{err:#}");
     assert!(
         msg.contains("lock already held"),
@@ -411,10 +412,11 @@ fn lock_contention_second_acquire_fails() {
 
     // Release and re-acquire should succeed
     lock1.release().expect("release");
-    assert!(!shipper::lock::LockFile::is_locked(&state_dir, None).expect("check unlocked"));
+    assert!(!shipper_core::lock::LockFile::is_locked(&state_dir, None).expect("check unlocked"));
 
-    let mut lock2 = shipper::lock::LockFile::acquire(&state_dir, None).expect("acquire lock 2");
-    assert!(shipper::lock::LockFile::is_locked(&state_dir, None).expect("check locked again"));
+    let mut lock2 =
+        shipper_core::lock::LockFile::acquire(&state_dir, None).expect("acquire lock 2");
+    assert!(shipper_core::lock::LockFile::is_locked(&state_dir, None).expect("check locked again"));
     lock2.release().expect("release lock 2");
 }
 
@@ -431,7 +433,7 @@ fn lock_stale_timeout_allows_reacquire() {
 
     // Create a lock then release the handle (drop releases it)
     {
-        let mut lock = shipper::lock::LockFile::acquire(&state_dir, None).expect("acquire");
+        let mut lock = shipper_core::lock::LockFile::acquire(&state_dir, None).expect("acquire");
         lock.set_plan_id("stale-plan").expect("set plan_id");
         // Intentionally don't release — lock file remains but process holds it
         // For testing, we manually write a stale lock file
@@ -439,7 +441,7 @@ fn lock_stale_timeout_allows_reacquire() {
     }
 
     // Write a fake stale lock with a very old timestamp
-    let lock_path = shipper::lock::lock_path(&state_dir, None);
+    let lock_path = shipper_core::lock::lock_path(&state_dir, None);
     let stale_info = serde_json::json!({
         "pid": 99999,
         "hostname": "old-host",
@@ -453,10 +455,13 @@ fn lock_stale_timeout_allows_reacquire() {
     .expect("write stale");
 
     // acquire_with_timeout should remove the stale lock and succeed
-    let mut lock =
-        shipper::lock::LockFile::acquire_with_timeout(&state_dir, None, Duration::from_secs(60))
-            .expect("acquire with timeout");
-    assert!(shipper::lock::LockFile::is_locked(&state_dir, None).expect("locked"));
+    let mut lock = shipper_core::lock::LockFile::acquire_with_timeout(
+        &state_dir,
+        None,
+        Duration::from_secs(60),
+    )
+    .expect("acquire with timeout");
+    assert!(shipper_core::lock::LockFile::is_locked(&state_dir, None).expect("locked"));
     lock.release().expect("release");
 }
 
@@ -760,7 +765,7 @@ fn lock_state_events_receipt_full_simulation() {
     let plan_id = "full-sim-001";
 
     // Step 1: Acquire lock
-    let mut lock = shipper::lock::LockFile::acquire(&state_dir, None).expect("acquire lock");
+    let mut lock = shipper_core::lock::LockFile::acquire(&state_dir, None).expect("acquire lock");
     lock.set_plan_id(plan_id).expect("set plan_id");
 
     // Step 2: Initialize state
@@ -844,7 +849,7 @@ fn lock_state_events_receipt_full_simulation() {
 
     // Verify everything is consistent
     assert!(!state::has_incomplete_state(&state_dir));
-    assert!(!shipper::lock::LockFile::is_locked(&state_dir, None).expect("check unlock"));
+    assert!(!shipper_core::lock::LockFile::is_locked(&state_dir, None).expect("check unlock"));
 
     let loaded_receipt = state::load_receipt(&state_dir)
         .expect("load receipt")
@@ -909,7 +914,7 @@ fn config_plan_registry_check_pipeline() {
         api_base,
         index_base: None,
     };
-    let client = shipper::registry::RegistryClient::new(reg).expect("client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("client");
 
     // Re-build plan for iteration (handler consumed the ws)
     let ws2 = plan::build_plan(&spec).expect("build plan 2");
@@ -1066,7 +1071,7 @@ fn ambiguous_state_resume_and_resolution() {
         api_base,
         index_base: None,
     };
-    let client = shipper::registry::RegistryClient::new(reg).expect("client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("client");
 
     let exists = client.version_exists("app", "0.1.0").expect("check");
     assert!(exists, "registry says app is published");
@@ -1811,11 +1816,12 @@ fn lock_lifecycle_around_state_operations() {
     let plan_id = "lock-lifecycle-test";
 
     // Acquire lock
-    let mut lock = shipper::lock::LockFile::acquire(&state_dir, None).expect("acquire");
+    let mut lock = shipper_core::lock::LockFile::acquire(&state_dir, None).expect("acquire");
     lock.set_plan_id(plan_id).expect("set plan_id");
 
     // Verify lock info
-    let info = shipper::lock::LockFile::read_lock_info(&state_dir, None).expect("read lock info");
+    let info =
+        shipper_core::lock::LockFile::read_lock_info(&state_dir, None).expect("read lock info");
     assert_eq!(info.plan_id.as_deref(), Some(plan_id));
     assert!(info.pid > 0);
     assert!(!info.hostname.is_empty());
@@ -1826,7 +1832,7 @@ fn lock_lifecycle_around_state_operations() {
 
     // Release lock
     lock.release().expect("release");
-    assert!(!shipper::lock::LockFile::is_locked(&state_dir, None).expect("check unlocked"));
+    assert!(!shipper_core::lock::LockFile::is_locked(&state_dir, None).expect("check unlocked"));
 
     // State should persist after lock release
     let loaded = state::load_state(&state_dir)
@@ -2102,7 +2108,7 @@ fn registry_404_means_not_published() {
         api_base,
         index_base: None,
     };
-    let client = shipper::registry::RegistryClient::new(reg).expect("client");
+    let client = shipper_core::registry::RegistryClient::new(reg).expect("client");
     let exists = client
         .version_exists("brand-new-crate", "0.1.0")
         .expect("check");

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,6 +10,10 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 shipper = { path = "../crates/shipper" }
+# Engine internals (auth, encryption, runtime) aren't re-exported from
+# the `shipper` façade after #95 PR 3. Fuzz targets that exercise them
+# depend on `shipper-core` directly.
+shipper-core = { path = "../crates/shipper-core" }
 shipper-duration = { path = "../crates/shipper-duration" }
 shipper-config = { path = "../crates/shipper-config" }
 shipper-output-sanitizer = { path = "../crates/shipper-output-sanitizer" }

--- a/fuzz/fuzz_targets/auth_token_resolve.rs
+++ b/fuzz/fuzz_targets/auth_token_resolve.rs
@@ -3,7 +3,7 @@
 use std::fs;
 
 use libfuzzer_sys::fuzz_target;
-use shipper::auth::resolve_token;
+use shipper_core::auth::resolve_token;
 use tempfile::tempdir;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/encrypt_decrypt.rs
+++ b/fuzz/fuzz_targets/encrypt_decrypt.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use shipper::encryption::{decrypt, encrypt};
+use shipper_core::encryption::{decrypt, encrypt};
 
 fuzz_target!(|data: &[u8]| {
     // Test encryption/decryption roundtrip with random data

--- a/fuzz/fuzz_targets/execution_core.rs
+++ b/fuzz/fuzz_targets/execution_core.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use shipper::runtime::execution;
+use shipper_core::runtime::execution;
 use shipper_retry::RetryStrategyType;
 use shipper_types::{ExecutionState, PackageProgress, PackageState, Registry};
 

--- a/fuzz/fuzz_targets/resolve_token.rs
+++ b/fuzz/fuzz_targets/resolve_token.rs
@@ -3,7 +3,7 @@
 use std::fs;
 
 use libfuzzer_sys::fuzz_target;
-use shipper::auth::resolve_token;
+use shipper_core::auth::resolve_token;
 use tempfile::tempdir;
 
 fuzz_target!(|data: &[u8]| {


### PR DESCRIPTION
## Summary

Third step of the #95 three-crate split. After PRs 1-2 (#140, #141) the code was in the right crates, but `crates/shipper/src/lib.rs` was still blanket-re-exporting every `shipper-core` module, and the README/CLAUDE.md still framed `shipper` as the core library. This PR makes the façade framing real.

## Architecture (finalized)

```
shipper (this crate — install handle + curated lib re-export)
  -> shipper-cli (real CLI adapter; pub fn run())
       -> shipper-core (engine — stable embedding surface)
```

## Curated library re-export

`crates/shipper/src/lib.rs` now re-exports only the six modules a programmatic driver would reach for as entry points:

```
engine, plan, types, config, state, store
```

Engine internals — `auth`, `cargo`, `cargo_failure`, `encryption`, `git`, `lock`, `registry`, `retry`, `runtime`, `webhook` — are **not** in the façade. Embedders who need them depend on `shipper-core` directly. That's the point of the split: the `shipper` install crate shouldn't double as "the programmatic API surface for every engine internal."

## Tests migrated

Several `crates/shipper/tests/*.rs` files reached into now-uncurated modules (`shipper::auth`, `shipper::lock`, `shipper::registry`, `shipper::runtime`). Their imports now read from `shipper_core::X` instead. `shipper-core` added as a dev-dep of `shipper`.

PR 4 will decide whether these engine-internal integration tests belong in `crates/shipper-core/tests/` instead.

## README

Rewritten as the product landing page:
- Opens with `cargo install shipper --locked`
- Names the five things Shipper does that raw `cargo publish` can't (resumable, backoff-aware, events-as-truth, prove, contain)
- Three-crate architecture diagram so users see where `shipper-core` and `shipper-cli` fit
- Quick-start preflight → publish → resume flow
- Scope section separates publishing from versioning/tags/GitHub releases

## CLAUDE.md

Updated to describe the façade role: behavior changes belong in `shipper-core` or `shipper-cli`; this crate's surface should move rarely; CLI dependencies stay out.

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test --workspace --doc` — clean
- `cargo test -p shipper` — 39 passed

## What this PR does not do

- Does not physically move `crates/shipper/tests/` into `crates/shipper-core/tests/` (PR 4 decision)
- Does not update workspace docs (`docs/how-to/*`, `docs/explanation/*`) that may reference `shipper::X` paths for no-longer-re-exported modules (PR 4 sweep)
- Does not touch architecture guard or CI topology

## Test plan

- [x] cargo check --workspace --all-targets
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [x] cargo test --workspace --doc
- [x] cargo test -p shipper
- [ ] CI green on all matrices
- [ ] `cargo install shipper --locked` still produces a working binary

Part of #95. PR 4 (docs/examples/workspace import sweep) to follow.