### PR TITLE
fix(release): OIDC fallback to token + correct shipper-cli wording

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,6 +250,15 @@ jobs:
       # registration checklist.
       - name: Mint crates.io token (Trusted Publishing)
         id: auth
+        # continue-on-error: if the repo/crates aren't yet registered for
+        # Trusted Publishing on crates.io, this action exits non-zero
+        # ("No Trusted Publishing config found for repository ..."). The
+        # downstream publish steps read
+        # `steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN`, so
+        # a failed OIDC exchange cleanly falls through to the secret
+        # token. This is the safety rail called out above — don't fail
+        # the whole release just because OIDC isn't configured yet.
+        continue-on-error: true
         uses: rust-lang/crates-io-auth-action@v1
 
       # --- Step 4: preflight ------------------------------------------------
@@ -448,8 +457,16 @@ jobs:
       # the CARGO_REGISTRY_TOKEN secret — rehearse keeps working either way.
       - name: Mint crates.io token (Trusted Publishing)
         id: auth
-        uses: rust-lang/crates-io-auth-action@v1
+        # continue-on-error: if the repo/crates aren't yet registered for
+        # Trusted Publishing on crates.io, this action exits non-zero
+        # ("No Trusted Publishing config found for repository ..."). The
+        # downstream publish steps read
+        # `steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN`, so
+        # a failed OIDC exchange cleanly falls through to the secret
+        # token. This is the safety rail called out above — don't fail
+        # the whole release just because OIDC isn't configured yet.
         continue-on-error: true
+        uses: rust-lang/crates-io-auth-action@v1
 
       # Preflight against crates.io without publishing. A token isn't strictly
       # required here (ownership checks are best-effort), but supply it if the
@@ -536,6 +553,15 @@ jobs:
       # token is already expired). Falls back to secret if OIDC unavailable.
       - name: Mint crates.io token (Trusted Publishing)
         id: auth
+        # continue-on-error: if the repo/crates aren't yet registered for
+        # Trusted Publishing on crates.io, this action exits non-zero
+        # ("No Trusted Publishing config found for repository ..."). The
+        # downstream publish steps read
+        # `steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN`, so
+        # a failed OIDC exchange cleanly falls through to the secret
+        # token. This is the safety rail called out above — don't fail
+        # the whole release just because OIDC isn't configured yet.
+        continue-on-error: true
         uses: rust-lang/crates-io-auth-action@v1
 
       - name: shipper resume

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ From crates.io:
 cargo install shipper --locked
 ```
 
-> `shipper-cli` is still published as a compatibility shim — older
-> scripts and CI that reference it keep working during the migration
-> window. Prefer `shipper` on new setups. Tracking: [#95](https://github.com/EffortlessMetrics/shipper/issues/95).
+> `shipper-cli` is the real CLI adapter crate (clap parsing, subcommand
+> dispatch, output/progress — exposes `pub fn run()`). Most users should
+> install `shipper`; `shipper-cli` is still published as its own crate
+> so callers that want the adapter directly — or that already wired
+> `cargo install shipper-cli` into pipelines — keep working. See [#95](https://github.com/EffortlessMetrics/shipper/issues/95).
 
 From this repository:
 

--- a/crates/shipper-cli/README.md
+++ b/crates/shipper-cli/README.md
@@ -33,19 +33,24 @@ For programmatic use **without** a `clap` dependency graph, depend on
 [`shipper-core`](https://crates.io/crates/shipper-core) instead — that's
 where the engine lives.
 
-## Back-compat binary
+## Installing the adapter directly
 
-A `shipper-cli` binary still ships so that existing pipelines with
-`cargo install shipper-cli --locked` keep working. Prefer
-`cargo install shipper --locked` on new setups.
+The `shipper-cli` crate ships its own `shipper-cli` binary, a
+three-line wrapper over `shipper_cli::run()` — the same entry point
+the `shipper` install uses. Install the adapter directly when you
+want the `shipper-cli` binary name (e.g., existing pipelines, or
+you prefer the adapter crate explicitly):
 
 ```bash
