### PR TITLE
chore(deps): ignore RustCrypto minor bumps until ecosystem stabilizes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,24 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+    # RustCrypto ecosystem (hmac, sha2, pbkdf2, aes-gcm) bumps minor versions
+    # together because they share the `digest` trait version. A lone hmac 0.13
+    # or sha2 0.11 bump fails to compile because pbkdf2 0.13 and aes-gcm 0.11
+    # (the coupled counterparts on digest 0.11) are still pre-release. Re-
+    # enable these updates once pbkdf2 0.13 and aes-gcm 0.11 ship as stable.
+    ignore:
+      - dependency-name: "hmac"
+        update-types:
+          - "version-update:semver-minor"
+      - dependency-name: "sha2"
+        update-types:
+          - "version-update:semver-minor"
+      - dependency-name: "pbkdf2"
+        update-types:
+          - "version-update:semver-minor"
+      - dependency-name: "aes-gcm"
+        update-types:
+          - "version-update:semver-minor"
     groups:
       # Group minor/patch updates for dev dependencies
       dev-deps:


### PR DESCRIPTION
## Summary

Adds dependabot ignore rules for `hmac`, `sha2`, `pbkdf2`, and `aes-gcm` minor bumps so #40 and #41 (and their re-opens) stop cluttering the tracker until the ecosystem stabilizes.

## The coupling problem

#40 (hmac 0.12→0.13) and #41 (sha2 0.10→0.11) look like independent dep bumps but are coupled through `digest`:

| Crate | We pin | Latest stable | digest version |
|---|---|---|---|
| hmac | 0.12.1 | 0.13.0 | 0.13 needs **digest 0.11** |
| sha2 | 0.10.9 | 0.11.0 | 0.11 needs **digest 0.11** |
| pbkdf2 | 0.12.2 | 0.13.0-**rc.10** | 0.13 needs **digest 0.11** |
| aes-gcm | 0.10.x | 0.11.0-**rc.3** | 0.11 needs **digest 0.11** |

`Hmac::<Sha256>` and `pbkdf2_hmac_array::<Sha256, _>` all require matching `digest` trait versions. A lone bump breaks compilation because the `digest` versions diverge.

Moving everything forward requires accepting **pre-release crypto crates** (pbkdf2 0.13.0-rc.10, aes-gcm 0.11.0-rc.3), which isn't a good trade for a security-relevant path.

## Action

1. Add ignore rules for the four coupled deps at `semver-minor` level.
2. Close #40 and #41 as blocked-on-ecosystem.
3. Re-enable by deleting these ignore entries once pbkdf2 0.13 and aes-gcm 0.11 ship as stable releases.

Our current pins (hmac 0.12, sha2 0.10, pbkdf2 0.12, aes-gcm 0.10) have no open security advisories; staying put is safe.

## Test plan

- [x] `.github/dependabot.yml` parses (YAML structure unchanged except for the `ignore:` block)
- [ ] After merge: `@dependabot recreate` on any reopened hmac/sha2 PR confirms they're suppressed