### PR TITLE
fix(ci-templates): default install command to shipper, not shipper-cli

### DIFF
--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -13,9 +13,10 @@
 //! ```
 //!
 //! The `shipper` binary on crates.io is a three-line wrapper that
-//! calls [`run`]; a separate `shipper-cli` binary exists in this
-//! crate for backward compatibility with `cargo install shipper-cli`
-//! and for workspace-local development.
+//! calls [`run`]. This crate also ships its own `shipper-cli` binary,
+//! another three-line wrapper over [`run`], for callers that want the
+//! adapter crate installed directly (`cargo install shipper-cli`) or
+//! for workspace-local development.
 //!
 //! ## Embedding
 //!
@@ -1887,7 +1888,7 @@ fn run_ci(ci_cmd: CiCommands, state_dir: &Path, workspace_root: &Path) -> Result
             println!("      - {}/", abs_state.display());
             println!("      - target/");
             println!("  script:");
-            println!("    - cargo install shipper-cli --locked");
+            println!("    - cargo install shipper --locked");
             println!("    - shipper publish --quiet");
             println!("  variables:");
             println!("    CARGO_TERM_COLOR: \"always\"");
@@ -1918,7 +1919,7 @@ fn run_ci(ci_cmd: CiCommands, state_dir: &Path, workspace_root: &Path) -> Result
             println!("            - shipper-state-");
             println!("      - run:");
             println!("          name: Install Shipper");
-            println!("          command: cargo install shipper-cli --locked");
+            println!("          command: cargo install shipper --locked");
             println!("      - run:");
             println!("          name: Publish Crates");
             println!("          command: shipper publish --quiet");
@@ -1966,7 +1967,7 @@ fn run_ci(ci_cmd: CiCommands, state_dir: &Path, workspace_root: &Path) -> Result
             println!("      path: $(CARGO_HOME)");
             println!("      cacheHitVar: CACHE_RESTORED");
             println!();
-            println!("  - script: cargo install shipper-cli --locked");
+            println!("  - script: cargo install shipper --locked");
             println!("    displayName: 'Install Shipper'");
             println!();
             println!("  - script: shipper publish --quiet");

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__ci_azure_devops.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__ci_azure_devops.snap
@@ -25,7 +25,7 @@ steps:
       path: $(CARGO_HOME)
       cacheHitVar: CACHE_RESTORED
 
-  - script: cargo install shipper-cli --locked
+  - script: cargo install shipper --locked
     displayName: 'Install Shipper'
 
   - script: shipper publish --quiet

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__ci_circleci.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__ci_circleci.snap
@@ -20,7 +20,7 @@ jobs:
             - shipper-state-
       - run:
           name: Install Shipper
-          command: cargo install shipper-cli --locked
+          command: cargo install shipper --locked
       - run:
           name: Publish Crates
           command: shipper publish --quiet

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__ci_gitlab.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__ci_gitlab.snap
@@ -14,7 +14,7 @@ publish:
       - <STATE_DIR>/
       - target/
   script:
-    - cargo install shipper-cli --locked
+    - cargo install shipper --locked
     - shipper publish --quiet
   variables:
     CARGO_TERM_COLOR: "always"


### PR DESCRIPTION
## Summary

Post-rc.2 docs sweep caught that the `shipper ci` subcommand generators for GitLab, CircleCI, and Azure DevOps still printed `cargo install shipper-cli --locked` as the install step. The three-crate story made `shipper` the recommended install path; these templates were stale.

## What changed

- `crates/shipper-cli/src/lib.rs` — three `cargo install shipper-cli --locked` strings → `cargo install shipper --locked` (GitLab, CircleCI, Azure DevOps templates). GitHub Actions template already assumed `shipper` on PATH.
- Module doc comment reworded: the `shipper-cli` binary is the adapter crate's own binary, not a back-compat shim.
- Three `insta` snapshots refreshed to match.

## Context

The post-rc.2 smoke installs confirmed:
- `cargo install shipper --version 0.3.0-rc.2 --locked` → works, `shipper 0.3.0-rc.2`
- `cargo install shipper-cli --version 0.3.0-rc.2 --locked` → works, same code path
- `shipper-core = "0.3.0-rc.2"` embedder compile → no clap/indicatif in dep graph

So the product story is correct on crates.io; this PR closes the last place in the repo that still told users the wrong install command.

## Test plan

- [x] `cargo check -p shipper-cli` clean
- [x] `cargo test -p shipper-cli --test e2e_expanded` — 129 passed (including the 3 updated snapshots)
- [x] `grep -rn "cargo install shipper-cli --locked" crates/` — no matches outside intentional adapter-path references