-# Backward-compatible — same code path
+# From crates.io — same code path as `cargo install shipper`
 cargo install shipper-cli --locked
 
 # From this repository
 cargo install --path crates/shipper-cli --locked
 ```
+
+Most users should prefer `cargo install shipper --locked`, which
+installs a binary named `shipper` against the same adapter.
 
 ## Core commands
 

--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -450,8 +450,9 @@ impl Reporter for CliReporter {
 }
 
 /// CLI entry point. Exposed for the `shipper` crate's binary target
-/// and for the `shipper-cli` compatibility shim, both of which are
-/// three-line `fn main() { shipper_cli::run() }` wrappers.
+/// and for the `shipper-cli` crate's own `shipper-cli` binary — both
+/// are three-line `fn main() { shipper_cli::run() }` wrappers over
+/// this function.
 pub fn run() -> Result<()> {
     let cli = Cli::parse();
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -89,7 +89,7 @@ Only finalize the GitHub Release after **all 12 crates are visible on crates.io*
 1. Workflow log shows `shipper publish` completed successfully.
 2. Every crate returns a 200 from `https://crates.io/api/v1/crates/<crate>`.
 3. `cargo search shipper-cli` (no path override) returns `0.3.0-rc.1`.
-4. At least one smoke install: `cargo install shipper --version 0.3.0-rc.1 --locked` from a scratch directory. (`shipper-cli` also works as the compatibility shim.)
+4. At least one smoke install: `cargo install shipper --version 0.3.0-rc.1 --locked` from a scratch directory. (`cargo install shipper-cli --version 0.3.0-rc.1 --locked` also works — same code path, the adapter crate installed directly.)
 5. The `shipper-state-final` artifact is downloaded and archived (90-day retention by default; take a local copy for the permanent record).
 
 Only then do the per-platform binary artifacts get attached to the GitHub Release. The release note should reference the `shipper-state-final` tarball as publish evidence.


### PR DESCRIPTION
## Summary

Two connected fixes after the `v0.3.0-rc.2` tag push failed at the crates.io OIDC exchange:

1. **Workflow fix**: add `continue-on-error: true` to the `rust-lang/crates-io-auth-action@v1` step so a failed OIDC exchange cleanly falls through to the `CARGO_REGISTRY_TOKEN` secret. The downstream publish/preflight steps already read `steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN` — the fallback was designed in but was unreachable because the auth step's non-zero exit killed the whole job.
2. **Docs wording**: `shipper-cli` is the real CLI adapter crate, not a "compatibility shim." Fixes README, crate README, runbook, and `run()` doc comment.

## What broke on rc.2

```
Failed to retrieve token from Cargo registry. Status: 400.
Error: No Trusted Publishing config found for repository `EffortlessMetrics/shipper`.
```

Trusted Publishing is a per-crate crates.io-side config (`crate → Settings → Trusted Publishing → Add`). Our 13 crates aren't registered there yet. The workflow-side OIDC code landed in #96, but crates.io-side setup was never done.

**Nothing was published to crates.io** — the OIDC failure happened before any `cargo publish` invocation. The `shipper-state-preflight.zip` artifact uploaded cleanly; Shipper's own failure-state handling worked as designed.

## Path forward

For rc.2 / 0.3.x:
- Merge this PR.
- Ensure `CARGO_REGISTRY_TOKEN` is set as a repository secret (you mentioned earlier it's available).
- Re-run the release by either:
  - Deleting and re-pushing the `v0.3.0-rc.2` tag (no crates were published, so no state to reconcile), or
  - Cutting `v0.3.0-rc.3`.

For 0.4.0:
- Register each publishable crate on crates.io under Trusted Publishing (repo: `EffortlessMetrics/shipper`, workflow: `release.yml`, environment: `release`).
- After one clean TP release, remove the `CARGO_REGISTRY_TOKEN` secret.

## Wording fix scope

- `README.md` — top-level install note.
- `crates/shipper-cli/README.md` — renamed "Back-compat binary" → "Installing the adapter directly".
- `crates/shipper-cli/src/lib.rs` — `run()` doc comment.
- `docs/release-runbook.md` — smoke-install note.

## Test plan

- [x] `grep -rn "compatibility shim"` returns zero hits.
- [x] Workflow YAML still parses (3 `continue-on-error: true` on auth steps, duplicate removed).
- [x] No code changes outside these five files.