### PR TITLE
docs(packaging): update workspace docs for three-crate split (#95 PR 4)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,8 +6,8 @@ This file collects repository-specific guidance for automated assistants (Copilo
 
 ## Quick summary
 
-- Repository is a Rust workspace with two members: `crates/shipper` (library) and `crates/shipper-cli` (binary/CLI).
-- The library builds a deterministic `ReleasePlan` and the CLI (shipper) runs commands that build plans, run preflight checks, and execute/resume publishes with retry/backoff and persistence.
+- Repository is a Rust workspace. The product is split across three primary crates: `crates/shipper-core` (engine/library), `crates/shipper-cli` (CLI adapter), and `crates/shipper` (install façade + binary).
+- `shipper-core` builds deterministic `ReleasePlan`s and runs preflight / publish / resume / rehearsal flows. `shipper-cli` wraps it with `clap` and owns operator-facing output. `shipper` is what users `cargo install`.
 
 ---
 
@@ -15,73 +15,85 @@ This file collects repository-specific guidance for automated assistants (Copilo
 
 From the repository root:
 
-- Build (debug):
-  - `cargo build`
-- Build (release):
-  - `cargo build --release`
+- Build (debug): `cargo build`
+- Build (release): `cargo build --release`
 - Install the CLI locally (recommended for manual testing):
-  - `cargo install --path crates\\shipper-cli --locked`
-- Run the CLI without installing (useful during development):
-  - `cargo run -p shipper-cli -- <command>`  (e.g. `cargo run -p shipper-cli -- plan`)
+  - `cargo install --path crates/shipper --locked`
+- Run the CLI without installing:
+  - `cargo run -p shipper -- <command>` (preferred — runs the `shipper` binary)
+  - `cargo run -p shipper-cli -- <command>` (equivalent — same code path)
 
 Tests / single-test usage:
-- Run all tests (workspace): `cargo test`
-- Run tests for a single package: `cargo test -p shipper` or `cargo test -p shipper-cli`
-- Run a specific test by name (substring): `cargo test -p shipper some_test_name`
-- Run an exact test name: `cargo test -p shipper some_test_name -- --exact`
-- Run an integration test binary: `cargo test --test <testname> -p shipper-cli`
+- All workspace tests: `cargo test`
+- Engine crate: `cargo test -p shipper-core`
+- CLI adapter: `cargo test -p shipper-cli`
+- Façade integration tests: `cargo test -p shipper`
+- By name: `cargo test -p shipper-core some_test_name`
+- Exact: `cargo test -p shipper-core some_test_name -- --exact`
+- Integration test binary: `cargo test --test <testname> -p shipper-cli`
 
 Formatting & linting:
-- Format code: `cargo fmt --all`
+- Format: `cargo fmt --all`
 - Check formatting (CI): `cargo fmt --all -- --check`
-- Run clippy (recommended flags for CI/local):
-  - `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- Clippy (recommended flags): `cargo clippy --workspace --all-targets --all-features -- -D warnings`
 
 Toolchain:
-- The workspace declares `rust-version = "1.92"` in `Cargo.toml`; use the matching toolchain (rustup) when reproducibility is required.
+- The workspace declares `rust-version = "1.92"` in `Cargo.toml`.
 
 ---
 
 ## High-level architecture (big picture)
 
-- Workspace layout:
-  - `crates/shipper` — core library exposing modules: `auth`, `cargo`, `config`, `engine` (with `engine::parallel`), `environment`, `events`, `git`, `lock`, `plan`, `registry`, `state`, `store`, `types`.
-  - `crates/shipper-cli` — binary that parses CLI args and calls into the library (builds `ReleaseSpec`/`RuntimeOptions` then runs plan/preflight/publish/resume/status/doctor flows).
+Three-crate product shape (#95):
 
-- Primary flow:
-  1. Build a deterministic `ReleasePlan` from the workspace manifest (`plan::build_plan` returns `PlannedWorkspace`).
+```
+shipper (install face — carries the `shipper` binary)
+  -> shipper-cli (real CLI adapter; pub fn run())
+       -> shipper-core (engine — no CLI deps)
+```
+
+- `crates/shipper-core` — library only. Modules: `auth`, `cargo`, `cargo_failure`, `config`, `encryption`, `engine` (with `engine::parallel`, `engine::plan_yank`, `engine::fix_forward`), `git`, `lock`, `plan`, `registry`, `retry`, `runtime`, `state`, `store`, `types`, `webhook`. No `clap`. This is the stable embedding surface.
+- `crates/shipper-cli` — CLI adapter. Owns argparse, subcommand dispatch, help text, progress rendering. Exposes `pub fn run() -> anyhow::Result<()>`. Both the `shipper` and `shipper-cli` binaries forward to this one function.
+- `crates/shipper` — install face. 3-line binary forwarding to `shipper_cli::run()`, plus a library that re-exports a curated subset of `shipper-core` (`engine`, `plan`, `types`, `config`, `state`, `store`) for drivers that prefer the product name. Engine internals (`auth`, `cargo`, `encryption`, `git`, `lock`, `registry`, `retry`, `runtime`, `webhook`) are **not** re-exported here — embedders reach through `shipper-core` directly.
+
+Primary flow (plan → preflight → publish → resume):
+  1. Build a deterministic `ReleasePlan` from the workspace manifest (`shipper_core::plan::build_plan` returns `PlannedWorkspace`).
   2. Optionally run preflight checks (git cleanliness, publishability, ownership, registry reachability).
   3. Execute the plan: publish crates one-by-one using `cargo publish -p <crate>` with retry/backoff and verification of registry visibility.
-  4. Persist progress to disk (`.shipper/state.json`) and write a `receipt.json` + `events.jsonl` for CI/audit.
+  4. Persist progress to `.shipper/state.json`, the append-only event log `.shipper/events.jsonl`, and an end-of-run `.shipper/receipt.json`.
 
-- Persistence & audit:
-  - By default state and receipts are written under `.shipper` in the workspace root. Use `--state-dir <path>` to change this location.
+Persistence & audit:
+- By default `.shipper/` lives in the workspace root. Use `--state-dir <path>` to change. Events are the authoritative source of truth; state is a projection; receipts are summaries.
 
-- Configuration:
-  - Project-specific settings via `.shipper.toml` (see `docs/configuration.md`).
-  - Sections: `[policy]`, `[verify]`, `[readiness]`, `[output]`, `[lock]`, `[retry]`, `[flags]`, `[parallel]`, `[registry]`.
-  - CLI flags always take precedence over config file values.
-  - Ownership and git-cleanliness flags live in `[flags]` (not a separate `[preflight]` section).
+Configuration:
+- Project settings via `.shipper.toml` (see `docs/configuration.md`).
+- Sections: `[policy]`, `[verify]`, `[readiness]`, `[output]`, `[lock]`, `[retry]`, `[flags]`, `[parallel]`, `[registry]`.
+- CLI flags always take precedence over config file values.
+- Ownership and git-cleanliness flags live in `[flags]` (not a separate `[preflight]` section).
 
-- Registry & auth:
-  - The project performs explicit registry checks (version existence and optional owners checks) and resolves tokens from the standard places: `CARGO_REGISTRY_TOKEN`, `CARGO_REGISTRIES_<NAME>_TOKEN`, or `$CARGO_HOME/credentials.toml`.
+Registry & auth:
+- Shipper performs explicit registry checks (version existence and optional owners checks) and resolves tokens from the standard places: `CARGO_REGISTRY_TOKEN`, `CARGO_REGISTRIES_<NAME>_TOKEN`, or `$CARGO_HOME/credentials.toml`. OIDC / Trusted Publishing is also supported on CI.
 
-- Error handling and retries:
-  - The engine applies exponential backoff with jitter for retryable failures and verifies registry state before treating a step as failed (see `docs/failure-modes.md`).
+Error handling and retries:
+- The engine applies exponential backoff with jitter for retryable failures and verifies registry state before treating a step as failed (see `docs/failure-modes.md`).
 
 ---
 
+## Where work goes
+
+- Behavior / engine / state / ops changes → `crates/shipper-core`
+- CLI changes (arguments, help text, output, subcommands) → `crates/shipper-cli`
+- `crates/shipper` itself should rarely move — it's the install face. Only touch it for product-surface decisions (curated re-export list, README, binary wrapper).
+
 ## Key conventions and repository-specific patterns
 
-- Workspace crate split: prefer library logic in `crates/shipper` and keep the CLI thin in `crates/shipper-cli`.
-- State files: `.shipper/state.json` (resumable state) and `.shipper/receipt.json` (machine-readable receipt for CI/auditing). Prefer `--state-dir` for CI artifact storage.
+- State files: `.shipper/state.json` (resumable state), `.shipper/events.jsonl` (truth), `.shipper/receipt.json` (summary). Prefer `--state-dir` for CI artifact storage.
 - Token resolution: treat tokens as opaque strings; resolve from `CARGO_REGISTRY_TOKEN`, `CARGO_REGISTRIES_<NAME>_TOKEN`, or `CARGO_HOME` credentials.
-- Unsafe code: the workspace Cargo.toml sets `unsafe_code = "forbid"` (see `[workspace].lints.rust`), so avoid adding unsafe blocks.
+- Unsafe code: the workspace Cargo.toml sets `unsafe_code = "forbid"` — no unsafe blocks.
 - Tests:
   - Many tests use `serial_test` and are intentionally run serially (tests may mutate global env or filesystem); use `#[serial]` in tests that need isolation.
-  - Tests mock registry interactions (e.g. `tiny_http`) — prefer local HTTP mocks in tests rather than hitting real registries.
-  - Snapshot testing uses `insta` in dev-dependencies.
-  - Property-based testing uses `proptest`.
+  - Tests mock registry interactions with `tiny_http` — never hit real registries.
+  - Snapshot testing uses `insta`. Property-based testing uses `proptest`.
 - CLI flags commonly used during development/debugging:
   - `--manifest-path <path>` (defaults to `Cargo.toml`)
   - `--config <path>` to use a custom `.shipper.toml`
@@ -90,22 +102,24 @@ Toolchain:
   - `--skip-ownership-check` and `--strict-ownership` to control owners preflight behavior
   - `--no-verify` to pass `--no-verify` to `cargo publish`
 - Config subcommands:
-  - `config init` accepts `-o`/`--output` for output path
-  - `config validate` accepts `-p`/`--path` for config file path
+  - `config init` accepts `-o`/`--output`
+  - `config validate` accepts `-p`/`--path`
 - Readiness config-only settings: `prefer_index` and `index_path` are only settable via `.shipper.toml`, not via CLI flags.
-- Selecting single-package operations: when running cargo commands in this workspace, prefer `-p <package>` to scope operations (e.g., `cargo test -p shipper` or `cargo run -p shipper-cli`).
 
 ---
 
 ## Where to look for more details
 
-- README.md (root) — quick start, commands, and install instructions.
+- `README.md` (root) — quick start, commands, and install instructions.
+- `docs/structure.md` — full workspace and module map for the three-crate shape.
+- `docs/architecture.md` — layer boundaries and import rules.
 - `docs/configuration.md` — `.shipper.toml` reference with all sections and options.
 - `docs/preflight.md` — preflight verification guide.
 - `docs/readiness.md` — readiness checking guide.
 - `docs/failure-modes.md` — notes on partial publishes, ambiguous timeouts, rate limiting, and CI cancellations.
-- `templates/` — example CI workflows for GitHub/GitLab showing how this repo is expected to be used in release pipelines.
-- `crates/shipper/src` — implementation entry points and module breakdown.
+- `templates/` — example CI workflows for GitHub/GitLab.
+- `crates/shipper-core/src/` — engine implementation entry points and module breakdown.
+- `crates/shipper-cli/src/` — CLI implementation.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,18 +19,20 @@ cargo build                    # debug
 cargo build --release          # release (LTO + strip)
 
 # Run CLI during development (without installing)
-cargo run -p shipper-cli -- <command>
+cargo run -p shipper -- <command>       # preferred: runs the `shipper` binary
+cargo run -p shipper-cli -- <command>   # equivalent; same code path
 
 # Install CLI locally
-cargo install --path crates/shipper-cli --locked
+cargo install --path crates/shipper --locked
 
 # Tests
 cargo test                                         # all workspace tests
-cargo test -p shipper                              # library crate only
-cargo test -p shipper-cli                          # CLI crate only
-cargo test -p shipper some_test_name               # substring match
-cargo test -p shipper some_test_name -- --exact    # exact match
-cargo test --test cli_e2e -p shipper-cli           # integration tests only
+cargo test -p shipper-core                         # engine crate
+cargo test -p shipper-cli                          # CLI adapter crate
+cargo test -p shipper                              # façade (integration tests)
+cargo test -p shipper-core some_test_name          # substring match
+cargo test -p shipper-core some_test_name -- --exact # exact match
+cargo test --test cli_e2e -p shipper-cli           # CLI integration tests only
 
 # Lint & format
 cargo fmt --all
@@ -40,26 +42,33 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 
 ## Architecture
 
-Rust workspace with two crates:
+Three-crate product shape (#95):
 
-- **`crates/shipper`** — Core library. All domain logic lives here.
-- **`crates/shipper-cli`** — Thin CLI binary. Parses args with clap, builds a `ReleaseSpec`/`RuntimeOptions`, then calls into the library.
+```
+shipper (install face — carries the `shipper` binary + curated lib re-export)
+  -> shipper-cli (real CLI adapter; exposes pub fn run())
+       -> shipper-core (engine — no CLI deps, stable embedding surface)
+```
 
-Keep library logic in `crates/shipper`; keep `crates/shipper-cli` as a thin dispatch layer.
+- **`crates/shipper-core`** — all engine/library logic: plan, preflight, publish, resume, state, ops. No `clap`, no `indicatif`. This is where behavior changes land.
+- **`crates/shipper-cli`** — CLI adapter. Owns `clap` derive types, subcommand dispatch, help text, progress rendering. Exposes `pub fn run() -> anyhow::Result<()>` as the embedding entry point.
+- **`crates/shipper`** — install façade. 3-line binary forwarding to `shipper_cli::run()`, plus a library that re-exports a curated subset of `shipper-core` (`engine`, `plan`, `types`, `config`, `state`, `store`) for drivers that prefer the product name. Changes rarely.
+
+When touching code: behavior work lives in `shipper-core`; CLI work (arguments, help text, output) lives in `shipper-cli`; the `shipper` crate mostly shouldn't move.
 
 ### Publishing Pipeline
 
 The core flow is: **plan → preflight → publish → (resume if interrupted)**
 
-1. **Plan** (`plan.rs`): Reads workspace via `cargo_metadata`, filters publishable crates, topologically sorts by intra-workspace dependencies (Kahn's algorithm with BTreeSet for determinism), generates a SHA256-based plan ID.
-2. **Preflight** (`engine.rs`): Validates git cleanliness, registry reachability, dry-run, version existence, and optional ownership checks. Produces a `Finishability` assessment (Proven/NotProven/Failed).
-3. **Publish** (`engine.rs`): Executes plan one crate at a time with retry/backoff. After each `cargo publish`, verifies registry visibility (API or sparse index) before proceeding. Persists `ExecutionState` to disk after every step for resumability.
+1. **Plan** (`shipper-core/src/plan/`): Reads workspace via `cargo_metadata`, filters publishable crates, topologically sorts by intra-workspace dependencies (Kahn's algorithm with BTreeSet for determinism), generates a SHA256-based plan ID.
+2. **Preflight** (`shipper-core/src/engine/`): Validates git cleanliness, registry reachability, dry-run, version existence, and optional ownership checks. Produces a `Finishability` assessment (Proven/NotProven/Failed).
+3. **Publish** (`shipper-core/src/engine/`): Executes plan one crate at a time with retry/backoff. After each `cargo publish`, verifies registry visibility (API or sparse index) before proceeding. Persists `ExecutionState` to disk after every step for resumability.
 4. **Resume**: Reloads state from `.shipper/state.json`, validates plan ID match, skips already-published packages, continues from first pending/failed.
 
 ### Key Abstractions
 
-- **`StateStore` trait** (`store.rs`): Persistence abstraction for state/receipt/events. Currently filesystem-backed; designed for future cloud storage backends.
-- **`Reporter` trait** (`engine.rs`): Pluggable output handler for publish/preflight progress.
+- **`StateStore` trait** (`shipper-core/src/state/store/`): Persistence abstraction for state/receipt/events. Currently filesystem-backed; designed for future cloud storage backends.
+- **`Reporter` trait** (`shipper-core/src/engine/`): Pluggable output handler for publish/preflight progress.
 - **`ErrorClass`** enum: Classifies failures as `Retryable` (HTTP 429, network), `Permanent` (auth, version conflict), or `Ambiguous` (upload may have succeeded despite client error). Only retryable errors trigger backoff retries.
 - **`PublishPolicy`/`VerifyMode`/`ReadinessMethod`**: Configuration enums controlling safety vs speed tradeoffs.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -15,19 +15,15 @@
 
 - **Core Purpose:** Enhances `cargo publish` by adding a reliability layer that handles planning, preflight checks, retries, and state persistence.
 - **Main Technologies:** Rust (Edition 2024), `clap` (CLI), `anyhow` (Error Handling), `serde` (Serialization), `tokio` (Async - though much of the current logic is sync with thread sleeps), `chrono` (Time).
-- **Architecture:**
-    - **`crates/shipper` (Library):** The engine of the project. Contains logic for:
-        - **Planning:** Building a dependency-aware publish order.
-        - **Preflight:** Verifying git state, crate ownership, and registry reachability.
-        - **Engine:** Executing the publish plan with backoff and retries.
-        - **Registry:** Interacting with Cargo registries (crates.io by default) via their web APIs.
-        - **State:** Persisting execution progress to disk for resumability.
-    - **`crates/shipper-cli` (Binary):** A CLI wrapper around the library logic, providing commands for the end-user.
+- **Architecture (three-crate product shape, #95):**
+    - **`crates/shipper-core` (Engine):** Library only, no CLI deps. Owns planning, preflight, engine execution, registry interaction, state/receipts/events, remediation primitives. Stable embedding surface.
+    - **`crates/shipper-cli` (CLI adapter):** Owns `clap` parsing, subcommand dispatch, help text, progress rendering. Exposes `pub fn run()`.
+    - **`crates/shipper` (Install face):** 3-line binary forwarding to `shipper_cli::run()`; library re-exports a curated subset of `shipper-core`. This is what users `cargo install`.
 
 ## Building and Running
 
 - **Build:** `cargo build`
-- **Install CLI:** `cargo install --path crates/shipper-cli --locked`
+- **Install CLI:** `cargo install --path crates/shipper --locked`
 - **Test:** `cargo test` (Note: some tests use `serial_test` as they modify environment variables or global state).
 - **Fuzzing:** Located in `fuzz/` directory; can be run with `cargo-fuzz`.
 
@@ -57,14 +53,20 @@
 
 ## Project Structure
 
+- `crates/shipper-core/src/`:
+    - `lib.rs`: Library surface.
+    - `engine/`: Preflight + publish + resume + rehearsal orchestration.
+    - `plan/`: Workspace analysis, topological ordering, plan ID.
+    - `state/`: `state.json`, `events.jsonl`, `receipt.json` persistence.
+    - `ops/`: I/O primitives (auth, cargo subprocess, git, lock, process, storage).
+    - `runtime/`: Error classification, policy, environment fingerprinting.
+    - `types.rs`: Shared data structures (re-exports `shipper-types`).
+- `crates/shipper-cli/src/`:
+    - `lib.rs`: `pub fn run()` — argparse + subcommand dispatch.
+    - `main.rs`: 3-line wrapper over `shipper_cli::run()`.
+    - `output/`: Progress bars, formatting.
 - `crates/shipper/src/`:
-    - `lib.rs`: Module declarations.
-    - `engine.rs`: The main execution loop for publishing.
-    - `plan.rs`: Workspace analysis and dependency sorting.
-    - `registry.rs`: HTTP client for registry APIs.
-    - `auth.rs`: Token resolution logic.
-    - `state.rs`: Persistence logic for `state.json` and `receipt.json`.
-    - `types.rs`: Shared data structures (Plans, States, Receipts).
-- `crates/shipper-cli/src/main.rs`: CLI entry point and argument parsing.
+    - `lib.rs`: Curated re-export of `shipper-core`.
+    - `bin/shipper.rs`: 3-line wrapper over `shipper_cli::run()`.
 - `templates/`: Example CI/CD configurations (GitHub/GitLab).
 - `fuzz/`: Fuzzing targets for robust state loading and token resolution.

--- a/README.md
+++ b/README.md
@@ -171,10 +171,13 @@ shipper publish --resume-from my-crate  # restart from a specific crate
 
 ## Workspace crates
 
-- [`shipper-cli`](crates/shipper-cli/README.md) — installs the `shipper` binary.
-- [`shipper`](crates/shipper/README.md) — reusable library: planning, preflight, publish, resume, receipts.
+Product surface (the three-crate split):
 
-The full crate map is in [docs/structure.md](docs/structure.md).
+- [`shipper`](crates/shipper/README.md) — the installable product. `cargo install shipper`.
+- [`shipper-cli`](crates/shipper-cli/README.md) — real CLI adapter (clap parsing, subcommands, output). Exposes `pub fn run()` for embedders.
+- [`shipper-core`](crates/shipper-core/README.md) — engine library (no CLI deps). Depend on this for programmatic use.
+
+The full crate map (including supporting microcrates) is in [docs/structure.md](docs/structure.md).
 
 ## Documentation
 

--- a/crates/shipper-cli/README.md
+++ b/crates/shipper-cli/README.md
@@ -1,76 +1,75 @@
 # shipper-cli
 
-`shipper-cli` provides the `shipper` command for reliable, resumable publishing
-of Rust workspace crates.
+CLI adapter crate for Shipper. Owns `clap` parsing, subcommand dispatch,
+help text, and progress rendering. Exposes `pub fn run() -> anyhow::Result<()>`
+as the embedding entry point; the `shipper-cli` binary is a three-line
+wrapper over `run`.
 
-This crate is the CLI frontend for the `shipper` library crate.
+## Use the `shipper` crate to install
 
-## Install
+Most users should install the product via the `shipper` crate:
 
 ```bash
+cargo install shipper --locked
+```
+
+That installs a binary named `shipper` that forwards to the same `run`
+function in this crate.
+
+## When to depend on `shipper-cli` directly
+
+Reach for this crate when you need the exact CLI surface programmatically
+— for example, a wrapper that invokes Shipper after extra preflight
+steps of your own:
+
+```rust,no_run
+fn main() -> anyhow::Result<()> {
+    // ... custom preflight ...
+    shipper_cli::run()
+}
+```
+
+For programmatic use **without** a `clap` dependency graph, depend on
+[`shipper-core`](https://crates.io/crates/shipper-core) instead — that's
+where the engine lives.
+
+## Back-compat binary
+
+A `shipper-cli` binary still ships so that existing pipelines with
+`cargo install shipper-cli --locked` keep working. Prefer
+`cargo install shipper --locked` on new setups.
+
+```bash
+# Backward-compatible — same code path
 cargo install shipper-cli --locked
-```
 
-From this repository:
-
-```bash
+# From this repository
 cargo install --path crates/shipper-cli --locked
-```
-
-## Quick start
-
-```bash
-shipper plan
-shipper preflight
-shipper publish
-```
-
-If a run is interrupted:
-
-```bash
-shipper resume
 ```
 
 ## Core commands
 
-- `shipper plan` - print publish order and skipped packages.
-- `shipper preflight` - run checks without publishing.
-- `shipper publish` - execute publish and persist state.
-- `shipper resume` - continue from previous state.
-- `shipper status` - compare local versions to registry versions.
-- `shipper doctor` - print environment and auth diagnostics.
+- `shipper plan` — print publish order and skipped packages.
+- `shipper preflight` — run checks without publishing.
+- `shipper publish` — execute publish and persist state.
+- `shipper resume` — continue from previous state.
+- `shipper status` — compare local versions to registry versions.
+- `shipper doctor` — print environment and auth diagnostics.
+- `shipper rehearse` — package + verify + publish to a rehearsal registry.
+- `shipper yank` / `shipper plan-yank` — receipt-driven containment.
+- `shipper fix-forward` — plan a minimal repair of a partial release.
 
-## State and evidence files
+## Architecture
 
-By default, the CLI writes to `.shipper/`:
-
-- `state.json` - resumable execution state.
-- `receipt.json` - machine-readable publish receipt.
-- `events.jsonl` - append-only event log.
-
-Use `--state-dir <path>` to relocate these files.
-
-## Configuration
-
-Generate and validate project config:
-
-```bash
-shipper config init
-shipper config validate
 ```
-
-The config file is `.shipper.toml` in your workspace root unless overridden by `--config`.
-
-## Authentication
-
-Publishing is delegated to Cargo. API checks use Cargo-compatible token locations:
-
-- `CARGO_REGISTRY_TOKEN`
-- `CARGO_REGISTRIES_<NAME>_TOKEN`
-- `$CARGO_HOME/credentials.toml`
+shipper (install face — `cargo install shipper`)
+  -> shipper-cli (this crate — CLI adapter, pub fn run())
+       -> shipper-core (engine — library only)
+```
 
 ## Related crates and docs
 
-- Library crate: <https://crates.io/crates/shipper>
+- Install face: <https://crates.io/crates/shipper>
+- Engine library: <https://crates.io/crates/shipper-core>
 - Project README: <https://github.com/EffortlessMetrics/shipper#readme>
 - Configuration reference: <https://github.com/EffortlessMetrics/shipper/blob/main/docs/configuration.md>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,17 +59,17 @@ Many subsystems that started as crates have been consolidated into modules under
 
 Examples (non-exhaustive — see [structure.md](structure.md) for the full module map):
 
-- `shipper::ops::auth` — token resolution + OIDC detection
-- `shipper::ops::lock` — file-based distributed locking
-- `shipper::ops::process` — subprocess invocation + capture
-- `shipper::plan` — workspace analysis, topo-sort, plan_id, levels, chunking
-- `shipper::engine` — preflight + parallel publish + readiness verification
-- `shipper::runtime::execution` — error classification, retry coordination
-- `shipper::runtime::policy` — publish/verify/readiness policy resolution
-- `shipper::runtime::environment` — environment fingerprinting
-- `shipper::state::execution_state` — `state.json` writer (atomic)
-- `shipper::state::events` — `events.jsonl` writer (append-only)
-- `shipper::state::store` — `StateStore` trait
+- `shipper_core::ops::auth` — token resolution + OIDC detection
+- `shipper_core::ops::lock` — file-based distributed locking
+- `shipper_core::ops::process` — subprocess invocation + capture
+- `shipper_core::plan` — workspace analysis, topo-sort, plan_id, levels, chunking
+- `shipper_core::engine` — preflight + parallel publish + readiness verification
+- `shipper_core::runtime::execution` — error classification, retry coordination
+- `shipper_core::runtime::policy` — publish/verify/readiness policy resolution
+- `shipper_core::runtime::environment` — environment fingerprinting
+- `shipper_core::state::execution_state` — `state.json` writer (atomic)
+- `shipper_core::state::events` — `events.jsonl` writer (append-only)
+- `shipper_core::state::store` — `StateStore` trait
 - `shipper-config::runtime` — config + CLI → `RuntimeOptions` conversion
 - `shipper-cli::output::progress` — progress bars and TTY rendering
 
@@ -126,8 +126,8 @@ Reloads `.shipper/state.json`, validates the `plan_id` matches the current works
 
 | Trait / Type | Lives in | Purpose |
 |---|---|---|
-| `StateStore` | `shipper::state::store` | Persistence abstraction. Currently filesystem-backed; designed to host future cloud backends. |
-| `Reporter` | `shipper::engine` | Pluggable output handler for publish/preflight progress. |
+| `StateStore` | `shipper_core::state::store` | Persistence abstraction. Currently filesystem-backed; designed to host future cloud backends. |
+| `Reporter` | `shipper_core::engine` | Pluggable output handler for publish/preflight progress. |
 | `RegistryClient` | `shipper-registry` | Trait-based registry API access (mock-friendly). |
 | `ErrorClass` | `shipper-types` | `Retryable` (HTTP 429, network) / `Permanent` (auth, version conflict) / `Ambiguous` (upload may have succeeded despite client error). Only `Retryable` triggers backoff today; `Ambiguous` reconciliation is the largest open gap ([#99](https://github.com/EffortlessMetrics/shipper/issues/99)). |
 | `PublishPolicy` / `VerifyMode` / `ReadinessMethod` | `shipper-types` | Configuration enums controlling safety vs speed tradeoffs. |

--- a/docs/how-to/run-in-github-actions.md
+++ b/docs/how-to/run-in-github-actions.md
@@ -132,7 +132,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo install shipper-cli --locked
+      - run: cargo install shipper --locked
 
       # Exchange the workflow's OIDC token for a short-lived
       # crates.io publish token. Output: steps.auth.outputs.token.

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -7,8 +7,9 @@
 ```
 shipper/
 ├── crates/                            # Workspace members
-│   ├── shipper/                       # Core library — engine, plan, state, runtime
-│   ├── shipper-cli/                   # Thin CLI binary (`shipper` command)
+│   ├── shipper/                       # Install façade (binary + curated lib re-export of shipper-core)
+│   ├── shipper-cli/                   # CLI adapter: clap parsing, subcommands, output (pub fn run())
+│   ├── shipper-core/                  # Engine: plan, preflight, publish, resume, state, ops (no CLI deps)
 │   ├── shipper-config/                # .shipper.toml parsing/validation
 │   ├── shipper-types/                 # Shared types (Plan, ExecutionState, Receipt, events)
 │   ├── shipper-registry/              # Registry HTTP clients
@@ -45,15 +46,29 @@ shipper/
 └── CHANGELOG.md
 ```
 
-All 12 workspace crates are published to crates.io as part of v0.3.0-rc.1. There is no separate "workspace-internal" tier — when a concern needs ownership, it lives as a module inside an owner crate (see [architecture.md](architecture.md)).
-
-## `crates/shipper` module map
+## Three-crate product shape (#95)
 
 ```
-crates/shipper/src/
-├── lib.rs                # Public API surface
+shipper (install face)
+  -> shipper-cli (CLI adapter; pub fn run())
+       -> shipper-core (engine; stable embedding surface)
+```
+
+- Users type `cargo install shipper --locked` — the `shipper` crate carries the `shipper` binary, which forwards to `shipper_cli::run()`.
+- Embedders add `shipper-core` to their `Cargo.toml` — no `clap`, no `indicatif`, no progress rendering pulled into their dep graph.
+- The `shipper` library surface re-exports a curated subset of `shipper-core` (`engine`, `plan`, `types`, `config`, `state`, `store`) for drivers that prefer the product name. Engine internals reach through `shipper-core` directly.
+
+All 13 workspace crates are published to crates.io. There is no separate "workspace-internal" tier — when a concern needs ownership, it lives as a module inside an owner crate (see [architecture.md](architecture.md)).
+
+## `crates/shipper-core` module map
+
+```
+crates/shipper-core/src/
+├── lib.rs                # Public library surface
 ├── engine/               # Plan/preflight/publish/resume execution
-│   ├── mod.rs            # Top-level engine entry points (run_preflight, run_publish, run_resume)
+│   ├── mod.rs            # Top-level engine entry points (run_preflight, run_publish, run_resume, run_rehearsal)
+│   ├── plan_yank.rs      # Reverse-topological yank planning
+│   ├── fix_forward.rs    # Fix-forward planning for compromised releases
 │   └── parallel/         # Parallel publish + readiness verification
 │       ├── publish.rs    # Per-crate publish loop with retry/backoff
 │       └── readiness.rs  # Sparse-index + API visibility queries
@@ -64,16 +79,42 @@ crates/shipper/src/
 │   ├── execution_state/  # state.json (atomic writes)
 │   ├── events/           # events.jsonl writer (append-only)
 │   └── store/            # StateStore trait
-├── ops/                  # Operations
+├── ops/                  # I/O primitives (layer 1)
 │   ├── auth/             # Token resolution + OIDC detection (oidc.rs)
-│   └── lock/             # File-based distributed locking
+│   ├── cargo/            # cargo subprocess invocation
+│   ├── git/              # Git working-tree checks
+│   ├── lock/             # File-based distributed lock
+│   ├── process/          # Subprocess capture
+│   └── storage/          # Storage backend trait + filesystem impl
 ├── config.rs             # Internal config helpers
-├── git.rs                # Git working-tree checks
+├── git.rs                # Public facade over ops/git
 ├── encryption.rs         # State encryption (uses shipper-encrypt)
 ├── webhook.rs            # Webhook event emission (uses shipper-webhook)
-├── types.rs              # Crate-internal type aliases
+├── types.rs              # Crate-internal type aliases + re-exports of shipper-types
 ├── property_tests.rs     # proptest harnesses
 └── stress_tests.rs       # Long-running validation
+```
+
+## `crates/shipper-cli` module map
+
+```
+crates/shipper-cli/src/
+├── lib.rs                # pub fn run() — argparse, subcommand dispatch
+├── main.rs               # 3-line wrapper: shipper_cli::run()
+└── output/               # Human output: progress bars, snapshots, formatting
+    └── progress/         # Terminal progress rendering
+```
+
+## `crates/shipper` module map
+
+```
+crates/shipper/
+├── src/
+│   ├── lib.rs            # Curated re-export of shipper-core
+│   └── bin/
+│       └── shipper.rs    # 3-line wrapper: shipper_cli::run()
+├── README.md             # Product landing page
+└── tests/                # Integration tests exercising the façade
 ```
 
 ## Runtime files (`.shipper/`)
@@ -91,7 +132,7 @@ Per [INVARIANTS.md](INVARIANTS.md):
 
 - **Unit tests** — alongside the code they cover (`#[cfg(test)] mod tests`)
 - **Integration tests** — `crates/<crate>/tests/`
-- **BDD scenarios** — `features/`
+- **BDD scenarios** — `features/` + `crates/shipper-cli/tests/bdd_*.rs`
 - **Fuzz targets** — `fuzz/fuzz_targets/`
 - **Snapshots** — `insta`
 - **Property tests** — `proptest`

--- a/templates/azure-pipelines.yml
+++ b/templates/azure-pipelines.yml
@@ -97,7 +97,7 @@ stages:
               path: 'target'
 
           - script: |
-              cargo install shipper-cli --locked
+              cargo install shipper --locked
             displayName: 'Install Shipper'
 
           - script: |

--- a/templates/circleci-config.yml
+++ b/templates/circleci-config.yml
@@ -76,7 +76,7 @@ jobs:
 
       - run:
           name: Install Shipper
-          command: cargo install shipper-cli --locked
+          command: cargo install shipper --locked
 
       - run:
           name: Run shipper doctor

--- a/templates/github-trusted-publishing.yml
+++ b/templates/github-trusted-publishing.yml
@@ -23,7 +23,7 @@ jobs:
         uses: rust-lang/crates-io-auth-action@v1
 
       - name: Install shipper
-        run: cargo install shipper-cli --locked
+        run: cargo install shipper --locked
 
       # Restore Shipper State (cache for faster restores)
       - name: Restore Shipper State Cache

--- a/templates/gitlab-publish.yml
+++ b/templates/gitlab-publish.yml
@@ -12,7 +12,7 @@ publish:
       - .shipper/
       - target/
   script:
-    - cargo install shipper-cli --locked
+    - cargo install shipper --locked
     - shipper publish --quiet
   variables:
     # Configure this in GitLab CI/CD settings (masked, protected)


### PR DESCRIPTION
## Summary

Final step of the #95 split. After PRs 1-3 (#140, #141, #142) landed the code in the right crates, repo-level docs still described a two-crate (`shipper` + `shipper-cli`) layout and pointed install commands at `cargo install shipper-cli`. This PR brings the docs in line with main.

## Updates

- **`README.md`** — workspace crates section now shows the three-crate product surface.
- **`CLAUDE.md`** — three-crate architecture, updated build/test commands, where behavior/CLI/surface changes belong.
- **`GEMINI.md`** — same architectural rewrite; project-structure section updated for the new layout.
- **`.github/copilot-instructions.md`** — rewritten to describe the three-crate shape and which paths to use in docs.
- **`docs/structure.md`** — three-crate diagram, `crates/shipper-core` module map, plus module maps for `shipper-cli` and the `shipper` façade.
- **`docs/architecture.md`** — `shipper::X` path references rewritten to `shipper_core::X` so readers aren't chasing paths that no longer resolve from outside the façade.
- **`docs/how-to/run-in-github-actions.md`** + **`templates/*.yml`** — `cargo install shipper-cli --locked` → `cargo install shipper --locked`.
- **`crates/shipper-cli/README.md`** — rewritten to describe this crate as the CLI adapter, with guidance on when to depend on `shipper-cli` vs `shipper-core` vs just installing `shipper`.

## What this PR does not do

- Does not physically move `crates/shipper/tests/` into `crates/shipper-core/tests/`. They exercise the curated re-export surface and moving them would double the churn here for little gain. Flagged for future cleanup.
- Does not touch `docs/decrating-plan.md` (historical narrative).

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean

Closes #95.

## Test plan

- [x] cargo check --workspace --all-targets
- [x] cargo clippy --workspace --all-targets --all-features -- -D warnings
- [ ] CI green on all matrices