### PR TITLE
docs(readme): rewrite the four user-facing READMEs as a coherent family

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,208 +1,49 @@
 # shipper
 
-`shipper` is a **publishing reliability layer** for Rust workspaces.
+Publishing a multi-crate Rust workspace is easy to start and hard to trust. Shipper gives you a deterministic plan, resumable execution, and an audit trail you can actually use when something goes sideways.
 
-Cargo packages and uploads. The workflow around it — planning a multi-crate release, surviving rate limits, recovering when CI dies, knowing what actually shipped when the upload was ambiguous — is where things tend to break. Shipper makes a workspace publish **safe to start** and **safe to re-run**.
+## What Shipper does
 
-> **The single test:** you can start a release train, stop staring at the terminal, and still trust the outcome.
+- Builds a deterministic, dependency-ordered publish plan.
+- Runs preflight checks before the first irreversible step.
+- Publishes one crate at a time, verifies visibility, then advances.
+- Persists state after every step so interrupted runs resume cleanly.
+- Reconciles ambiguous `cargo publish` outcomes against registry truth instead of blind-retrying.
+- Records events, state, and receipts for post-run auditing and remediation.
 
-> **Why this exists:** see [MISSION.md](MISSION.md) for mission, vision, audience, and the convictions that shape every default.
-
-## Status
-
-**v0.3.0-rc.1 shipped 2026-04-16** — first real-world crates.io publish, 12 crates live, driven by Shipper itself. The publish absorbed 41 retries silently across a 69-minute run. See [ROADMAP.md](ROADMAP.md) for the post-rc.1 product thesis (nine competencies) and master tracking issue [#109](https://github.com/EffortlessMetrics/shipper/issues/109).
-
-| Audience | Start here |
-|---|---|
-| New user | This README → [docs/release-runbook.md](docs/release-runbook.md) |
-| Operator | [docs/release-runbook.md](docs/release-runbook.md), [docs/configuration.md](docs/configuration.md) |
-| Contributor | [MISSION.md](MISSION.md) → [ROADMAP.md](ROADMAP.md) → [CONTRIBUTING.md](CONTRIBUTING.md) → an issue from #100–#109 |
-| AI assistant | [CLAUDE.md](CLAUDE.md) or [GEMINI.md](GEMINI.md) |
-| Auditing receipts/events | [docs/INVARIANTS.md](docs/INVARIANTS.md) |
-
-## Install
-
-From crates.io:
+## Try it
 
 ```bash
 cargo install shipper --locked
-```
-
-> `shipper-cli` is the real CLI adapter crate (clap parsing, subcommand
-> dispatch, output/progress — exposes `pub fn run()`). Most users should
-> install `shipper`; `shipper-cli` is still published as its own crate
-> so callers that want the adapter directly — or that already wired
-> `cargo install shipper-cli` into pipelines — keep working. See [#95](https://github.com/EffortlessMetrics/shipper/issues/95).
-
-From this repository:
-
-```bash
-cargo install --path crates/shipper --locked
-```
-
-## Quick start
-
-```bash
 shipper plan        # preview the publish order
-shipper preflight   # verify everything is ready
+shipper preflight   # check readiness
 shipper publish     # execute the plan
 shipper resume      # if interrupted, continue from the last state
 ```
 
-`shipper --help` and `shipper <subcommand> --help` are the canonical command/flag reference.
+## What Shipper does not do
 
-For a walkthrough, see the [first-publish tutorial](docs/tutorials/first-publish.md). For the full docs tree (tutorials / how-to / reference / explanation), see [docs/README.md](docs/README.md).
+Shipper does not decide version numbers, generate changelogs, tag releases, or create GitHub releases. Pair it with [cargo-release](https://github.com/crate-ci/cargo-release) or [release-plz](https://github.com/MarcoIeni/release-plz) for those; Shipper picks up after the version is decided.
 
-## How it works
+## Where to go next
 
-The core flow is **plan → preflight → publish → (resume if interrupted)**.
+- **Learn** → [docs/tutorials](docs/tutorials) (first publish, recovery walkthrough)
+- **Do** → [docs/how-to](docs/how-to) (CI integration, stalled-run triage, remediation)
+- **Look up** → [docs/reference](docs/reference) (CLI, state files, `.shipper.toml`)
+- **Understand** → [docs/explanation](docs/explanation) (why Shipper, `not_proven`, invariants)
+- **All docs** → [docs/README.md](docs/README.md)
 
-1. **Plan.** Reads the workspace via `cargo_metadata`, filters publishable crates, topologically sorts them by intra-workspace dependencies, and computes a SHA256-based `plan_id`. Same workspace state always produces the same `plan_id`.
-2. **Preflight.** Validates git cleanliness, registry reachability, performs a workspace dry-run, checks version-not-taken, optionally verifies ownership. Produces a `Finishability` assessment (Proven / NotProven / Failed).
-3. **Publish.** Executes the plan one crate at a time with retry/backoff. After each `cargo publish`, verifies registry visibility (sparse index and/or API) before advancing to a dependent crate. Persists state to disk after every step.
-4. **Resume.** Reloads `.shipper/state.json`, validates the `plan_id` matches the current workspace, skips already-published packages, continues from the first pending crate.
+## For embedders
 
-State lives in `.shipper/`:
+Depend on [`shipper-core`](crates/shipper-core/README.md) — the engine library with no CLI dependencies. The [`shipper`](crates/shipper/README.md) crate is the install face; [`shipper-cli`](crates/shipper-cli/README.md) is the real CLI adapter. See [docs/structure.md](docs/structure.md) for the full crate map.
 
-- **`events.jsonl`** — append-only event stream. **The authoritative record.**
-- **`state.json`** — projection over events for fast resume.
-- **`receipt.json`** — end-of-run summary with evidence.
-- **`lock`** — concurrent-publish guard.
+## Project
 
-The truth/projection/summary contract is documented in [docs/INVARIANTS.md](docs/INVARIANTS.md). Use `--state-dir <path>` to redirect (e.g. into a CI artifacts directory).
-
-## What shipper does
-
-- Deterministic, dependency-ordered publish plan.
-- Pre-flight checks (git, registry, dry-run, version, ownership).
-- Per-crate publish with retry/backoff for retryable failures.
-- Post-publish readiness verification before advancing to dependents.
-- Resumable state after every step.
-- Append-only audit event log + machine-readable receipt with evidence (stdout/stderr, exit codes, git context, environment fingerprint).
-- Multi-registry orchestration in a single run (state segregated per registry).
-- Parallel publishing for independent crates within the dependency graph.
-- Configurable safety/speed tradeoff via publish policies (`safe`, `balanced`, `fast`).
-
-## What shipper does not do
-
-- Bump versions, generate changelogs, create git tags, or write release notes. Use [cargo-release](https://github.com/crate-ci/cargo-release) or [release-plz](https://github.com/MarcoIeni/release-plz) for those. Shipper picks up *after* the version is decided.
-
-## Authentication
-
-Publishing itself is performed by Cargo. Shipper resolves a registry token from the same places Cargo does:
-
-1. `CARGO_REGISTRY_TOKEN` (crates.io)
-2. `CARGO_REGISTRIES_<NAME>_TOKEN` (alternative registries; `<NAME>` uppercased, `-` replaced with `_`)
-3. `$CARGO_HOME/credentials.toml`
-
-The token is opaque, never logged, sanitized from receipts.
-
-`shipper doctor` reports `auth_type`:
-
-- `token` — Cargo token detected
-- `trusted` — GitHub OIDC trusted-publishing env detected
-- `unknown` — partial auth env detected
-- `-` — none
-
-> Trusted Publishing detection exists today; making it the default (with OIDC token exchange) is tracked at [#96](https://github.com/EffortlessMetrics/shipper/issues/96).
-
-## Configuration
-
-Project-specific configuration via `.shipper.toml` in the workspace root. CLI flags always take precedence.
-
-```bash
-shipper config init       # generate a default config file
-shipper config validate   # validate a configuration file
-```
-
-See [docs/configuration.md](docs/configuration.md) for the full reference.
-
-## CI integration
-
-Generate a workflow snippet for your platform:
-
-```bash
-shipper ci github-actions
-shipper ci gitlab
-shipper ci circleci
-shipper ci azure-devops
-```
-
-Or browse `templates/` for reference workflows.
-
-## Examples
-
-### Choosing a publish policy
-
-```bash
-shipper publish --policy safe       # default: verify every step
-shipper publish --policy balanced   # verify when needed
-shipper publish --policy fast       # skip verification (with caution)
-```
-
-### Choosing a readiness method
-
-```bash
-shipper publish --readiness-method api    # fast (default)
-shipper publish --readiness-method index  # more accurate
-shipper publish --readiness-method both   # most reliable
-```
-
-### Multi-registry publishing
-
-```bash
-shipper publish --registries crates-io,internal-mirror
-shipper publish --all-registries
-```
-
-### Inspecting state and receipts
-
-```bash
-shipper inspect-events                  # human-readable event log
-shipper inspect-receipt --format json   # JSON receipt for CI consumption
-shipper status                          # compare local versions to the registry
-```
-
-### Resuming after interruption
-
-```bash
-shipper resume
-shipper resume --force-resume           # if the workspace plan has changed
-shipper publish --resume-from my-crate  # restart from a specific crate
-```
-
-## Workspace crates
-
-Product surface (the three-crate split):
-
-- [`shipper`](crates/shipper/README.md) — the installable product. `cargo install shipper`.
-- [`shipper-cli`](crates/shipper-cli/README.md) — real CLI adapter (clap parsing, subcommands, output). Exposes `pub fn run()` for embedders.
-- [`shipper-core`](crates/shipper-core/README.md) — engine library (no CLI deps). Depend on this for programmatic use.
-
-The full crate map (including supporting microcrates) is in [docs/structure.md](docs/structure.md).
-
-## Documentation
-
-The full docs tree is organized by reader purpose ([Diátaxis](https://diataxis.fr/)): tutorials, how-to guides, reference, explanation. Start at **[docs/README.md](docs/README.md)**.
-
-Top of the repo:
-
-- [MISSION.md](MISSION.md) — mission, vision, audience, beliefs
-- [ROADMAP.md](ROADMAP.md) — five pillars, nine-competency scorecard, now/next/later
-- [docs/README.md](docs/README.md) — documentation index
-
-Quick links:
-
-- **Learn:** [First publish tutorial](docs/tutorials/first-publish.md) • [Recover from interruption](docs/tutorials/recover-from-interruption.md)
-- **Do:** [Run in GitHub Actions](docs/how-to/run-in-github-actions.md) • [Inspect state & receipts](docs/how-to/inspect-state-and-receipts.md) • [Inspect a stalled run](docs/how-to/inspect-a-stalled-run.md)
-- **Look up:** [CLI reference](docs/reference/cli.md) • [State files cheat sheet](docs/reference/state-files.md) • [`.shipper.toml`](docs/configuration.md) • [Failure modes](docs/failure-modes.md)
-- **Understand:** [Why Shipper](docs/explanation/why-shipper.md) • [`not_proven` explained](docs/explanation/finishability.md) • [Architecture](docs/architecture.md) • [Invariants](docs/INVARIANTS.md)
+- [MISSION.md](MISSION.md) — mission, vision, audience
+- [ROADMAP.md](ROADMAP.md) — nine-competency thesis, current status
+- [CHANGELOG.md](CHANGELOG.md) — release history
+- [CONTRIBUTING.md](CONTRIBUTING.md) — how to contribute
 
 ## License
 
-Licensed under either of:
-
-- Apache License, Version 2.0
-- MIT license
-
-at your option.
+Licensed under either of Apache-2.0 or MIT at your option.

--- a/crates/shipper-cli/README.md
+++ b/crates/shipper-cli/README.md
@@ -1,26 +1,16 @@
 # shipper-cli
 
-CLI adapter crate for Shipper. Owns `clap` parsing, subcommand dispatch,
-help text, and progress rendering. Exposes `pub fn run() -> anyhow::Result<()>`
-as the embedding entry point; the `shipper-cli` binary is a three-line
-wrapper over `run`.
+CLI adapter for [Shipper](https://crates.io/crates/shipper).
 
-## Use the `shipper` crate to install
-
-Most users should install the product via the `shipper` crate:
+**Most users should install `shipper`, not this crate:**
 
 ```bash
 cargo install shipper --locked
 ```
 
-That installs a binary named `shipper` that forwards to the same `run`
-function in this crate.
+## Use this crate when
 
-## When to depend on `shipper-cli` directly
-
-Reach for this crate when you need the exact CLI surface programmatically
-— for example, a wrapper that invokes Shipper after extra preflight
-steps of your own:
+You need the exact clap-based CLI surface programmatically — for example, a wrapper that invokes Shipper after extra preflight steps of your own:
 
 ```rust,no_run
 fn main() -> anyhow::Result<()> {
@@ -29,52 +19,28 @@ fn main() -> anyhow::Result<()> {
 }
 ```
 
-For programmatic use **without** a `clap` dependency graph, depend on
-[`shipper-core`](https://crates.io/crates/shipper-core) instead — that's
-where the engine lives.
-
-## Installing the adapter directly
-
-The `shipper-cli` crate ships its own `shipper-cli` binary, a
-three-line wrapper over `shipper_cli::run()` — the same entry point
-the `shipper` install uses. Install the adapter directly when you
-want the `shipper-cli` binary name (e.g., existing pipelines, or
-you prefer the adapter crate explicitly):
+Or you want to install the adapter binary directly:
 
 ```bash
-# From crates.io — same code path as `cargo install shipper`
-cargo install shipper-cli --locked
-
-# From this repository
-cargo install --path crates/shipper-cli --locked
+cargo install shipper-cli --locked   # same code path as `cargo install shipper`
 ```
 
-Most users should prefer `cargo install shipper --locked`, which
-installs a binary named `shipper` against the same adapter.
-
-## Core commands
-
-- `shipper plan` — print publish order and skipped packages.
-- `shipper preflight` — run checks without publishing.
-- `shipper publish` — execute publish and persist state.
-- `shipper resume` — continue from previous state.
-- `shipper status` — compare local versions to registry versions.
-- `shipper doctor` — print environment and auth diagnostics.
-- `shipper rehearse` — package + verify + publish to a rehearsal registry.
-- `shipper yank` / `shipper plan-yank` — receipt-driven containment.
-- `shipper fix-forward` — plan a minimal repair of a partial release.
+For programmatic use **without** the `clap` graph, depend on [`shipper-core`](https://crates.io/crates/shipper-core) instead — that's the lean embedding surface.
 
 ## Architecture
 
-```
+```text
 shipper (install face — `cargo install shipper`)
   -> shipper-cli (this crate — CLI adapter, pub fn run())
-       -> shipper-core (engine — library only)
+       -> shipper-core (engine, no CLI deps)
 ```
 
-## Related crates and docs
+## Related
 
 - Install face: <https://crates.io/crates/shipper>
 - Engine library: <https://crates.io/crates/shipper-core>
 - Project README: <https://github.com/EffortlessMetrics/shipper#readme>
-- Configuration reference: <https://github.com/EffortlessMetrics/shipper/blob/main/docs/configuration.md>
+
+## License
+
+MIT OR Apache-2.0.

--- a/crates/shipper-core/README.md
+++ b/crates/shipper-core/README.md
@@ -1,24 +1,65 @@
 # shipper-core
 
-Core library behind the [`shipper`](https://crates.io/crates/shipper) CLI.
+Lean engine library behind [Shipper](https://crates.io/crates/shipper).
 
-`shipper-core` is the engine, planning, state, registry, and remediation
-layer. It has no CLI dependencies (no `clap`, no `indicatif`) and is
-intended for programmatic use by CI frameworks, custom tools, and tests
-that need to drive `cargo publish` with the same safety guarantees the
-CLI gives operators.
+`shipper-core` is the stable embedding surface for Shipper's workspace-publish engine. It has no CLI dependencies — no `clap`, no `indicatif`, no progress rendering — and is intended for Rust tools, CI frameworks, and tests that need to drive `cargo publish` with Shipper's safety guarantees but do not need the operator-facing CLI.
 
-## When to use which crate
+## Use this crate when
 
-- **Installing the CLI** — `cargo install shipper --locked`. Use the
-  [`shipper`](https://crates.io/crates/shipper) crate.
-- **Embedding the engine in your own Rust tool** — add
-  `shipper-core` as a dependency.
-- **Rewriting the CLI surface or writing a different frontend** — add
-  [`shipper-cli`](https://crates.io/crates/shipper-cli), which re-exports
-  `shipper-core` and owns the `clap` layer.
+You want deterministic publish planning, preflight, publish/resume orchestration, and state/receipt/event handling **without** pulling the clap and terminal-UX graph.
+
+If you just want to run Shipper from a terminal or CI, install [`shipper`](https://crates.io/crates/shipper) instead.
+
+## What lives here
+
+- **Plan** — deterministic dependency-ordered publish plan from `cargo_metadata`, with a stable `plan_id`.
+- **Preflight** — git cleanliness, registry reachability, dry-run, version-not-taken, optional ownership checks.
+- **Publish / resume** — per-crate `cargo publish` with retry/backoff, post-publish readiness verification, resumable state.
+- **Reconciliation** — ambiguous-outcome handling against registry truth (`Published` / `NotPublished` / `StillUnknown`).
+- **State / events / receipts** — append-only `events.jsonl` as truth, `state.json` as projection, `receipt.json` as summary.
+- **Remediation planning** — yank, reverse-topological containment, fix-forward planning.
+- **Rehearsal** — package + verify against an alternate registry before touching production.
+
+## What does not live here
+
+- CLI parsing (`clap`) — in `shipper-cli`.
+- Progress rendering (`indicatif`) — in `shipper-cli`.
+- Install-facing docs and binary — in `shipper`.
+
+## Minimal shape
+
+```rust
+use shipper_core::plan::build_plan;
+
+// See docs/ and the engine entry points for the full API.
+// The load-bearing pieces are:
+//   - shipper_core::plan   — build a ReleasePlan from a workspace
+//   - shipper_core::engine — run preflight / publish / resume
+//   - shipper_core::state  — read persisted execution state
+//   - shipper_core::store  — StateStore trait + filesystem impl
+//   - shipper_core::types  — domain types (specs, receipts, state, events)
+//   - shipper_core::config — load and merge `.shipper.toml`
+```
+
+## Architecture
+
+```text
+shipper (install face)
+  -> shipper-cli (CLI adapter: clap, subcommands, output, pub fn run())
+       -> shipper-core (this crate — engine, no CLI deps)
+```
+
+## Related
+
+- Install face: <https://crates.io/crates/shipper>
+- CLI adapter: <https://crates.io/crates/shipper-cli>
+- Project README: <https://github.com/EffortlessMetrics/shipper#readme>
+- Architecture: <https://github.com/EffortlessMetrics/shipper/blob/main/docs/architecture.md>
 
 ## Stability
 
-Pre-1.0. The public API will move; breaking changes are called out in
-[`CHANGELOG.md`](https://github.com/EffortlessMetrics/shipper/blob/main/CHANGELOG.md).
+Pre-1.0. The public API will move; breaking changes are called out in [`CHANGELOG.md`](https://github.com/EffortlessMetrics/shipper/blob/main/CHANGELOG.md).
+
+## License
+
+MIT OR Apache-2.0.

--- a/crates/shipper/README.md
+++ b/crates/shipper/README.md
@@ -1,85 +1,58 @@
 # shipper
 
-Reliable, resumable `cargo publish` for Rust workspaces.
+Installable release-execution facade for Rust workspaces.
 
-```text
+A workspace release can fail after some crates publish and before the rest do. Cargo's own docs note that `cargo publish --workspace` is non-atomic and that a client timeout does not always mean the upload failed. Shipper gives you a plan, a preflight gate, durable state, and a recovery path for that failure mode.
+
+## Install
+
+```bash
 cargo install shipper --locked
 ```
-
-Shipper runs a multi-crate workspace release to crates.io (or any
-Cargo-compatible registry) with the safety guarantees that `cargo
-publish` alone can't give you:
-
-- **Resumable** — if a publish is interrupted (CI timeout, rate limit,
-  network blip), `shipper resume` picks up from exactly where it
-  stopped. Already-published crates are skipped; ambiguous crates
-  reconcile against the registry first.
-- **Backoff-aware** — 429s and transient network errors retry with
-  jittered exponential backoff. Permanent failures fail fast.
-- **Events-as-truth** — every step writes to `.shipper/events.jsonl`.
-  `state.json` is a projection, `receipt.json` is a summary. When the
-  three disagree, events win.
-- **Prove before publish** — optional rehearsal against an alternate
-  registry (`shipper rehearse`) that packages, verifies, and
-  install-smokes every crate before touching crates.io.
-- **Contain damage** — receipt-driven `shipper yank`, reverse-topological
-  yank plans, and fix-forward planning for partial or compromised
-  releases.
-- **Trusted Publishing** — OIDC authentication against crates.io in CI
-  via GitHub's `rust-lang/crates-io-auth-action`, no long-lived tokens
-  required.
-
-## Architecture
-
-```text
-shipper (this crate — install face)
-  -> shipper-cli (CLI adapter: clap parsing, dispatch, output)
-       -> shipper-core (engine: plan, preflight, publish, resume, …)
-```
-
-Three crates, one product. You install `shipper`. If you're embedding
-the engine in your own Rust tool, you have two options:
-
-1. Depend on [`shipper-core`](https://crates.io/crates/shipper-core)
-   directly — it has no CLI dependencies (no `clap`, no `indicatif`).
-2. Disable this crate's default `cli` feature to drop `shipper-cli`
-   (and therefore `clap`) while keeping the curated re-export paths:
-
-   ```toml
-   shipper = { version = "...", default-features = false }
-   ```
 
 ## Quick start
 
 ```bash
-# In a Rust workspace with crates you want to publish
-cargo install shipper --locked
-
-# Preview the plan + preflight
-shipper preflight
-
-# Publish (writes receipt, events, state to .shipper/)
-shipper publish
-
-# If interrupted, continue from where it stopped
-shipper resume
+shipper plan        # preview the publish order
+shipper preflight   # check readiness
+shipper publish     # execute the plan
+shipper resume      # continue after an interrupted run
 ```
 
-See [the how-to guides](https://github.com/EffortlessMetrics/shipper/tree/main/docs/how-to)
-for rehearsal against an alternate registry, remediating a compromised
-release, and running recovery drills.
+`shipper --help` and `shipper <subcommand> --help` are the canonical command reference.
+
+## What this crate is
+
+`shipper` is the user-facing package — the one you install and the one that shows up on crates.io. It wraps:
+
+- a small binary that forwards to the CLI adapter,
+- a curated library re-export over the engine (`engine`, `plan`, `types`, `config`, `state`, `store`),
+- product-facing documentation.
+
+The actual work happens in two sibling crates:
+
+- [`shipper-cli`](https://crates.io/crates/shipper-cli) — CLI adapter (clap parsing, subcommands, output, `pub fn run()`).
+- [`shipper-core`](https://crates.io/crates/shipper-core) — engine library with no CLI dependencies.
+
+## Use another crate when
+
+- You want the lean embedding surface (no `clap`, no `indicatif`) → depend on [`shipper-core`](https://crates.io/crates/shipper-core).
+- You need the exact clap-driven CLI surface programmatically (custom wrappers, pre-run hooks) → depend on [`shipper-cli`](https://crates.io/crates/shipper-cli) and call `shipper_cli::run()`.
+- You want `shipper` as a library but without the `clap` graph → `shipper = { version = "...", default-features = false }`.
 
 ## Scope
 
-Shipper **does** handle publishing, retrying, resuming, rehearsing,
-yanking, and fix-forward planning. It **does not** decide version
-numbers, generate changelogs, tag releases, or create GitHub
-releases — pair it with your preferred versioning/release workflow.
+Shipper handles publishing, retrying, resuming, rehearsing, yanking, and fix-forward planning. It does not decide version numbers, generate changelogs, tag releases, or create GitHub releases — pair it with your preferred versioning/release workflow.
+
+## Documentation
+
+- Project README: <https://github.com/EffortlessMetrics/shipper#readme>
+- Full docs tree: <https://github.com/EffortlessMetrics/shipper/tree/main/docs>
+- Configuration reference: <https://github.com/EffortlessMetrics/shipper/blob/main/docs/configuration.md>
 
 ## Stability
 
-Pre-1.0. Breaking changes are called out in
-[`CHANGELOG.md`](https://github.com/EffortlessMetrics/shipper/blob/main/CHANGELOG.md).
+Pre-1.0. Breaking changes are called out in [`CHANGELOG.md`](https://github.com/EffortlessMetrics/shipper/blob/main/CHANGELOG.md).
 
 ## License
 

--- a/docs/product.md
+++ b/docs/product.md
@@ -1,49 +1,72 @@
 # Product Overview
 
-> Quick orientation for contributors and AI assistants. For mission/vision/beliefs see [../MISSION.md](../MISSION.md). For sequencing see [../ROADMAP.md](../ROADMAP.md).
+> Steering doc: orientation for contributors and AI assistants. For mission/vision/beliefs see [../MISSION.md](../MISSION.md). For the nine-competency scorecard and sequencing see [../ROADMAP.md](../ROADMAP.md). For per-release detail see [../CHANGELOG.md](../CHANGELOG.md).
 
 ## What Shipper is
 
-Shipper is a publishing reliability layer for Rust workspaces. It wraps `cargo publish` with the workflow that production releases need: deterministic planning, pre-flight proof, retry absorption, ambiguity reconciliation against registry truth, persistent state, and operator-grade observability.
+Shipper is a publishing reliability layer for Rust workspaces. It wraps `cargo publish` with the workflow that production releases need: a deterministic plan, pre-flight proof, retry absorption, ambiguity reconciliation against registry truth, persistent state for recovery, and operator-grade evidence.
 
-It is intentionally narrow. Cargo packages and uploads; Shipper handles everything between *"I want to release"* and *"all crates are live, here's the audit trail."*
+It is intentionally narrow. Cargo packages and uploads; Shipper owns everything between *"I want to release"* and *"all crates are live, here is the audit trail."* Version decisions, changelog generation, tags, and GitHub releases are deliberately out of scope — pair Shipper with [cargo-release](https://github.com/crate-ci/cargo-release) or [release-plz](https://github.com/MarcoIeni/release-plz) for those.
 
 ## Who it is for
 
-See [../MISSION.md](../MISSION.md) for the full audience definition. Briefly: workspace maintainers who publish multiple interdependent crates as coherent releases through CI, and need recovery to be mechanical rather than heroic.
+Workspace maintainers who publish **multiple interdependent crates** as a coherent release, run that release **through CI**, treat publishing as **serious and audited**, and need recovery to be **mechanical rather than heroic**. Solo authors of single crates are already well-served by `cargo publish` directly; their workflow is fine. Ours is what happens when the workflow has consequences.
 
-## What's shipped (v0.3.0-rc.1)
+The full audience definition lives in [../MISSION.md](../MISSION.md#audience).
 
-| Capability | Status |
-|---|---|
-| Deterministic publish planning (topo-sort + plan_id) | Production |
-| Workspace dry-run preflight | Production |
-| Retry/backoff with HTTP 429 handling | Production |
-| Per-step state persistence and resume | Production (resume verification pending — see [#90](https://github.com/EffortlessMetrics/shipper/issues/90)) |
-| Audit receipts with evidence | Production |
-| Multi-registry orchestration | Production |
-| Sparse-index caching | Production |
-| Workspace-aware locking | Production |
-| Shell completions, doctor diagnostics | Production |
-| OIDC trusted publishing detection | Detection only ([#96](https://github.com/EffortlessMetrics/shipper/issues/96)) |
-| Ambiguity reconciliation | Missing ([#99](https://github.com/EffortlessMetrics/shipper/issues/99) / [#102](https://github.com/EffortlessMetrics/shipper/issues/102)) |
-| Live retry visibility for operators | Missing ([#91](https://github.com/EffortlessMetrics/shipper/issues/91) / [#103](https://github.com/EffortlessMetrics/shipper/issues/103)) |
-| Yank planning / fix-forward | Missing ([#98](https://github.com/EffortlessMetrics/shipper/issues/98) / [#104](https://github.com/EffortlessMetrics/shipper/issues/104)) |
+## Product shape
 
-See [../ROADMAP.md](../ROADMAP.md) for the nine-competency status table and sequencing.
+Shipper ships as three crates with distinct roles:
 
-## Compared to alternatives
-
-| Tool | Use case | Relationship |
+| Crate | Role | What it owns |
 |---|---|---|
-| `cargo publish -p X` | Single crate | Shipper is the workflow wrapper |
-| [cargo-release](https://github.com/crate-ci/cargo-release) | Version bump + tag + publish | Shipper covers the publish; cargo-release covers the versioning |
-| [release-plz](https://github.com/MarcoIeni/release-plz) | PR-based automated releases | Drives cargo-release; can drive Shipper |
-| `cargo workspaces publish` | Workspace publishing | Shipper adds preflight/state/resume/retry/evidence |
-| Cargo 1.90 `cargo publish --workspace` | Multi-package publish | Same primitive — Shipper adds the reliability layer on top |
+| **`shipper`** | Install face | The `shipper` binary (3-line forwarder), plus a curated library re-export of `shipper-core` for drivers that prefer the product name. This is what `cargo install shipper --locked` installs. |
+| **`shipper-cli`** | CLI adapter | `clap` parsing, subcommand dispatch, help text, progress rendering. Exposes `pub fn run() -> anyhow::Result<()>` as the embedding entry point. |
+| **`shipper-core`** | Engine library | Plan, preflight, publish, resume, reconcile, rehearsal, remediate, state/events/receipts. **No CLI dependencies.** This is the stable embedding surface for IDP plugins, dashboards, and automation. |
 
-Shipper is what you reach for **after** version-decision and tag-creation are done, when the actual upload needs to be safe and recoverable.
+All 13 workspace crates publish to crates.io on the same train. Engine internals (`shipper-types`, `shipper-registry`, `shipper-cargo-failure`, `shipper-retry`, `shipper-sparse-index`, `shipper-output-sanitizer`, `shipper-config`, `shipper-duration`, `shipper-encrypt`, `shipper-webhook`) live as peer library crates. See [structure.md](structure.md) for the full crate map and module layout.
+
+## What Shipper does today
+
+The nine competencies from [../ROADMAP.md](../ROADMAP.md) are all present in `main`:
+
+- **Prove** — deterministic plan (`plan_id` = SHA256 of topo-sorted workspace), preflight (git cleanliness, registry reachability, dry-run, version existence, ownership), and a rehearsal registry pass with optional smoke-install before the live dispatch.
+- **Survive** — per-step state persistence, workspace-aware locking, resume that reconciles before re-entering the retry loop, registry-aware backoff.
+- **Reconcile** — ambiguous `cargo publish` outcomes are reconciled against registry truth (sparse index + API), not blind-retried. Cargo stdout is demoted to a fast-path hint.
+- **Narrate** — structured retry/backoff events and live CLI narration so operators can see what the engine is waiting on and why.
+- **Remediate** — receipt-driven `yank`, reverse-topological `plan-yank` (saveable and replayable), and `fix-forward` for partial releases.
+- **Harden** — Trusted Publishing (OIDC) is a first-class path for crates.io, alongside tokens.
+- **Consistency** — events-as-truth invariant enforced at end-of-run; drift is detected and reported.
+- **Ergonomics** — `cargo install shipper --locked` works end-to-end via the install façade.
+- **Integrate** — `shipper-core` is consumable as a library without pulling the CLI graph.
+
+For per-capability status and sequencing, see [../ROADMAP.md](../ROADMAP.md). For what changed when, see [../CHANGELOG.md](../CHANGELOG.md).
 
 ## Non-goals
 
-See [../MISSION.md](../MISSION.md) "What we are not."
+Shipper does **not** decide versions, generate changelogs, create git tags, create GitHub releases, manage crates.io team membership, or update dependencies. See [../MISSION.md](../MISSION.md#what-we-are-not) for the full list and the tools that do own each of those.
+
+Shipper targets Rust → cargo-protocol registries. Alternative registries (Cloudsmith, kellnr, self-hosted) are in scope as they appear; other ecosystems are not.
+
+## Compared to alternatives
+
+| Tool | Use case | Relationship to Shipper |
+|---|---|---|
+| `cargo publish -p X` | Single crate upload | Shipper is the workflow wrapper around this primitive |
+| `cargo publish --workspace` (Cargo 1.90+) | Multi-package upload | Same primitive; Shipper adds plan/preflight/state/reconcile/evidence on top |
+| [cargo-release](https://github.com/crate-ci/cargo-release) | Version bump + tag + publish | Shipper covers the publish; cargo-release covers the versioning |
+| [release-plz](https://github.com/MarcoIeni/release-plz) | PR-based automated releases | Drives cargo-release; can equally drive Shipper |
+| `cargo workspaces publish` | Workspace publishing | Shipper adds preflight/state/resume/reconcile/evidence |
+
+Shipper is what you reach for **after** version-decision and tag-creation are done, when the actual upload needs to be safe, resumable, and auditable.
+
+## Where to go from here
+
+| If you are… | Start here |
+|---|---|
+| A new user | [../README.md](../README.md) → [tutorials](tutorials) |
+| An operator setting up CI | [release-runbook.md](release-runbook.md), [configuration.md](configuration.md) |
+| An embedder | [`shipper-core`](../crates/shipper-core/README.md) → [structure.md](structure.md) |
+| A contributor | [../MISSION.md](../MISSION.md) → [../ROADMAP.md](../ROADMAP.md) → [../CONTRIBUTING.md](../CONTRIBUTING.md) |
+| Auditing receipts or events | [INVARIANTS.md](INVARIANTS.md) |
+| An AI assistant | [../CLAUDE.md](../CLAUDE.md) or [../GEMINI.md](../GEMINI.md) |

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,69 +1,87 @@
 # Release Runbook — operator crib sheet
 
 One-page operator procedure for cutting a crates.io release train via Shipper.
-Full technical detail lives in [`release-v0.3.0-rc.1-manifest.md`](./release-v0.3.0-rc.1-manifest.md) — this doc is the "what do I actually type and when do I stop."
 
-Current RC baseline: `v0.3.0-rc.1`, commit [`5beab9b`](https://github.com/EffortlessMetrics/shipper/commit/5beab9b).
+This is the "what do I actually type and when do I stop" doc. For the broader how-to (workflow YAML, Trusted Publishing setup), see [`how-to/run-in-github-actions.md`](./how-to/run-in-github-actions.md). For the last historical per-crate manifest (rc.1 tarball contents and topo proof), see [`release-v0.3.0-rc.1-manifest.md`](./release-v0.3.0-rc.1-manifest.md) — kept as an artifact of the first publish, not as the moving reference.
+
+Shipper dogfoods its own release: `shipper plan → preflight → publish` drive the train end-to-end, with `shipper resume` for recovery. The workflow is tag-driven (`.github/workflows/release.yml`): pushing a `vX.Y.Z` tag triggers `publish-crates-io`.
+
+## Crates in the train
+
+Thirteen crates publish in this dependency order. Tier boundaries matter: crates-io's new-crate rate limit (5 burst, then 1 per 10 min) applies only to the first publish of each crate, so the first release train after adding a crate to the workspace is the one where wall-clock balloons.
+
+Tier 1 — leaves: `shipper-cargo-failure`, `shipper-duration`, `shipper-encrypt`, `shipper-output-sanitizer`, `shipper-retry`, `shipper-sparse-index`, `shipper-webhook`.
+Tier 2: `shipper-types` (depends on Tier 1 leaves).
+Tier 3: `shipper-config`, `shipper-registry` (depend on `shipper-types`).
+Tier 4: `shipper-core` (engine; depends on Tiers 1–3).
+Tier 5: `shipper-cli` (adapter; depends on `shipper-core`).
+Tier 6: `shipper` (install façade; depends on `shipper-cli`).
+
+The authoritative order for a given release is whatever `shipper plan` prints for that commit — always trust the plan artifact, not this doc, if they disagree.
 
 ---
 
 ## Pre-flight (before cutting the tag)
 
-1. **CI is green on `main`.** Every lane in the latest `CI` run for `main` must show success (`gh run list --workflow=ci.yml --branch=main --limit=1`). `architecture-guard` has a `paths:` trigger gate — if it hasn't re-posted a status since the last `crates/shipper/src/**` commit, verify the workflow file on `main` contains the `--include='*.rs'` filter (guard against false-reds predating #85).
-2. **Rehearsal is green.** `gh workflow run release.yml --ref main --field mode=rehearse` completed successfully, plan ID in the uploaded `.shipper/` artifact matches the plan ID from local `shipper plan`.
+1. **CI is green on `main`.** Every lane in the latest `CI` run for `main` must show success (`gh run list --workflow=ci.yml --branch=main --limit=1`). `architecture-guard` has a `paths:` trigger gate — if it hasn't re-posted a status since the last `crates/shipper/src/**` commit, verify the workflow file on `main` still has the `--include='*.rs'` filter (false-red guard from #85).
+2. **Rehearsal is green.** `gh workflow run release.yml --ref main --field mode=rehearse` completed successfully. The plan ID in the uploaded `shipper-rehearse-<run_id>` artifact must match the plan ID from a local `shipper plan` on the same SHA.
 3. **No mainline changes since the rehearsal.** Any commit to `main` after the rehearsal invalidates the plan ID. If mainline moved, re-rehearse.
-4. **crates.io is healthy.** Open [status.crates.io](https://status.crates.io/) immediately before starting. If the **git index** is running behind but the **sparse index** is healthy, that's OK — the workflow is configured with `--readiness-method both` so it will hit the sparse index path. If the **sparse index** itself is reporting incidents, abort and wait.
-5. **Token / auth is present.**
-   - **Trusted Publishing (primary path)**: the `release.yml` workflow
-     mints a short-lived token via `rust-lang/crates-io-auth-action@v1`
-     (see #96). Each of the 12 crates must be registered on crates.io
-     as a trusted publisher for this repo + `release.yml` +
-     `release` environment. Verify via crates.io's "Trusted Publishing"
-     settings panel for any one of the crates; if it's missing for any
-     crate, `cargo publish` will 401 for that crate and the train stalls.
-   - **Token fallback**: `CARGO_REGISTRY_TOKEN` repo secret is still
-     consulted if the OIDC action can't mint (incident response, pre-
-     registration gaps). Keep it set with publish scope for all 12
-     crates until Trusted Publishing is confirmed end-to-end.
+4. **Version is bumped and committed.** `cargo metadata --format-version 1 | jq -r '.workspace_default_members[0]' | ...` → every publishable crate in `Cargo.toml` reads the intended `vX.Y.Z`. `CHANGELOG.md` has an entry for the new version (not `[Unreleased]`).
+5. **crates.io is healthy.** Open [status.crates.io](https://status.crates.io/) immediately before starting. If the **git index** is running behind but the **sparse index** is healthy, that's OK — the workflow uses `--readiness-method both` and will use the sparse index path. If the **sparse index** itself is reporting incidents, abort and wait.
+6. **Auth is present.**
+   - **Token fallback (primary path today).** `CARGO_REGISTRY_TOKEN` repo secret must be set with publish scope for every crate in the plan. Trusted Publishing is wired in `release.yml` but not yet configured per-crate on crates.io — the OIDC step has `continue-on-error: true` and cleanly falls through to the token. Until Trusted Publishing is registered for every crate (see below), the token is what's actually doing the auth.
+   - **Trusted Publishing (target path).** When you're ready to switch, follow the one-time-registration checklist in [`how-to/run-in-github-actions.md`](./how-to/run-in-github-actions.md#token-vs-trusted-publishing). Every crate in the plan must be registered as a trusted publisher for this repo + `release.yml` + `release` environment before the next tag push, or you'll mid-train 401 on the unregistered ones. Rehearse with the `release` environment bound (the workflow already does) to prove the scope wiring before going live.
 
 ## Cut the tag
 
+Use the workspace version already committed to `Cargo.toml`. Read it once:
+
 ```bash
-# from origin/main, never from a local branch
+VERSION=$(cargo metadata --format-version 1 --no-deps \
+  | jq -r '.packages[] | select(.name=="shipper") | .version')
+echo "Releasing v$VERSION"
+```
+
+Then tag from `origin/main`, never from a local branch:
+
+```bash
 git fetch origin
 git checkout origin/main
-git tag -a v0.3.0-rc.1 -m "v0.3.0-rc.1 — first public crates.io wave"
-git push origin v0.3.0-rc.1
+git tag -a "v$VERSION" -m "v$VERSION"
+git push origin "v$VERSION"
 ```
 
 Pushing the tag triggers `.github/workflows/release.yml` → `publish-crates-io` job.
 
 ## During the train
 
-Expected wall-clock: **70–90 minutes.** Driven by the crates.io new-crate rate limit (5 burst, then 1 per 10 min). Topo order per the [manifest §"Topological publish order"](./release-v0.3.0-rc.1-manifest.md#topological-publish-order).
+Expected wall-clock depends heavily on whether this is a first-publish of any crate or a re-publish of existing versions:
+
+- **Re-publish of existing crates** (routine subsequent releases): typically well under 30 minutes; no new-crate rate limit, readiness polling is the dominant wait.
+- **First-publish of new crates**: budget ~10 minutes per new crate past the initial 5-crate burst. A wave that adds multiple brand-new crates can stretch past an hour. The runner timeout in `release.yml` is 180 minutes for this reason.
 
 ### What to monitor
 
-- **The workflow log** — watch for the `shipper publish` per-crate events.
-- **`.shipper/` artifact uploads** — there are three: `shipper-state-plan`, `shipper-state-preflight`, `shipper-state-final`. The plan artifact uploads before any publish happens, so even a catastrophic runner death preserves the plan.
-- **crates.io visibility** — after each publish, `shipper` runs readiness checks (sparse index + API). You can also hit `https://index.crates.io/<prefix>/<crate>` directly for a fresh-resolver view (see the manifest for the URL pattern).
+- **The workflow log** — watch for per-crate `shipper publish` events (`PackagePublishStarted`, `PackagePublished`, `PackageReadinessVerified`).
+- **`.shipper/` artifact uploads.** Three are uploaded by the workflow: `shipper-state-plan`, `shipper-state-preflight`, `shipper-state-final`. The plan artifact uploads before any publish happens, so even a catastrophic runner death preserves the plan.
+- **crates.io visibility.** After each publish, Shipper runs readiness checks (sparse index + API). You can also hit `https://index.crates.io/<prefix>/<crate>` directly for a fresh-resolver view of the sparse index.
 
 ### Stop conditions
 
 | Situation | Action |
 |---|---|
-| `Permanent` error (auth, version conflict, manifest) | **Stop.** Fix the cause, bump version, re-tag. Do NOT retry a permanent error. |
+| `Permanent` error (auth, version conflict, manifest) | **Stop.** Fix the cause, bump version, re-tag. Never retry a permanent error. |
 | `Retryable` error (429, transient network) | Let the engine retry — `--max-attempts 12`, `--max-delay 15m` is configured to ride out rate-limit windows. |
-| `Ambiguous` error (upload may have succeeded) | **Pause.** Query the sparse index and API directly for `<crate>@0.3.0-rc.1`. Only resume after out-of-band confirmation; see Resume below. |
+| `Ambiguous` error (upload may have succeeded) | **Let Shipper reconcile.** As of rc.2, the engine polls the registry on ambiguous and resolves to `Published` / `NotPublished` / `StillUnknown` without blind-retrying. `StillUnknown` halts for operator review — that's your stop signal, not a generic ambiguous. |
 | Runner dies / 180-min timeout | `.shipper/` artifact is still uploaded. Use Resume below. |
-| crates.io status page reports a new incident mid-train | Let the engine absorb 429s; only cancel the workflow if incidents are hitting the sparse index specifically. |
-| Any unexpected silence (no progress in >20 min, no events appended) | Check the runner's resource state. Don't cancel unless certain — a rate-limit sleep is expected. |
+| crates.io status page reports a new incident mid-train | Let the engine absorb 429s; only cancel the workflow if the incident is specifically hitting the sparse index. |
+| Unexpected silence (no progress in >20 min, no events appended) | Check runner resource state. Don't cancel unless certain — a rate-limit sleep is expected between new-crate publishes. |
 
 ### Do NOT
 
 - Run `cargo publish` manually on any crate in the plan mid-train. Trust the state file.
-- Kill the workflow to "try again fresh" without first reading `.shipper/state.json` to understand what completed.
-- Merge any PR to `main` while the train is live — it invalidates the plan ID.
+- Kill the workflow to "try again fresh" without first reading `.shipper/state.json` (or `events.jsonl`) to understand what completed.
+- Merge any PR to `main` while the train is live — it invalidates the plan ID and prevents resume.
 
 ## Resume
 
@@ -75,37 +93,44 @@ gh run list --workflow=release.yml --limit=5
 
 # Dispatch resume against that run's uploaded .shipper/ artifact
 gh workflow run release.yml \
-  --ref main \
+  --ref "v$VERSION" \
   --field mode=resume \
   --field artifact_run_id=<prior-run-id>
 ```
 
-The `resume` path downloads the prior `shipper-state-final` artifact into `.shipper/` and runs `shipper resume`. Plan-ID validation will abort if the workspace has changed since the original run — don't try to "fix and resume," cut a new RC instead.
+The `resume` path downloads the prior `shipper-state-final` artifact into `.shipper/` and runs `shipper resume`. Plan-ID validation aborts if the workspace has changed since the original run — don't try to "fix and resume." Cut a new RC instead.
 
 ## Post-train verification
 
-Only finalize the GitHub Release after **all 12 crates are visible on crates.io** from a fresh resolver:
+Only finalize the GitHub Release after **every crate in the plan is visible on crates.io from a fresh resolver**:
 
-1. Workflow log shows `shipper publish` completed successfully.
-2. Every crate returns a 200 from `https://crates.io/api/v1/crates/<crate>`.
-3. `cargo search shipper-cli` (no path override) returns `0.3.0-rc.1`.
-4. At least one smoke install: `cargo install shipper --version 0.3.0-rc.1 --locked` from a scratch directory. (`cargo install shipper-cli --version 0.3.0-rc.1 --locked` also works — same code path, the adapter crate installed directly.)
-5. The `shipper-state-final` artifact is downloaded and archived (90-day retention by default; take a local copy for the permanent record).
+1. Workflow log shows `shipper publish` completed successfully, all `PackageReadinessVerified` events emitted.
+2. Every crate returns 200 from `https://crates.io/api/v1/crates/<crate>`.
+3. `cargo search shipper` (no path override, clean cache) returns the new version. Repeat for `shipper-cli` and `shipper-core` — these are the three user-facing crate names.
+4. At least one smoke install from a scratch directory:
+   ```bash
+   cargo install shipper --version "$VERSION" --locked
+   shipper --version
+   ```
+   (`cargo install shipper-cli --version "$VERSION" --locked` also works — same code path, installs the adapter binary directly.)
+5. The `shipper-state-final` artifact is downloaded and archived. GitHub retains it for 90 days; take a local copy for the permanent record — it's the events-as-truth evidence for that release.
 
-Only then do the per-platform binary artifacts get attached to the GitHub Release. The release note should reference the `shipper-state-final` tarball as publish evidence.
+Only then do the per-platform binary artifacts get attached to the GitHub Release. The release note should reference the `shipper-release-state.tar.gz` bundle as publish evidence.
 
 ## If you need to walk it back
 
 Cargo's containment primitive is `cargo yank`. Yanking does NOT remove the published artifact; it only removes the version from future resolution. Existing `Cargo.lock` files continue to resolve yanked versions. Treat yank as containment, not undo.
 
-Automated receipt-to-yank is a planned feature (remediation milestone, not yet implemented). Until then, yank manually in reverse topological order:
+As of rc.2, Shipper has receipt-driven containment via `shipper plan-yank` and `shipper yank` (see [#98](https://github.com/EffortlessMetrics/shipper/issues/98)). Prefer those over manual `cargo yank` — they read the receipt, generate a reverse-topological plan, and emit `PackageYanked` events to the ledger.
 
 ```bash
-cargo yank --vers 0.3.0-rc.1 shipper-cli
-cargo yank --vers 0.3.0-rc.1 shipper
-cargo yank --vers 0.3.0-rc.1 shipper-config shipper-registry
-cargo yank --vers 0.3.0-rc.1 shipper-types
-cargo yank --vers 0.3.0-rc.1 shipper-cargo-failure shipper-duration shipper-encrypt shipper-output-sanitizer shipper-retry shipper-sparse-index shipper-webhook
+# Generate a containment plan from the release's receipt
+shipper plan-yank --state-dir .shipper --output yank-plan.json
+
+# Execute it
+shipper yank --plan yank-plan.json
 ```
 
-Fix-forward (bump the affected crate to `0.3.0-rc.2` and re-release just that slice) is almost always preferable to a full yank cascade.
+Manual fallback, if you don't have the receipt handy, is reverse topological order — install face first, then adapter, then core, then tiers 3 → 2 → 1. `cargo yank --vers "$VERSION" <crate>` per crate.
+
+**Fix-forward** (bump the affected crate to the next patch/rc and re-release just that slice) is almost always preferable to a full yank cascade. `shipper fix-forward --mark-compromised <crate>@<version>` plans the minimal repair; the receipt schema records `compromised_at`, `compromised_by`, `superseded_by` so the history survives.


### PR DESCRIPTION
## Summary

Rewrites the four user-facing READMEs so each has **one job** instead of trying to be product pitch + status bulletin + reference + architecture all at once. Extends the same alignment pass to two steering docs.

## Files rewritten (6)

### READMEs — four-file family with one job each

| File | Job |
|---|---|
| `README.md` | **ROUTE** — problem, one quick-start, boundary, links into Diátaxis docs |
| `crates/shipper/README.md` | **INSTALL FACE** — what crates.io viewers see for the install target |
| `crates/shipper-core/README.md` | **SDK PAGE** — when to embed, what lives here, minimal code sketch |
| `crates/shipper-cli/README.md` | **ADAPTER PAGE** — shortest; tells readers to install `shipper` first |

### Steering docs — aligned with the new READMEs

| File | Change |
|---|---|
| `docs/product.md` | Dropped stale `What's shipped (v0.3.0-rc.1)` table; added three-crate Product Shape; reworked nine-competency section as present capabilities (not a scorecard); expanded alternatives table for Cargo 1.90+ |
| `docs/release-runbook.md` | Dropped `rc.1 baseline` framing and hardcoded tag commands; replaced with `VERSION=$(cargo metadata…)` pattern; 13-crate tier structure with the three-crate split; auth section reframed as "token fallback primary today / Trusted Publishing target path" matching PR #150's actual landing |

## What got cut (from all six files)

- Dated release-history prose (`v0.3.0-rc.1 shipped 2026-04-16…`)
- Runtime metrics (`41 retries`, `69-minute run`, `12 crates live`)
- Audience matrix on the root
- Full command catalogs
- Long architecture walkthroughs
- Config/auth/CI deep reference (those live in their own docs)
- `shipper-cli` as "compatibility shim" wording — it's the real adapter

## What got added / grew

- `shipper-core` README went 25 → 65 lines (it was too thin — now a proper embedder onboarding with when/what/what-not/minimal sketch).
- `docs/release-runbook.md` now re-runnable for rc.3, 0.3.0 stable, 0.4.0 etc. without edits — `VERSION` pulled from `Cargo.toml` at release time.

## Numbers

- READMEs: 497 → 219 lines (≈56% reduction) across the four files.
- Intentional single version-pinned link preserved (`release-v0.3.0-rc.1-manifest.md` kept as a historical artifact, reframed as such in the runbook prose).

## Test plan

- [x] `cargo check --workspace` clean
- [x] `grep -rn "compatibility shim"` in the rewritten files → no hits
- [x] `grep -rn "v0.3.0-rc.1 shipped"` in the rewritten files → no hits
- [x] Cross-references between READMEs and steering docs all resolve to correct crates/paths
- [x] `release-runbook.md` tag-cut commands use `VERSION=` pattern, not hardcoded

## Still out of scope (future cleanup)

- `docs/reference/state-files.md` — example snippets use `0.3.0-rc.1`. Purely illustrative; not blocking.
- `docs/decrating-plan.md` — version strings in an illustrative example block from the rc.1 era. Historical plan doc.
- `docs/explanation/finishability.md` / `docs/INVARIANTS.md` — intentionally reference rc.1 as a specific historical incident (appropriate to pin).