### PR TITLE
chore(release): bump workspace to 0.3.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0-rc.2] - 2026-04-18
 
 Nine-competency roadmap ([#109](https://github.com/EffortlessMetrics/shipper/issues/109)) landed end-to-end on `main` since `v0.3.0-rc.1`: **Prove**, **Survive**, **Reconcile**, **Narrate**, **Remediate**, **Harden** (Trusted Publishing), **Ergonomics** (three-crate split), plus consistency enforcement and operator-trust docs.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2271,7 +2271,7 @@ dependencies = [
 
 [[package]]
 name = "shipper"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2291,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-cargo-failure"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "insta",
  "proptest",
@@ -2299,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-cli"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2328,7 +2328,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-config"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "anyhow",
  "insta",
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-core"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2389,7 +2389,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-duration"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "humantime",
  "insta",
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-encrypt"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2418,7 +2418,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-output-sanitizer"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "insta",
  "proptest",
@@ -2426,7 +2426,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-registry"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2444,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-retry"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "humantime-serde",
  "insta",
@@ -2455,7 +2455,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-sparse-index"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "insta",
  "proptest",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-types"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2482,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-webhook"
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 dependencies = [
  "anyhow",
  "hmac 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["fuzz"]
 resolver = "3"
 
 [workspace.package]
-version = "0.3.0-rc.1"
+version = "0.3.0-rc.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.92"
@@ -29,19 +29,19 @@ unsafe_code = "forbid"
 
 [workspace.dependencies]
 # Intra-workspace crates (path + version for publish-readiness).
-shipper = { path = "crates/shipper", version = "0.3.0-rc.1" }
-shipper-core = { path = "crates/shipper-core", version = "0.3.0-rc.1" }
-shipper-cli = { path = "crates/shipper-cli", version = "0.3.0-rc.1" }
-shipper-config = { path = "crates/shipper-config", version = "0.3.0-rc.1" }
-shipper-types = { path = "crates/shipper-types", version = "0.3.0-rc.1" }
-shipper-duration = { path = "crates/shipper-duration", version = "0.3.0-rc.1" }
-shipper-retry = { path = "crates/shipper-retry", version = "0.3.0-rc.1" }
-shipper-encrypt = { path = "crates/shipper-encrypt", version = "0.3.0-rc.1" }
-shipper-webhook = { path = "crates/shipper-webhook", version = "0.3.0-rc.1" }
-shipper-registry = { path = "crates/shipper-registry", version = "0.3.0-rc.1" }
-shipper-sparse-index = { path = "crates/shipper-sparse-index", version = "0.3.0-rc.1" }
-shipper-cargo-failure = { path = "crates/shipper-cargo-failure", version = "0.3.0-rc.1" }
-shipper-output-sanitizer = { path = "crates/shipper-output-sanitizer", version = "0.3.0-rc.1" }
+shipper = { path = "crates/shipper", version = "0.3.0-rc.2" }
+shipper-core = { path = "crates/shipper-core", version = "0.3.0-rc.2" }
+shipper-cli = { path = "crates/shipper-cli", version = "0.3.0-rc.2" }
+shipper-config = { path = "crates/shipper-config", version = "0.3.0-rc.2" }
+shipper-types = { path = "crates/shipper-types", version = "0.3.0-rc.2" }
+shipper-duration = { path = "crates/shipper-duration", version = "0.3.0-rc.2" }
+shipper-retry = { path = "crates/shipper-retry", version = "0.3.0-rc.2" }
+shipper-encrypt = { path = "crates/shipper-encrypt", version = "0.3.0-rc.2" }
+shipper-webhook = { path = "crates/shipper-webhook", version = "0.3.0-rc.2" }
+shipper-registry = { path = "crates/shipper-registry", version = "0.3.0-rc.2" }
+shipper-sparse-index = { path = "crates/shipper-sparse-index", version = "0.3.0-rc.2" }
+shipper-cargo-failure = { path = "crates/shipper-cargo-failure", version = "0.3.0-rc.2" }
+shipper-output-sanitizer = { path = "crates/shipper-output-sanitizer", version = "0.3.0-rc.2" }
 
 # External crates.
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -302,7 +302,7 @@ enum Commands {
         /// unless `--plan` is supplied.
         #[arg(long = "crate", value_name = "NAME", conflicts_with = "plan")]
         crate_name: Option<String>,
-        /// Version to yank (e.g., `0.3.0-rc.1`). Required unless `--plan`
+        /// Version to yank (e.g., `1.2.3`). Required unless `--plan`
         /// is supplied.
         #[arg(long, value_name = "VERSION", conflicts_with = "plan")]
         version: Option<String>,

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_yank.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_yank.snap
@@ -23,7 +23,7 @@ Options:
           [default: Cargo.toml]
 
       --version <VERSION>
-          Version to yank (e.g., `[VERSION]`). Required unless `--plan` is supplied
+          Version to yank (e.g., `1.2.3`). Required unless `--plan` is supplied
 
       --reason <REASON>
           Operator-supplied reason. Required unless `--plan` is supplied. Recorded in the event log, audit trails, and any future receipts that reference this yank.


### PR DESCRIPTION
## Summary

- Bumps workspace version from `0.3.0-rc.1` → `0.3.0-rc.2`.
- Promotes the `[Unreleased]` CHANGELOG section to `[0.3.0-rc.2] - 2026-04-18`.
- Regenerates `Cargo.lock` accordingly.

## Why rc.2 (not 0.3.0 stable)

The 29 commits since rc.1 include substantial new surface (rehearse, yank/fix-forward, OIDC, three-crate split, reconcile). The code is tested, but the **operator-side real Recover rehearsal still hasn't been run on current `main`** — that's the last trust check before stable.

## Not in this PR

- Git tag (create after merge: `git tag -a v0.3.0-rc.2 -m "..."; git push origin v0.3.0-rc.2`)
- `cargo publish` (requires your token; publish order is `shipper-core` → `shipper-cli` → `shipper` plus any changed microcrates)

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test -p shipper-core shipper_version` — version-handling tests green
- [x] CHANGELOG entry dated correctly (2026-04-18)
- [x] Cargo.lock regenerated with rc.2 versions