### PR TITLE
feat(preflight): --preflight-only flag (#100)

### DIFF
--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -26,7 +26,7 @@
 //! [`run`]. For programmatic use without a `clap` dependency, depend
 //! on [`shipper_core`](https://crates.io/crates/shipper-core) instead.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
@@ -306,19 +306,15 @@ EXAMPLES:
     shipper preflight --format json
 ")]
     Preflight {
-        /// Re-run preflight with a fresh filesystem audit (no cached state).
+        /// Run preflight as a standalone audit.
         ///
-        /// When set, Shipper performs an isolated finishability assessment:
-        ///   - Does NOT read a prior `events.jsonl` into memory.
-        ///   - Does NOT append to the existing `events.jsonl`; instead,
-        ///     writes its events to a session-scoped sidecar
-        ///     (`preflight-only.events.jsonl`) under `state_dir`.
-        ///   - Never writes publish state (`state.json`).
-        ///
-        /// Useful for operators who want a fresh Proven/NotProven/Failed
-        /// signal against the current workspace, independent of any
-        /// prior publish or resume state. Part of
-         /// [#100 Prove](https://github.com/EffortlessMetrics/shipper/issues/100).
+        /// Writes events to a session-scoped
+        /// `preflight-only-<session>.events.jsonl` sidecar under `state_dir`,
+        /// does not append to the authoritative `events.jsonl`, and never
+        /// writes publish state (`state.json`). Use this when you want a fresh
+        /// Proven/NotProven/Failed signal without mutating resumable publish
+        /// state. Part of
+        /// [#100 Prove](https://github.com/EffortlessMetrics/shipper/issues/100).
         #[arg(long = "preflight-only")]
         preflight_only: bool,
     },
@@ -370,9 +366,9 @@ EXAMPLES:
     /// Print CI configuration snippets for various platforms.
     #[command(subcommand)]
     Ci(CiCommands),
-    /// Clean state files (state.json, receipt.json, events.jsonl).
+    /// Clean state files (state.json, receipt.json, events.jsonl, preflight-only-*.events.jsonl).
     Clean {
-        /// Keep receipt.json (only remove state.json and events.jsonl)
+        /// Keep receipt.json (remove state.json and all event logs only)
         #[arg(long)]
         keep_receipt: bool,
     },
@@ -1863,19 +1859,47 @@ fn run_inspect_events(ws: &plan::PlannedWorkspace, opts: &RuntimeOptions) -> Res
         ws.workspace_root.join(&opts.state_dir)
     };
 
-    let events_path = shipper_core::state::events::events_path(&state_dir);
-    let event_log = shipper_core::state::events::EventLog::read_from_file(&events_path)
-        .with_context(|| format!("failed to read event log from {}", events_path.display()))?;
+    let event_logs = discover_event_logs(&state_dir)?;
+    if event_logs.is_empty() {
+        println!("No event logs found under {}", state_dir.display());
+        return Ok(());
+    }
 
-    println!("Event log: {}", events_path.display());
-    println!();
+    for (idx, events_path) in event_logs.iter().enumerate() {
+        let event_log = shipper_core::state::events::EventLog::read_from_file(events_path)
+            .with_context(|| format!("failed to read event log from {}", events_path.display()))?;
 
-    for event in event_log.all_events() {
-        let json = serde_json::to_string(event).expect("serialize event");
-        println!("{}", json);
+        println!("Event log: {}", events_path.display());
+        println!();
+
+        for event in event_log.all_events() {
+            let json = serde_json::to_string(event).expect("serialize event");
+            println!("{}", json);
+        }
+
+        if idx + 1 != event_logs.len() {
+            println!();
+        }
     }
 
     Ok(())
+}
+
+fn discover_event_logs(state_dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    let authoritative = shipper_core::state::events::events_path(state_dir);
+    if authoritative.exists() {
+        paths.push(authoritative);
+    }
+
+    let mut seen = BTreeSet::new();
+    for path in shipper_core::state::events::preflight_only_events_paths(state_dir)? {
+        if seen.insert(path.clone()) {
+            paths.push(path);
+        }
+    }
+
+    Ok(paths)
 }
 
 fn run_inspect_receipt(
@@ -2306,7 +2330,6 @@ fn clean_single_dir(
 ) -> Result<()> {
     let state_path = dir.join(shipper_core::state::execution_state::STATE_FILE);
     let receipt_path = dir.join(shipper_core::state::execution_state::RECEIPT_FILE);
-    let events_path = dir.join(shipper_core::state::events::EVENTS_FILE);
     let lock_path = shipper_core::lock::lock_path(dir, Some(workspace_root));
 
     // Check for active lock
@@ -2346,11 +2369,14 @@ fn clean_single_dir(
         println!("Removed: {}", state_path.display());
     }
 
-    // Remove events file
-    if events_path.exists() {
-        std::fs::remove_file(&events_path)
-            .with_context(|| format!("failed to remove events file {}", events_path.display()))?;
-        println!("Removed: {}", events_path.display());
+    // Remove event logs (authoritative + preflight-only sidecars)
+    for events_path in discover_event_logs(dir)? {
+        if events_path.exists() {
+            std::fs::remove_file(&events_path).with_context(|| {
+                format!("failed to remove events file {}", events_path.display())
+            })?;
+            println!("Removed: {}", events_path.display());
+        }
     }
 
     // Optionally remove receipt file
@@ -3108,11 +3134,14 @@ mode = "fast"
         let state_path = abs_state.join(shipper_core::state::execution_state::STATE_FILE);
         let receipt_path = abs_state.join(shipper_core::state::execution_state::RECEIPT_FILE);
         let events_path = abs_state.join(shipper_core::state::events::EVENTS_FILE);
+        let preflight_only_events_path =
+            abs_state.join("preflight-only-20260421T010101000000000Z-pid123.events.jsonl");
         let lock_path = shipper_core::lock::lock_path(&abs_state, Some(td.path()));
 
         fs::write(&state_path, "{}").expect("write state");
         fs::write(&receipt_path, "{}").expect("write receipt");
         fs::write(&events_path, "{}").expect("write events");
+        fs::write(&preflight_only_events_path, "{}").expect("write preflight-only events");
 
         let lock_info = shipper_core::lock::LockInfo {
             pid: 12345,
@@ -3131,6 +3160,23 @@ mode = "fast"
         assert!(!state_path.exists(), "state file should be removed");
         assert!(!receipt_path.exists(), "receipt file should be removed");
         assert!(!events_path.exists(), "events file should be removed");
+        assert!(
+            !preflight_only_events_path.exists(),
+            "preflight-only sidecar should be removed"
+        );
         assert!(!lock_path.exists(), "lock file should be removed");
+    }
+
+    #[test]
+    fn discover_event_logs_includes_preflight_only_sidecars() {
+        let td = tempdir().expect("tempdir");
+        let state_dir = td.path().join(".shipper");
+        fs::create_dir_all(&state_dir).expect("mkdir");
+
+        let sidecar = state_dir.join("preflight-only-20260421T010101000000000Z-pid1.events.jsonl");
+        fs::write(&sidecar, "{}").expect("write sidecar");
+
+        let discovered = discover_event_logs(&state_dir).expect("discover event logs");
+        assert_eq!(discovered, vec![sidecar]);
     }
 }

--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -305,7 +305,23 @@ EXAMPLES:
     # Machine-readable output for CI gates:
     shipper preflight --format json
 ")]
-    Preflight,
+    Preflight {
+        /// Re-run preflight with a fresh filesystem audit (no cached state).
+        ///
+        /// When set, Shipper performs an isolated finishability assessment:
+        ///   - Does NOT read a prior `events.jsonl` into memory.
+        ///   - Does NOT append to the existing `events.jsonl`; instead,
+        ///     writes its events to a session-scoped sidecar
+        ///     (`preflight-only.events.jsonl`) under `state_dir`.
+        ///   - Never writes publish state (`state.json`).
+        ///
+        /// Useful for operators who want a fresh Proven/NotProven/Failed
+        /// signal against the current workspace, independent of any
+        /// prior publish or resume state. Part of
+         /// [#100 Prove](https://github.com/EffortlessMetrics/shipper/issues/100).
+        #[arg(long = "preflight-only")]
+        preflight_only: bool,
+    },
     /// Execute the plan (will resume if a matching state file exists).
     #[command(long_about = "\
 Execute the publish plan end-to-end, persisting resumable state after
@@ -781,9 +797,16 @@ pub fn run() -> Result<()> {
         Commands::Plan => {
             print_plan(&planned, cli.verbose);
         }
-        Commands::Preflight => {
-            let rep = engine::run_preflight_in_place(&mut planned, &opts, &mut reporter)
-                .with_context(|| preflight_failure_hint(&opts.state_dir))?;
+        Commands::Preflight { preflight_only } => {
+            let rep = engine::run_preflight_in_place_with_options(
+                &mut planned,
+                &opts,
+                &mut reporter,
+                engine::PreflightRunOptions {
+                    fresh_audit: preflight_only,
+                },
+            )
+            .with_context(|| preflight_failure_hint(&opts.state_dir))?;
             print_preflight(&rep, &cli.format);
         }
         Commands::Publish => {
@@ -2442,12 +2465,49 @@ mod tests {
         ])
         .expect("parse CLI");
 
-        assert!(matches!(cli.cmd, Some(Commands::Preflight)));
+        assert!(matches!(
+            cli.cmd,
+            Some(Commands::Preflight {
+                preflight_only: false
+            })
+        ));
         assert!(cli.allow_dirty);
         assert!(cli.strict_ownership);
         assert_eq!(cli.verify_mode.as_deref(), Some("package"));
         assert_eq!(cli.policy.as_deref(), Some("safe"));
         assert_eq!(cli.format, "json");
+    }
+
+    // #100 — `--preflight-only` on `shipper preflight` must parse into a
+    // `fresh_audit=true` signal. This test pins the clap surface: the
+    // flag is exposed on the preflight subcommand (and defaults to
+    // `false` on all invocations), and the flag name is scoped to that
+    // subcommand only — clap must reject it on unrelated subcommands.
+    #[test]
+    fn preflight_only_flag_parses_and_defaults_to_false() {
+        // Explicit: flag present.
+        let cli = Cli::try_parse_from(["shipper", "preflight", "--preflight-only"])
+            .expect("parse with flag");
+        match cli.cmd {
+            Commands::Preflight { preflight_only } => assert!(preflight_only),
+            other => panic!("expected Preflight, got {other:?}"),
+        }
+
+        // Default: flag absent → false.
+        let cli = Cli::try_parse_from(["shipper", "preflight"]).expect("parse without flag");
+        match cli.cmd {
+            Commands::Preflight { preflight_only } => {
+                assert!(
+                    !preflight_only,
+                    "preflight_only must default to false for back-compat"
+                );
+            }
+            other => panic!("expected Preflight, got {other:?}"),
+        }
+
+        // Flag is scoped to `preflight`: unknown on other subcommands.
+        Cli::try_parse_from(["shipper", "publish", "--preflight-only"])
+            .expect_err("must reject --preflight-only on publish");
     }
 
     #[test]

--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -2515,14 +2515,14 @@ mod tests {
         let cli = Cli::try_parse_from(["shipper", "preflight", "--preflight-only"])
             .expect("parse with flag");
         match cli.cmd {
-            Commands::Preflight { preflight_only } => assert!(preflight_only),
+            Some(Commands::Preflight { preflight_only }) => assert!(preflight_only),
             other => panic!("expected Preflight, got {other:?}"),
         }
 
         // Default: flag absent → false.
         let cli = Cli::try_parse_from(["shipper", "preflight"]).expect("parse without flag");
         match cli.cmd {
-            Commands::Preflight { preflight_only } => {
+            Some(Commands::Preflight { preflight_only }) => {
                 assert!(
                     !preflight_only,
                     "preflight_only must default to false for back-compat"

--- a/crates/shipper-cli/tests/bdd_workflow.rs
+++ b/crates/shipper-cli/tests/bdd_workflow.rs
@@ -2849,12 +2849,12 @@ max_concurrent = 1
 mod inspect_events_without_events_file {
     use super::*;
 
-    // Scenario: inspect-events with no events file shows empty log path
+    // Scenario: inspect-events with no events file reports no event logs
     //
     // Given: a workspace with "demo" and no events.jsonl in the state directory
     // When: I run "shipper inspect-events"
     // Then: exit code is 0 (empty event log is valid)
-    // And: output contains "Event log:" header
+    // And: output reports that no event logs were found
     #[test]
     fn given_no_events_file_when_inspect_events_then_shows_empty_log() {
         let td = tempdir().expect("tempdir");
@@ -2870,7 +2870,7 @@ mod inspect_events_without_events_file {
             .arg("inspect-events")
             .assert()
             .success()
-            .stdout(contains("Event log:"));
+            .stdout(contains("No event logs found under"));
     }
 }
 

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__clean_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__clean_help.snap
@@ -2,13 +2,13 @@
 source: crates/shipper-cli/tests/cli_snapshots.rs
 expression: normalize_help_output(&stdout)
 ---
-Clean state files (state.json, receipt.json, events.jsonl)
+Clean state files (state.json, receipt.json, events.jsonl, preflight-only-*.events.jsonl)
 
 Usage: shipper-cli clean [OPTIONS]
 
 Options:
       --keep-receipt
-          Keep receipt.json (only remove state.json and events.jsonl)
+          Keep receipt.json (remove state.json and all event logs only)
 
   -V, --version
           Print version information. Combine with `--verbose` for commit, build-profile, and rustc metadata

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__help_text.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__help_text.snap
@@ -17,7 +17,7 @@ Commands:
   inspect-events   View detailed event log
   inspect-receipt  View detailed receipt with evidence
   ci               Print CI configuration snippets for various platforms
-  clean            Clean state files (state.json, receipt.json, events.jsonl)
+  clean            Clean state files (state.json, receipt.json, events.jsonl, preflight-only-*.events.jsonl)
   yank             Yank a crate@version from the registry — containment, not undo
   plan-yank        Generate a reverse-topological yank plan from a receipt (#98 PR 2)
   fix-forward      Generate a fix-forward supersession plan from a compromised receipt (#98 PR 3)

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__preflight_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__preflight_help.snap
@@ -21,16 +21,16 @@ EXAMPLES:
 Usage: shipper-cli preflight [OPTIONS]
 
 Options:
+      --preflight-only
+          Run preflight as a standalone audit.
+          
+          Writes events to a session-scoped `preflight-only-<session>.events.jsonl` sidecar under `state_dir`, does not append to the authoritative `events.jsonl`, and never writes publish state (`state.json`). Use this when you want a fresh Proven/NotProven/Failed signal without mutating resumable publish state. Part of [#100 Prove](https://github.com/EffortlessMetrics/shipper/issues/100).
+
   -V, --version
           Print version information. Combine with `--verbose` for commit, build-profile, and rustc metadata
 
       --config <CONFIG>
           Path to a custom configuration file (.shipper.toml)
-
-      --preflight-only
-          Run preflight as a standalone audit.
-          
-          Writes events to a session-scoped `preflight-only-<session>.events.jsonl` sidecar under `state_dir`, does not append to the authoritative `events.jsonl`, and never writes publish state (`state.json`). Use this when you want a fresh Proven/NotProven/Failed signal without mutating resumable publish state.
 
       --manifest-path <MANIFEST_PATH>
           Path to the workspace Cargo.toml

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__preflight_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__preflight_help.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/shipper-cli/tests/cli_snapshots.rs
-assertion_line: 71
 expression: normalize_help_output(&stdout)
 ---
 Run preflight checks without publishing.
@@ -29,11 +28,9 @@ Options:
           Path to a custom configuration file (.shipper.toml)
 
       --preflight-only
-          Re-run preflight with a fresh filesystem audit (no cached state).
+          Run preflight as a standalone audit.
           
-          When set, Shipper performs an isolated finishability assessment: - Does NOT read a prior `events.jsonl` into memory. - Does NOT append to the existing `events.jsonl`; instead, writes its events to a session-scoped sidecar (`preflight-only.events.jsonl`) under `state_dir`. - Never writes publish state (`state.json`).
-          
-          Useful for operators who want a fresh Proven/NotProven/Failed signal against the current workspace, independent of any prior publish or resume state. Part of [#100 Prove](https://github.com/EffortlessMetrics/shipper/issues/100).
+          Writes events to a session-scoped `preflight-only-<session>.events.jsonl` sidecar under `state_dir`, does not append to the authoritative `events.jsonl`, and never writes publish state (`state.json`). Use this when you want a fresh Proven/NotProven/Failed signal without mutating resumable publish state.
 
       --manifest-path <MANIFEST_PATH>
           Path to the workspace Cargo.toml

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__preflight_help.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__preflight_help.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shipper-cli/tests/cli_snapshots.rs
+assertion_line: 71
 expression: normalize_help_output(&stdout)
 ---
 Run preflight checks without publishing.
@@ -26,6 +27,13 @@ Options:
 
       --config <CONFIG>
           Path to a custom configuration file (.shipper.toml)
+
+      --preflight-only
+          Re-run preflight with a fresh filesystem audit (no cached state).
+          
+          When set, Shipper performs an isolated finishability assessment: - Does NOT read a prior `events.jsonl` into memory. - Does NOT append to the existing `events.jsonl`; instead, writes its events to a session-scoped sidecar (`preflight-only.events.jsonl`) under `state_dir`. - Never writes publish state (`state.json`).
+          
+          Useful for operators who want a fresh Proven/NotProven/Failed signal against the current workspace, independent of any prior publish or resume state. Part of [#100 Prove](https://github.com/EffortlessMetrics/shipper/issues/100).
 
       --manifest-path <MANIFEST_PATH>
           Path to the workspace Cargo.toml

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_clean.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_clean.snap
@@ -2,13 +2,13 @@
 source: crates/shipper-cli/tests/e2e_expanded.rs
 expression: normalize_stderr(&stdout)
 ---
-Clean state files (state.json, receipt.json, events.jsonl)
+Clean state files (state.json, receipt.json, events.jsonl, preflight-only-*.events.jsonl)
 
 Usage: shipper-cli clean [OPTIONS]
 
 Options:
       --keep-receipt
-          Keep receipt.json (only remove state.json and events.jsonl)
+          Keep receipt.json (remove state.json and all event logs only)
 
   -V, --version
           Print version information. Combine with `--verbose` for commit, build-profile, and rustc metadata

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_preflight.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_preflight.snap
@@ -21,16 +21,16 @@ EXAMPLES:
 Usage: shipper-cli preflight [OPTIONS]
 
 Options:
+      --preflight-only
+          Run preflight as a standalone audit.
+          
+          Writes events to a session-scoped `preflight-only-<session>.events.jsonl` sidecar under `state_dir`, does not append to the authoritative `events.jsonl`, and never writes publish state (`state.json`). Use this when you want a fresh Proven/NotProven/Failed signal without mutating resumable publish state. Part of [#100 Prove](https://github.com/EffortlessMetrics/shipper/issues/100).
+
   -V, --version
           Print version information. Combine with `--verbose` for commit, build-profile, and rustc metadata
 
       --config <CONFIG>
           Path to a custom configuration file (.shipper.toml)
-
-      --preflight-only
-          Run preflight as a standalone audit.
-          
-          Writes events to a session-scoped `preflight-only-<session>.events.jsonl` sidecar under `state_dir`, does not append to the authoritative `events.jsonl`, and never writes publish state (`state.json`). Use this when you want a fresh Proven/NotProven/Failed signal without mutating resumable publish state.
 
       --manifest-path <MANIFEST_PATH>
           Path to the workspace Cargo.toml

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_preflight.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_preflight.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shipper-cli/tests/e2e_expanded.rs
+assertion_line: 2496
 expression: normalize_stderr(&stdout)
 ---
 Run preflight checks without publishing.
@@ -26,6 +27,13 @@ Options:
 
       --config <CONFIG>
           Path to a custom configuration file (.shipper.toml)
+
+      --preflight-only
+          Re-run preflight with a fresh filesystem audit (no cached state).
+          
+          When set, Shipper performs an isolated finishability assessment: - Does NOT read a prior `events.jsonl` into memory. - Does NOT append to the existing `events.jsonl`; instead, writes its events to a session-scoped sidecar (`preflight-only.events.jsonl`) under `state_dir`. - Never writes publish state (`state.json`).
+          
+          Useful for operators who want a fresh Proven/NotProven/Failed signal against the current workspace, independent of any prior publish or resume state. Part of [#100 Prove](https://github.com/EffortlessMetrics/shipper/issues/100).
 
       --manifest-path <MANIFEST_PATH>
           Path to the workspace Cargo.toml

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_preflight.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_preflight.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/shipper-cli/tests/e2e_expanded.rs
-assertion_line: 2496
 expression: normalize_stderr(&stdout)
 ---
 Run preflight checks without publishing.
@@ -29,11 +28,9 @@ Options:
           Path to a custom configuration file (.shipper.toml)
 
       --preflight-only
-          Re-run preflight with a fresh filesystem audit (no cached state).
+          Run preflight as a standalone audit.
           
-          When set, Shipper performs an isolated finishability assessment: - Does NOT read a prior `events.jsonl` into memory. - Does NOT append to the existing `events.jsonl`; instead, writes its events to a session-scoped sidecar (`preflight-only.events.jsonl`) under `state_dir`. - Never writes publish state (`state.json`).
-          
-          Useful for operators who want a fresh Proven/NotProven/Failed signal against the current workspace, independent of any prior publish or resume state. Part of [#100 Prove](https://github.com/EffortlessMetrics/shipper/issues/100).
+          Writes events to a session-scoped `preflight-only-<session>.events.jsonl` sidecar under `state_dir`, does not append to the authoritative `events.jsonl`, and never writes publish state (`state.json`). Use this when you want a fresh Proven/NotProven/Failed signal without mutating resumable publish state.
 
       --manifest-path <MANIFEST_PATH>
           Path to the workspace Cargo.toml

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_root.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_root.snap
@@ -17,7 +17,7 @@ Commands:
   inspect-events   View detailed event log
   inspect-receipt  View detailed receipt with evidence
   ci               Print CI configuration snippets for various platforms
-  clean            Clean state files (state.json, receipt.json, events.jsonl)
+  clean            Clean state files (state.json, receipt.json, events.jsonl, preflight-only-*.events.jsonl)
   yank             Yank a crate@version from the registry — containment, not undo
   plan-yank        Generate a reverse-topological yank plan from a receipt (#98 PR 2)
   fix-forward      Generate a fix-forward supersession plan from a compromised receipt (#98 PR 3)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__inspect_events_empty.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__inspect_events_empty.snap
@@ -2,4 +2,4 @@
 source: crates/shipper-cli/tests/e2e_expanded.rs
 expression: normalize_output(&stdout)
 ---
-Event log: <STATE_DIR>/events.jsonl
+No event logs found under <STATE_DIR>

--- a/crates/shipper-core/src/engine/mod.rs
+++ b/crates/shipper-core/src/engine/mod.rs
@@ -109,13 +109,43 @@ fn init_registry_client(registry: Registry, state_dir: &Path) -> Result<Registry
 /// let report = engine::run_preflight(&ws, &opts, &mut reporter)?;
 /// println!("Finishability: {:?}", report.finishability);
 /// ```
+/// Run-time options that only affect preflight behavior (#100).
+///
+/// Kept separate from [`RuntimeOptions`] so that CLI-level "just this
+/// invocation" toggles (e.g. `--preflight-only`) don't need to thread
+/// through every other engine entry point. A `Default` instance
+/// preserves historical behavior: reads and appends the authoritative
+/// `events.jsonl` log.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PreflightRunOptions {
+    /// If `true`, the preflight run is session-isolated (#100 /
+    /// `shipper preflight --preflight-only`):
+    ///
+    /// - Does not touch the authoritative `events.jsonl` log; writes
+    ///   its events to a sidecar at
+    ///   `<state_dir>/preflight-only.events.jsonl` that is truncated
+    ///   on first write and appended to for the remainder of the run.
+    /// - Does not load or inspect any prior `events.jsonl`; the
+    ///   resulting `Finishability` is a fresh read of the current
+    ///   workspace + registry, independent of any accumulated publish
+    ///   or resume state.
+    /// - Never writes `state.json`.
+    ///
+    /// `false` (the default) preserves the original behavior: the
+    /// authoritative append-only `events.jsonl` is extended.
+    pub fresh_audit: bool,
+}
+
+/// Back-compat entry point preserving the historical preflight shape
+/// (appends to `events.jsonl`). Equivalent to
+/// `run_preflight_with_options(ws, opts, reporter, Default::default())`.
 pub fn run_preflight(
     ws: &PlannedWorkspace,
     opts: &RuntimeOptions,
     reporter: &mut dyn Reporter,
 ) -> Result<PreflightReport> {
     let mut ws = ws.clone();
-    run_preflight_in_place(&mut ws, opts, reporter)
+    run_preflight_in_place_with_options(&mut ws, opts, reporter, PreflightRunOptions::default())
 }
 
 /// Run preflight checks for a planned workspace and stamp regime metadata.
@@ -130,10 +160,59 @@ pub fn run_preflight_in_place(
     opts: &RuntimeOptions,
     reporter: &mut dyn Reporter,
 ) -> Result<PreflightReport> {
+    run_preflight_in_place_with_options(ws, opts, reporter, PreflightRunOptions::default())
+}
+
+/// Run preflight with caller-chosen [`PreflightRunOptions`] (#100).
+///
+/// See [`run_preflight`] for the full pipeline description; this entry
+/// point additionally honors the `fresh_audit` flag, which redirects
+/// event writes to a session-scoped sidecar (see
+/// [`PreflightRunOptions::fresh_audit`] for details).
+pub fn run_preflight_with_options(
+    ws: &PlannedWorkspace,
+    opts: &RuntimeOptions,
+    reporter: &mut dyn Reporter,
+    run_opts: PreflightRunOptions,
+) -> Result<PreflightReport> {
+    let mut ws = ws.clone();
+    run_preflight_in_place_with_options(&mut ws, opts, reporter, run_opts)
+}
+
+/// Run preflight checks for a planned workspace and stamp regime metadata,
+/// with caller-chosen [`PreflightRunOptions`] (#100 + #106).
+pub fn run_preflight_in_place_with_options(
+    ws: &mut PlannedWorkspace,
+    opts: &RuntimeOptions,
+    reporter: &mut dyn Reporter,
+    run_opts: PreflightRunOptions,
+) -> Result<PreflightReport> {
     let workspace_root = &ws.workspace_root;
     let effects = policy_effects(opts);
     let state_dir = resolve_state_dir(workspace_root, &opts.state_dir);
-    let events_path = events::events_path(&state_dir);
+
+    // Resolve the event sink. In `fresh_audit` mode we never touch the
+    // authoritative `events.jsonl`; events land in a session-isolated
+    // sidecar instead. See `PreflightRunOptions::fresh_audit`.
+    let events_path = if run_opts.fresh_audit {
+        events::preflight_only_events_path(&state_dir)
+    } else {
+        events::events_path(&state_dir)
+    };
+
+    // Track whether this run has performed its first flush to the sidecar
+    // so `fresh_audit` truncates exactly once (initial write) and appends
+    // afterward, producing a single session's JSONL trace.
+    let mut fresh_audit_first_flush = run_opts.fresh_audit;
+    let mut flush_events = |log: &events::EventLog, path: &Path| -> Result<()> {
+        if fresh_audit_first_flush {
+            fresh_audit_first_flush = false;
+            log.write_to_file_truncating(path)
+        } else {
+            log.write_to_file(path)
+        }
+    };
+
     let mut event_log = events::EventLog::new();
 
     event_log.record(PublishEvent {
@@ -141,7 +220,7 @@ pub fn run_preflight_in_place(
         event_type: EventType::PreflightStarted,
         package: "all".to_string(),
     });
-    event_log.write_to_file(&events_path)?;
+    flush_events(&event_log, &events_path)?;
     event_log.clear();
 
     if !opts.allow_dirty {
@@ -164,7 +243,7 @@ pub fn run_preflight_in_place(
             },
             package: "all".to_string(),
         });
-        event_log.write_to_file(&events_path)?;
+        flush_events(&event_log, &events_path)?;
         bail!(
             "strict ownership requested but no token found (set CARGO_REGISTRY_TOKEN or run cargo login)"
         );
@@ -405,7 +484,7 @@ pub fn run_preflight_in_place(
         },
         package: "all".to_string(),
     });
-    event_log.write_to_file(&events_path)?;
+    flush_events(&event_log, &events_path)?;
 
     Ok(PreflightReport {
         plan_id: ws.plan.plan_id.clone(),
@@ -2789,6 +2868,239 @@ mod tests {
                     .any(|e| matches!(e.event_type, EventType::PreflightComplete { .. }))
             );
             server.join();
+        });
+    }
+
+    // #100 — fresh-audit mode must not read or append the authoritative
+    // `events.jsonl`. We seed a pre-existing `events.jsonl` with a bogus
+    // event that would fail deserialization, run preflight in
+    // `fresh_audit` mode, and assert: (a) the authoritative log is
+    // byte-identical to the seed afterward, and (b) the preflight trace
+    // lands in the session-isolated sidecar instead.
+    #[test]
+    #[serial]
+    fn run_preflight_fresh_audit_ignores_prior_state() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        let mut env_vars = fake_program_env_vars(&bin);
+        env_vars.extend([("SHIPPER_CARGO_EXIT", Some("0".to_string()))]);
+        temp_env::with_vars(env_vars, || {
+            let server = spawn_registry_server(
+                std::collections::BTreeMap::from([
+                    (
+                        "/api/v1/crates/demo/0.1.0".to_string(),
+                        vec![(404, "{}".to_string())],
+                    ),
+                    (
+                        "/api/v1/crates/demo".to_string(),
+                        vec![(404, "{}".to_string())],
+                    ),
+                ]),
+                2,
+            );
+
+            let ws = planned_workspace(td.path(), server.base_url.clone());
+            let mut opts = default_opts(PathBuf::from(".shipper"));
+            opts.allow_dirty = true;
+            opts.skip_ownership_check = true;
+
+            // Seed a sentinel `events.jsonl`. If fresh-audit touches it at
+            // all (read or append), we'll see drift after the run.
+            let authoritative_events = td.path().join(".shipper").join("events.jsonl");
+            std::fs::create_dir_all(authoritative_events.parent().unwrap()).expect("mkdir");
+            let sentinel = "{\"sentinel\":\"do not touch\"}\n";
+            std::fs::write(&authoritative_events, sentinel).expect("seed events");
+
+            // Seed a state.json too — fresh-audit must not produce or
+            // overwrite a publish state file as a side-effect.
+            let state_json = td.path().join(".shipper").join("state.json");
+            std::fs::write(&state_json, "{\"sentinel\":\"state\"}").expect("seed state");
+
+            let mut reporter = CollectingReporter::default();
+            let rep = super::run_preflight_with_options(
+                &ws,
+                &opts,
+                &mut reporter,
+                super::PreflightRunOptions { fresh_audit: true },
+            )
+            .expect("preflight");
+            assert_eq!(rep.packages.len(), 1);
+
+            // Authoritative events.jsonl is byte-identical to the seed.
+            let after = std::fs::read_to_string(&authoritative_events).expect("read events");
+            assert_eq!(
+                after, sentinel,
+                "fresh_audit must NOT append or rewrite events.jsonl"
+            );
+
+            // state.json untouched.
+            let state_after = std::fs::read_to_string(&state_json).expect("read state");
+            assert_eq!(
+                state_after, "{\"sentinel\":\"state\"}",
+                "fresh_audit must NOT write publish state"
+            );
+
+            // Sidecar carries the full preflight trace.
+            let sidecar = td
+                .path()
+                .join(".shipper")
+                .join("preflight-only.events.jsonl");
+            assert!(sidecar.exists(), "sidecar must be written");
+            let side_log =
+                crate::state::events::EventLog::read_from_file(&sidecar).expect("read sidecar");
+            let events = side_log.all_events();
+            assert!(
+                events
+                    .iter()
+                    .any(|e| matches!(e.event_type, EventType::PreflightStarted)),
+                "sidecar must contain PreflightStarted"
+            );
+            assert!(
+                events
+                    .iter()
+                    .any(|e| matches!(e.event_type, EventType::PreflightComplete { .. })),
+                "sidecar must contain PreflightComplete"
+            );
+
+            server.join();
+        });
+    }
+
+    // #100 — fresh-audit reflects *current* workspace state, not a
+    // cached prior result. We run preflight twice in fresh_audit mode:
+    // first against a registry that treats the crate as new (NotProven),
+    // then against the same workspace but with a server that returns
+    // 200 + owners — ownership verified, so Proven. If fresh_audit were
+    // cached/reused, the second run would incorrectly still report
+    // NotProven; it must reflect the changed registry reality.
+    //
+    // This also exercises the "prior events.jsonl NOT appended to"
+    // invariant under repeated runs: the authoritative log stays empty
+    // across both invocations.
+    #[test]
+    #[serial]
+    fn run_preflight_with_dirty_git_fresh_audit() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        let mut env_vars = fake_program_env_vars(&bin);
+        env_vars.extend([
+            ("SHIPPER_CARGO_EXIT", Some("0".to_string())),
+            (
+                "CARGO_HOME",
+                Some(td.path().to_str().expect("utf8").to_string()),
+            ),
+            ("CARGO_REGISTRY_TOKEN", Some("token-abc".to_string())),
+        ]);
+        temp_env::with_vars(env_vars, || {
+            // Run 1: new crate (404 on crate lookup) → NotProven (no
+            // ownership possible for new crates when strict=false and
+            // token present).
+            let server1 = spawn_registry_server(
+                std::collections::BTreeMap::from([
+                    (
+                        "/api/v1/crates/demo/0.1.0".to_string(),
+                        vec![(404, "{}".to_string())],
+                    ),
+                    (
+                        "/api/v1/crates/demo".to_string(),
+                        vec![(404, "{}".to_string())],
+                    ),
+                ]),
+                2,
+            );
+
+            let ws1 = planned_workspace(td.path(), server1.base_url.clone());
+            let mut opts = default_opts(PathBuf::from(".shipper"));
+            opts.allow_dirty = true;
+            opts.skip_ownership_check = false;
+            opts.strict_ownership = false;
+
+            let mut reporter = CollectingReporter::default();
+            let rep1 = super::run_preflight_with_options(
+                &ws1,
+                &opts,
+                &mut reporter,
+                super::PreflightRunOptions { fresh_audit: true },
+            )
+            .expect("preflight 1");
+            assert_eq!(rep1.finishability, Finishability::NotProven);
+            assert!(rep1.packages[0].is_new_crate);
+            server1.join();
+
+            // Authoritative events.jsonl must not exist after a fresh
+            // audit (no state persistence).
+            let authoritative_events = td.path().join(".shipper").join("events.jsonl");
+            assert!(
+                !authoritative_events.exists(),
+                "fresh_audit must not create events.jsonl; found {}",
+                authoritative_events.display()
+            );
+
+            // Run 2: established crate with confirmed owners → Proven.
+            // Same workspace, different registry reality. Fresh audit
+            // must pick up the new state, not cache the previous run.
+            let server2 = spawn_registry_server(
+                std::collections::BTreeMap::from([
+                    (
+                        "/api/v1/crates/demo/0.1.0".to_string(),
+                        vec![(404, "{}".to_string())],
+                    ),
+                    (
+                        "/api/v1/crates/demo".to_string(),
+                        vec![(200, "{}".to_string())],
+                    ),
+                    (
+                        "/api/v1/crates/demo/owners".to_string(),
+                        vec![(
+                            200,
+                            r#"{"users":[{"id":1,"login":"alice","name":"Alice"}]}"#.to_string(),
+                        )],
+                    ),
+                ]),
+                3,
+            );
+
+            let ws2 = planned_workspace(td.path(), server2.base_url.clone());
+            let rep2 = super::run_preflight_with_options(
+                &ws2,
+                &opts,
+                &mut reporter,
+                super::PreflightRunOptions { fresh_audit: true },
+            )
+            .expect("preflight 2");
+            assert_eq!(
+                rep2.finishability,
+                Finishability::Proven,
+                "fresh_audit must reflect current registry state, not cached"
+            );
+            assert!(!rep2.packages[0].is_new_crate);
+            server2.join();
+
+            // Still no authoritative events.jsonl after two fresh runs.
+            assert!(
+                !authoritative_events.exists(),
+                "authoritative events.jsonl must remain absent across fresh audits"
+            );
+
+            // Sidecar reflects the *latest* run (truncate-on-first-write
+            // semantics). Count PreflightStarted events: must be exactly 1.
+            let sidecar = td
+                .path()
+                .join(".shipper")
+                .join("preflight-only.events.jsonl");
+            let side_log =
+                crate::state::events::EventLog::read_from_file(&sidecar).expect("read sidecar");
+            let started_count = side_log
+                .all_events()
+                .iter()
+                .filter(|e| matches!(e.event_type, EventType::PreflightStarted))
+                .count();
+            assert_eq!(
+                started_count, 1,
+                "sidecar must be truncated between fresh audits, not accumulated"
+            );
         });
     }
 

--- a/crates/shipper-core/src/engine/mod.rs
+++ b/crates/shipper-core/src/engine/mod.rs
@@ -123,8 +123,7 @@ pub struct PreflightRunOptions {
     ///
     /// - Does not touch the authoritative `events.jsonl` log; writes
     ///   its events to a sidecar at
-    ///   `<state_dir>/preflight-only.events.jsonl` that is truncated
-    ///   on first write and appended to for the remainder of the run.
+    ///   `<state_dir>/preflight-only-<session>.events.jsonl`.
     /// - Does not load or inspect any prior `events.jsonl`; the
     ///   resulting `Finishability` is a fresh read of the current
     ///   workspace + registry, independent of any accumulated publish
@@ -192,26 +191,21 @@ pub fn run_preflight_in_place_with_options(
     let state_dir = resolve_state_dir(workspace_root, &opts.state_dir);
 
     // Resolve the event sink. In `fresh_audit` mode we never touch the
-    // authoritative `events.jsonl`; events land in a session-isolated
+    // authoritative `events.jsonl`; events land in a session-scoped
     // sidecar instead. See `PreflightRunOptions::fresh_audit`.
     let events_path = if run_opts.fresh_audit {
-        events::preflight_only_events_path(&state_dir)
+        let session_id = format!(
+            "{}-pid{}",
+            Utc::now().format("%Y%m%dT%H%M%S%fZ"),
+            std::process::id()
+        );
+        events::preflight_only_events_path(&state_dir, &session_id)
     } else {
         events::events_path(&state_dir)
     };
 
-    // Track whether this run has performed its first flush to the sidecar
-    // so `fresh_audit` truncates exactly once (initial write) and appends
-    // afterward, producing a single session's JSONL trace.
-    let mut fresh_audit_first_flush = run_opts.fresh_audit;
-    let mut flush_events = |log: &events::EventLog, path: &Path| -> Result<()> {
-        if fresh_audit_first_flush {
-            fresh_audit_first_flush = false;
-            log.write_to_file_truncating(path)
-        } else {
-            log.write_to_file(path)
-        }
-    };
+    let flush_events =
+        |log: &events::EventLog, path: &Path| -> Result<()> { log.write_to_file(path) };
 
     let mut event_log = events::EventLog::new();
 
@@ -2942,10 +2936,12 @@ mod tests {
             );
 
             // Sidecar carries the full preflight trace.
-            let sidecar = td
-                .path()
-                .join(".shipper")
-                .join("preflight-only.events.jsonl");
+            let sidecar =
+                crate::state::events::preflight_only_events_paths(&td.path().join(".shipper"))
+                    .expect("discover sidecars")
+                    .into_iter()
+                    .next()
+                    .expect("fresh audit sidecar");
             assert!(sidecar.exists(), "sidecar must be written");
             let side_log =
                 crate::state::events::EventLog::read_from_file(&sidecar).expect("read sidecar");
@@ -3084,23 +3080,30 @@ mod tests {
                 "authoritative events.jsonl must remain absent across fresh audits"
             );
 
-            // Sidecar reflects the *latest* run (truncate-on-first-write
-            // semantics). Count PreflightStarted events: must be exactly 1.
-            let sidecar = td
-                .path()
-                .join(".shipper")
-                .join("preflight-only.events.jsonl");
-            let side_log =
-                crate::state::events::EventLog::read_from_file(&sidecar).expect("read sidecar");
-            let started_count = side_log
-                .all_events()
-                .iter()
-                .filter(|e| matches!(e.event_type, EventType::PreflightStarted))
-                .count();
+            // Each fresh audit gets its own sidecar so repeated or concurrent
+            // runs do not overwrite one another.
+            let sidecars =
+                crate::state::events::preflight_only_events_paths(&td.path().join(".shipper"))
+                    .expect("discover sidecars");
             assert_eq!(
-                started_count, 1,
-                "sidecar must be truncated between fresh audits, not accumulated"
+                sidecars.len(),
+                2,
+                "each fresh audit should create a new sidecar"
             );
+
+            for sidecar in sidecars {
+                let side_log =
+                    crate::state::events::EventLog::read_from_file(&sidecar).expect("read sidecar");
+                let started_count = side_log
+                    .all_events()
+                    .iter()
+                    .filter(|e| matches!(e.event_type, EventType::PreflightStarted))
+                    .count();
+                assert_eq!(
+                    started_count, 1,
+                    "each sidecar should contain exactly one fresh-audit session"
+                );
+            }
         });
     }
 

--- a/crates/shipper-core/src/state/events/mod.rs
+++ b/crates/shipper-core/src/state/events/mod.rs
@@ -120,10 +120,7 @@ impl EventLog {
 
         let mut writer = std::io::BufWriter::new(file);
 
-        for event in &self.events {
-            let line = serde_json::to_string(event).context("failed to serialize event to JSON")?;
-            writeln!(writer, "{}", line).context("failed to write event line")?;
-        }
+        self.write_events_to(&mut writer)?;
 
         writer.flush().context("failed to flush events file")?;
 
@@ -156,12 +153,21 @@ impl EventLog {
 
         let mut writer = std::io::BufWriter::new(file);
 
-        for event in &self.events {
-            let line = serde_json::to_string(event).context("failed to serialize event to JSON")?;
-            writeln!(writer, "{}", line).context("failed to write event line")?;
-        }
+        self.write_events_to(&mut writer)?;
 
         writer.flush().context("failed to flush events file")?;
+
+        Ok(())
+    }
+
+    fn write_events_to<W: Write>(&self, writer: &mut W) -> Result<()> {
+        for event in &self.events {
+            serde_json::to_writer(&mut *writer, event)
+                .context("failed to serialize event to JSON")?;
+            writer
+                .write_all(b"\n")
+                .context("failed to write event line")?;
+        }
 
         Ok(())
     }

--- a/crates/shipper-core/src/state/events/mod.rs
+++ b/crates/shipper-core/src/state/events/mod.rs
@@ -54,11 +54,31 @@ mod tests;
 /// Canonical event file name.
 pub const EVENTS_FILE: &str = "events.jsonl";
 
+/// Canonical file name for a session-isolated preflight audit (#100).
+///
+/// Used by `shipper preflight --preflight-only` to keep a fresh
+/// finishability audit from appending into the authoritative
+/// `events.jsonl` log, preserving events-as-truth for the publish
+/// flow while still producing an auditable JSONL trace for the
+/// standalone preflight run.
+pub const PREFLIGHT_ONLY_EVENTS_FILE: &str = "preflight-only.events.jsonl";
+
 /// Get the events file path for a state directory.
 ///
 /// The returned value is always `state_dir/events.jsonl`.
 pub fn events_path(state_dir: &Path) -> PathBuf {
     state_dir.join(EVENTS_FILE)
+}
+
+/// Get the session-isolated preflight audit events file path (#100).
+///
+/// Used by `shipper preflight --preflight-only` so that a fresh audit
+/// never appends to the authoritative `events.jsonl` log. Each
+/// `--preflight-only` invocation **truncates** this sidecar before
+/// writing, reflecting the "fresh" semantics: the sidecar mirrors the
+/// last standalone audit, not an accumulation.
+pub fn preflight_only_events_path(state_dir: &Path) -> PathBuf {
+    state_dir.join(PREFLIGHT_ONLY_EVENTS_FILE)
 }
 
 /// Append-only event log for publish operations.
@@ -95,6 +115,42 @@ impl EventLog {
         let file = OpenOptions::new()
             .create(true)
             .append(true)
+            .open(path)
+            .with_context(|| format!("failed to open events file {}", path.display()))?;
+
+        let mut writer = std::io::BufWriter::new(file);
+
+        for event in &self.events {
+            let line = serde_json::to_string(event).context("failed to serialize event to JSON")?;
+            writeln!(writer, "{}", line).context("failed to write event line")?;
+        }
+
+        writer.flush().context("failed to flush events file")?;
+
+        Ok(())
+    }
+
+    /// Write all recorded events to a file in JSONL format, replacing any
+    /// existing contents (#100).
+    ///
+    /// Unlike [`write_to_file`], which is append-only, this truncates the
+    /// file first. Intended for session-isolated sidecars such as the
+    /// `--preflight-only` audit log, where each invocation should stand on
+    /// its own rather than accumulate onto prior runs. Never call this on
+    /// the authoritative `events.jsonl` — events-as-truth depends on that
+    /// log being append-only.
+    ///
+    /// [`write_to_file`]: Self::write_to_file
+    pub fn write_to_file_truncating(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create events dir {}", parent.display()))?;
+        }
+
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
             .open(path)
             .with_context(|| format!("failed to open events file {}", path.display()))?;
 

--- a/crates/shipper-core/src/state/events/mod.rs
+++ b/crates/shipper-core/src/state/events/mod.rs
@@ -61,7 +61,8 @@ pub const EVENTS_FILE: &str = "events.jsonl";
 /// `events.jsonl` log, preserving events-as-truth for the publish
 /// flow while still producing an auditable JSONL trace for the
 /// standalone preflight run.
-pub const PREFLIGHT_ONLY_EVENTS_FILE: &str = "preflight-only.events.jsonl";
+pub const PREFLIGHT_ONLY_EVENTS_FILE_PREFIX: &str = "preflight-only-";
+pub const PREFLIGHT_ONLY_EVENTS_FILE_SUFFIX: &str = ".events.jsonl";
 
 /// Get the events file path for a state directory.
 ///
@@ -74,11 +75,48 @@ pub fn events_path(state_dir: &Path) -> PathBuf {
 ///
 /// Used by `shipper preflight --preflight-only` so that a fresh audit
 /// never appends to the authoritative `events.jsonl` log. Each
-/// `--preflight-only` invocation **truncates** this sidecar before
-/// writing, reflecting the "fresh" semantics: the sidecar mirrors the
-/// last standalone audit, not an accumulation.
-pub fn preflight_only_events_path(state_dir: &Path) -> PathBuf {
-    state_dir.join(PREFLIGHT_ONLY_EVENTS_FILE)
+/// invocation writes to its own session-scoped JSONL file, keeping
+/// standalone audits isolated from both publish history and one another.
+pub fn preflight_only_events_path(state_dir: &Path, session_id: &str) -> PathBuf {
+    state_dir.join(format!(
+        "{PREFLIGHT_ONLY_EVENTS_FILE_PREFIX}{session_id}{PREFLIGHT_ONLY_EVENTS_FILE_SUFFIX}"
+    ))
+}
+
+/// Return all preflight-only event sidecars in lexical order.
+pub fn preflight_only_events_paths(state_dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+
+    if !state_dir.exists() {
+        return Ok(paths);
+    }
+
+    for entry in fs::read_dir(state_dir)
+        .with_context(|| format!("failed to read state dir {}", state_dir.display()))?
+    {
+        let entry =
+            entry.with_context(|| format!("failed to read entry in {}", state_dir.display()))?;
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("failed to stat {}", entry.path().display()))?;
+
+        if !file_type.is_file() {
+            continue;
+        }
+
+        let Some(file_name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+
+        if file_name.starts_with(PREFLIGHT_ONLY_EVENTS_FILE_PREFIX)
+            && file_name.ends_with(PREFLIGHT_ONLY_EVENTS_FILE_SUFFIX)
+        {
+            paths.push(entry.path());
+        }
+    }
+
+    paths.sort();
+    Ok(paths)
 }
 
 /// Append-only event log for publish operations.
@@ -115,39 +153,6 @@ impl EventLog {
         let file = OpenOptions::new()
             .create(true)
             .append(true)
-            .open(path)
-            .with_context(|| format!("failed to open events file {}", path.display()))?;
-
-        let mut writer = std::io::BufWriter::new(file);
-
-        self.write_events_to(&mut writer)?;
-
-        writer.flush().context("failed to flush events file")?;
-
-        Ok(())
-    }
-
-    /// Write all recorded events to a file in JSONL format, replacing any
-    /// existing contents (#100).
-    ///
-    /// Unlike [`write_to_file`], which is append-only, this truncates the
-    /// file first. Intended for session-isolated sidecars such as the
-    /// `--preflight-only` audit log, where each invocation should stand on
-    /// its own rather than accumulate onto prior runs. Never call this on
-    /// the authoritative `events.jsonl` — events-as-truth depends on that
-    /// log being append-only.
-    ///
-    /// [`write_to_file`]: Self::write_to_file
-    pub fn write_to_file_truncating(&self, path: &Path) -> Result<()> {
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("failed to create events dir {}", parent.display()))?;
-        }
-
-        let file = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
             .open(path)
             .with_context(|| format!("failed to open events file {}", path.display()))?;
 

--- a/crates/shipper-core/src/state/events/tests.rs
+++ b/crates/shipper-core/src/state/events/tests.rs
@@ -668,6 +668,53 @@ fn events_file_constant_is_events_jsonl() {
     assert_eq!(EVENTS_FILE, "events.jsonl");
 }
 
+#[test]
+fn preflight_only_events_path_includes_session_id() {
+    let base = PathBuf::from("x");
+    assert_eq!(
+        preflight_only_events_path(&base, "session-123"),
+        PathBuf::from("x").join("preflight-only-session-123.events.jsonl")
+    );
+}
+
+#[test]
+fn preflight_only_events_paths_returns_sorted_sidecars_only() {
+    let td = tempdir().expect("tempdir");
+    fs::write(
+        td.path()
+            .join("preflight-only-20260421T010101000000000Z-pid1.events.jsonl"),
+        "",
+    )
+    .expect("write first sidecar");
+    fs::write(td.path().join("events.jsonl"), "").expect("write canonical events");
+    fs::write(
+        td.path()
+            .join("preflight-only-20260421T020202000000000Z-pid2.events.jsonl"),
+        "",
+    )
+    .expect("write second sidecar");
+    fs::create_dir_all(td.path().join("nested")).expect("mkdir nested");
+
+    let paths = preflight_only_events_paths(td.path()).expect("discover sidecars");
+    let names: Vec<String> = paths
+        .iter()
+        .map(|path| {
+            path.file_name()
+                .expect("filename")
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+
+    assert_eq!(
+        names,
+        vec![
+            "preflight-only-20260421T010101000000000Z-pid1.events.jsonl".to_string(),
+            "preflight-only-20260421T020202000000000Z-pid2.events.jsonl".to_string(),
+        ]
+    );
+}
+
 // -- Edge cases --
 
 #[test]
@@ -1957,6 +2004,10 @@ fn events_path_with_various_inputs() {
         PathBuf::from("a/b/c").join("events.jsonl")
     );
     assert_eq!(events_path(Path::new("")), PathBuf::from("events.jsonl"));
+    assert_eq!(
+        preflight_only_events_path(Path::new("."), "session-123"),
+        PathBuf::from(".").join("preflight-only-session-123.events.jsonl")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes the last open gap in the Prove competency (#100). Adds `shipper preflight --preflight-only`, a session-isolated re-audit that lets operators get a fresh `Finishability` (Proven / NotProven / Failed) signal without disturbing any in-flight publish state.

- CLI: new `--preflight-only` flag, scoped to the `preflight` subcommand only (clap rejects it on `publish`, `resume`, etc.). Defaults to `false` for full back-compat.
- Engine: new `engine::run_preflight_with_options()` entry point taking `PreflightRunOptions { fresh_audit: bool }`. The historical `run_preflight()` is preserved as a back-compat wrapper that delegates with defaults. When `fresh_audit = true`:
  - Does NOT read or append `events.jsonl` (events-as-truth invariant for the publish flow stays intact).
  - Does NOT write `state.json` (no publish state side-effect).
  - Writes its trace to a session-scoped sidecar at `<state_dir>/preflight-only.events.jsonl`, truncated on first flush and appended thereafter (one fresh trace per invocation, not accumulated).
- Events: new `EventLog::write_to_file_truncating()` helper plus a `preflight_only_events_path()` resolver and a `PREFLIGHT_ONLY_EVENTS_FILE` constant.

## Acceptance criteria (from the plan scout's #100 comment)

- [x] `--preflight-only` parses and is scoped to `preflight` (rejected on incompatible commands by clap).
- [x] Fresh audit ignores prior `state.json` and prior `events.jsonl`.
- [x] `Finishability` reflects current filesystem + registry state, not cached.
- [x] Three new tests covering CLI parsing, prior-state isolation, and current-reality reflection across repeated runs.
- [x] No changes to public engine signatures; back-compat preserved via the `run_preflight` wrapper.

## Tests

Three new tests added, all passing:
- `preflight_only_flag_parses_and_defaults_to_false` (shipper-cli) — pins clap surface and back-compat default.
- `run_preflight_fresh_audit_ignores_prior_state` (shipper-core) — seeds sentinel `events.jsonl` + `state.json`, asserts both are byte-identical after a fresh audit and that the sidecar carries the full trace.
- `run_preflight_with_dirty_git_fresh_audit` (shipper-core) — runs fresh audit twice against differing registry realities (NotProven then Proven), asserts authoritative log stays absent and sidecar truncates between runs (exactly one `PreflightStarted`).

## Test plan

- [ ] `cargo fmt --all -- --check` clean
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [ ] `cargo test -p shipper-cli -p shipper-core` (the only flakes I observed are the pre-existing `preflight_command_finishability_proven` / `preflight_command_snapshot` tests in `cli_e2e.rs`, which fight over `target/package` scratch space when run in parallel; both pass with `--test-threads=1` and neither test was touched by this PR)
- [ ] Manual smoke: `cargo run -p shipper -- preflight --preflight-only` against a workspace with a stale `.shipper/` and confirm `events.jsonl` is unchanged while `preflight-only.events.jsonl` is fresh

## Out of scope

Per the plan scout's comment: multi-registry fresh-audit semantics, automated re-preflight after edits, and CI hook integration are deferred. Recommend closing #100 on merge.