### PR TITLE
feat(shipper): gate shipper-cli behind default 'cli' feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`shipper` crate:** the `shipper-cli` dependency is now behind a default `cli` feature. `cargo install shipper` and the `shipper` binary still work unchanged (the feature is on by default). Library consumers that only want the curated `shipper-core` re-export can opt out with `shipper = { version = "...", default-features = false }`, which drops the `clap` graph. `shipper-core` remains the canonical lean embedding surface.
+
 ## [0.3.0-rc.2] - 2026-04-18
 
 Nine-competency roadmap ([#109](https://github.com/EffortlessMetrics/shipper/issues/109)) landed end-to-end on `main` since `v0.3.0-rc.1`: **Prove**, **Survive**, **Reconcile**, **Narrate**, **Remediate**, **Harden** (Trusted Publishing), **Ergonomics** (three-crate split), plus consistency enforcement and operator-trust docs.

--- a/crates/shipper/Cargo.toml
+++ b/crates/shipper/Cargo.toml
@@ -22,13 +22,24 @@ categories = ["command-line-utilities", "development-tools", "development-tools:
 # The library target re-exports `shipper-core`'s public surface so the
 # historical `shipper::engine`, `shipper::plan`, etc. paths keep
 # resolving for callers that depend on the product name.
+#
+# The `cli` feature is on by default so `cargo install shipper` works
+# out of the box. Library consumers that only want the curated
+# `shipper-core` re-export (no `clap`, no `indicatif`) can opt out
+# with `shipper = { version = "...", default-features = false }`.
+[features]
+default = ["cli"]
+# Pulls in `shipper-cli` and enables the `[[bin]]` target.
+cli = ["dep:shipper-cli"]
+
 [[bin]]
 name = "shipper"
 path = "src/bin/shipper.rs"
+required-features = ["cli"]
 
 [dependencies]
 shipper-core.workspace = true
-shipper-cli.workspace = true
+shipper-cli = { workspace = true, optional = true }
 anyhow = "1.0.102"
 
 [lints]

--- a/crates/shipper/README.md
+++ b/crates/shipper/README.md
@@ -38,9 +38,16 @@ shipper (this crate — install face)
 ```
 
 Three crates, one product. You install `shipper`. If you're embedding
-the engine in your own Rust tool, depend on
-[`shipper-core`](https://crates.io/crates/shipper-core) directly — it
-has no CLI dependencies (no `clap`, no `indicatif`).
+the engine in your own Rust tool, you have two options:
+
+1. Depend on [`shipper-core`](https://crates.io/crates/shipper-core)
+   directly — it has no CLI dependencies (no `clap`, no `indicatif`).
+2. Disable this crate's default `cli` feature to drop `shipper-cli`
+   (and therefore `clap`) while keeping the curated re-export paths:
+
+   ```toml
+   shipper = { version = "...", default-features = false }
+   ```
 
 ## Quick start
 

--- a/crates/shipper/src/lib.rs
+++ b/crates/shipper/src/lib.rs
@@ -24,9 +24,19 @@
 //! ## Embedding
 //!
 //! For programmatic use — driving a publish from your own Rust code
-//! without a CLI dependency graph (no `clap`, no `indicatif`) — depend
-//! on [`shipper-core`](https://crates.io/crates/shipper-core) directly.
-//! That crate is the stable embedding surface.
+//! without a CLI dependency graph (no `clap`, no `indicatif`) — you
+//! have two options:
+//!
+//! 1. Depend on [`shipper-core`](https://crates.io/crates/shipper-core)
+//!    directly. That crate is the stable embedding surface.
+//! 2. Or disable the default `cli` feature on this crate:
+//!
+//!    ```toml
+//!    shipper = { version = "...", default-features = false }
+//!    ```
+//!
+//!    This drops the `shipper-cli` (and therefore `clap`) dependency
+//!    while keeping the curated re-export paths below.
 //!
 //! This crate re-exports a **curated** set of `shipper-core` modules
 //! for convenience so `shipper::engine`, `shipper::plan`, etc. keep


### PR DESCRIPTION
## Summary

Makes `shipper-cli` an optional dependency of the `shipper` crate, behind a default `cli` feature. `cargo install shipper` and the `shipper` binary keep working unchanged; lean embedders who want the curated `shipper-core` re-export via the product name can now opt out of the `clap` graph.

## Why

The `shipper` crate's library surface (`engine`, `plan`, `types`, `config`, `state`, `store`) only touches `shipper-core` — but until now, depending on `shipper` forced consumers to pull `shipper-cli` and therefore `clap`, even when they never intended to invoke the CLI. The #95 three-crate split identified `shipper-core` as the canonical lean embedding surface and this closes the loop for callers who prefer the product name.

## Changes

- `shipper-cli` dependency is now `optional = true`.
- New `[features]` block: `default = ["cli"]`, `cli = ["dep:shipper-cli"]`.
- `[[bin]] name = "shipper"` gets `required-features = ["cli"]` — `--no-default-features` cleanly skips the binary instead of failing late with a `clap` missing-dep error.
- `src/lib.rs` and `crates/shipper/README.md` document the embedding opt-out.
- `CHANGELOG.md` gets an `[Unreleased]` entry.

## Compatibility

- `cargo install shipper --locked` — unchanged (default features include `cli`).
- `cargo install shipper-cli --locked` — unchanged.
- `shipper = "0.3.0-rc.2"` (lib consumers) — unchanged (they already got `shipper-cli` transitively; now they still do, by default).
- `shipper = { version = "0.3.0-rc.2", default-features = false }` — **new opt-in**: drops `clap`.

## Test plan

- [x] `cargo check -p shipper` clean
- [x] `cargo check -p shipper --no-default-features` clean
- [x] `cargo build -p shipper --bin shipper --no-default-features` fails with the intended `requires the features: cli` message
- [x] `cargo test -p shipper` — 39 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo clippy -p shipper --no-default-features --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean