### PR TITLE
feat(profile): thread PublishRegime through preflight to publish (#106 PR 1)

### DIFF
--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -619,7 +619,7 @@ pub fn run() -> Result<()> {
             print_plan(&planned, cli.verbose);
         }
         Commands::Preflight => {
-            let rep = engine::run_preflight(&mut planned, &opts, &mut reporter)?;
+            let rep = engine::run_preflight_in_place(&mut planned, &opts, &mut reporter)?;
             print_preflight(&rep, &cli.format);
         }
         Commands::Publish => {

--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -619,7 +619,7 @@ pub fn run() -> Result<()> {
             print_plan(&planned, cli.verbose);
         }
         Commands::Preflight => {
-            let rep = engine::run_preflight(&planned, &opts, &mut reporter)?;
+            let rep = engine::run_preflight(&mut planned, &opts, &mut reporter)?;
             print_preflight(&rep, &cli.format);
         }
         Commands::Publish => {

--- a/crates/shipper-core/src/engine/mod.rs
+++ b/crates/shipper-core/src/engine/mod.rs
@@ -2358,7 +2358,7 @@ mod tests {
     #[serial]
     fn run_preflight_errors_in_strict_mode_without_token() {
         let td = tempdir().expect("tempdir");
-        let mut ws = planned_workspace(td.path(), "http://127.0.0.1:9".to_string());
+        let ws = planned_workspace(td.path(), "http://127.0.0.1:9".to_string());
         let mut opts = default_opts(PathBuf::from(".shipper"));
         opts.strict_ownership = true;
         opts.skip_ownership_check = false;
@@ -2373,7 +2373,7 @@ mod tests {
             ],
             || {
                 let mut reporter = CollectingReporter::default();
-                let err = run_preflight(&mut ws, &opts, &mut reporter).expect_err("must fail");
+                let err = run_preflight(&ws, &opts, &mut reporter).expect_err("must fail");
                 assert!(
                     format!("{err:#}").contains("strict ownership requested but no token found")
                 );
@@ -2415,13 +2415,13 @@ mod tests {
                 3,
             );
 
-            let mut ws = planned_workspace(td.path(), server.base_url.clone());
+            let ws = planned_workspace(td.path(), server.base_url.clone());
             let mut opts = default_opts(PathBuf::from(".shipper"));
             opts.skip_ownership_check = false;
             opts.strict_ownership = false;
 
             let mut reporter = CollectingReporter::default();
-            let rep = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
+            let rep = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
             assert!(rep.token_detected);
             assert_eq!(rep.packages.len(), 1);
             assert!(!rep.packages[0].already_published);
@@ -2479,13 +2479,13 @@ mod tests {
                 3,
             );
 
-            let mut ws = planned_workspace(td.path(), server.base_url.clone());
+            let ws = planned_workspace(td.path(), server.base_url.clone());
             let mut opts = default_opts(PathBuf::from(".shipper"));
             opts.skip_ownership_check = false;
             opts.strict_ownership = false;
 
             let mut reporter = CollectingReporter::default();
-            let rep = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
+            let rep = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
             assert_eq!(rep.packages.len(), 1);
             assert!(reporter.warns.is_empty());
             server.join();
@@ -2528,13 +2528,13 @@ mod tests {
                 3,
             );
 
-            let mut ws = planned_workspace(td.path(), server.base_url.clone());
+            let ws = planned_workspace(td.path(), server.base_url.clone());
             let mut opts = default_opts(PathBuf::from(".shipper"));
             opts.skip_ownership_check = false;
             opts.strict_ownership = true;
 
             let mut reporter = CollectingReporter::default();
-            let err = run_preflight(&mut ws, &opts, &mut reporter).expect_err("must fail");
+            let err = run_preflight(&ws, &opts, &mut reporter).expect_err("must fail");
             assert!(format!("{err:#}").contains("forbidden when querying owners"));
             server.join();
         });
@@ -2716,13 +2716,13 @@ mod tests {
                 2,
             );
 
-            let mut ws = planned_workspace(td.path(), server.base_url.clone());
+            let ws = planned_workspace(td.path(), server.base_url.clone());
             let mut opts = default_opts(PathBuf::from(".shipper"));
             opts.allow_dirty = true;
             opts.skip_ownership_check = true;
 
             let mut reporter = CollectingReporter::default();
-            let _ = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
+            let _ = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
 
             let events_path = td.path().join(".shipper").join("events.jsonl");
             let log =
@@ -2797,13 +2797,13 @@ mod tests {
                 2,
             );
 
-            let mut ws = planned_workspace(td.path(), server.base_url.clone());
+            let ws = planned_workspace(td.path(), server.base_url.clone());
             let mut opts = default_opts(PathBuf::from(".shipper"));
             opts.allow_dirty = true;
             opts.skip_ownership_check = true;
 
             let mut reporter = CollectingReporter::default();
-            let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
+            let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
 
             assert!(!report.token_detected);
             assert_eq!(
@@ -2837,13 +2837,13 @@ mod tests {
                 2,
             );
 
-            let mut ws = planned_workspace(td.path(), server.base_url.clone());
+            let ws = planned_workspace(td.path(), server.base_url.clone());
             let mut opts = default_opts(PathBuf::from(".shipper"));
             opts.allow_dirty = false;
             opts.skip_ownership_check = true;
 
             let mut reporter = CollectingReporter::default();
-            let rep = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
+            let rep = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
             assert_eq!(rep.packages.len(), 1);
             server.join();
         });
@@ -3665,13 +3665,13 @@ mod tests {
                     ]),
                     2,
                 );
-                let mut ws = planned_workspace(td.path(), server.base_url.clone());
+                let ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.allow_dirty = true;
                 opts.skip_ownership_check = true;
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
 
                 assert_eq!(report.packages.len(), 1);
                 assert!(report.packages[0].already_published);
@@ -3706,13 +3706,13 @@ mod tests {
                     ]),
                     2,
                 );
-                let mut ws = planned_workspace(td.path(), server.base_url.clone());
+                let ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.allow_dirty = true;
                 opts.skip_ownership_check = true;
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
 
                 assert_eq!(report.packages.len(), 1);
                 assert!(!report.packages[0].already_published);
@@ -3754,13 +3754,13 @@ mod tests {
                     ]),
                     3,
                 );
-                let mut ws = planned_workspace(td.path(), server.base_url.clone());
+                let ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.allow_dirty = true;
                 opts.skip_ownership_check = false;
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
 
                 assert_eq!(report.packages.len(), 1);
                 assert!(!report.packages[0].ownership_verified);
@@ -3797,13 +3797,13 @@ mod tests {
                     ]),
                     2,
                 );
-                let mut ws = planned_workspace(td.path(), server.base_url.clone());
+                let ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.allow_dirty = true;
                 opts.skip_ownership_check = true;
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
 
                 assert_eq!(report.packages.len(), 1);
                 assert!(!report.packages[0].dry_run_passed);
@@ -3832,14 +3832,14 @@ mod tests {
                 ("CARGO_REGISTRIES_CRATES_IO_TOKEN", None),
             ],
             || {
-                let mut ws = planned_workspace(td.path(), "http://127.0.0.1:9".to_string());
+                let ws = planned_workspace(td.path(), "http://127.0.0.1:9".to_string());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.allow_dirty = true;
                 opts.strict_ownership = true;
                 // No token set
 
                 let mut reporter = CollectingReporter::default();
-                let err = run_preflight(&mut ws, &opts, &mut reporter).expect_err("must fail");
+                let err = run_preflight(&ws, &opts, &mut reporter).expect_err("must fail");
                 assert!(
                     format!("{err:#}").contains("strict ownership requested but no token found")
                 );
@@ -3878,13 +3878,13 @@ mod tests {
                     ]),
                     3,
                 );
-                let mut ws = planned_workspace(td.path(), server.base_url.clone());
+                let ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.allow_dirty = true;
                 opts.skip_ownership_check = false;
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
 
                 assert_eq!(report.packages.len(), 1);
                 assert!(report.packages[0].ownership_verified);
@@ -3920,12 +3920,12 @@ mod tests {
                     ]),
                     2,
                 );
-                let mut ws = planned_workspace(td.path(), server.base_url.clone());
+                let ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.policy = crate::types::PublishPolicy::Fast;
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
 
                 // dry_run_passed should be true (skipped), not false (cargo would have failed)
                 assert!(report.packages[0].dry_run_passed);
@@ -3971,13 +3971,13 @@ mod tests {
                     ]),
                     2,
                 );
-                let mut ws = planned_workspace(td.path(), server.base_url.clone());
+                let ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.policy = crate::types::PublishPolicy::Balanced;
                 opts.skip_ownership_check = false; // would check in Safe, but Balanced overrides
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
 
                 // ownership_verified false (Balanced skips ownership)
                 assert!(!report.packages[0].ownership_verified);
@@ -4019,13 +4019,13 @@ mod tests {
                     ]),
                     3,
                 );
-                let mut ws = planned_workspace(td.path(), server.base_url.clone());
+                let ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.policy = crate::types::PublishPolicy::Safe;
                 opts.skip_ownership_check = false;
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
 
                 // All checks ran
                 assert!(report.packages[0].dry_run_passed);
@@ -4060,12 +4060,12 @@ mod tests {
                     ]),
                     2,
                 );
-                let mut ws = planned_workspace(td.path(), server.base_url.clone());
+                let ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.verify_mode = crate::types::VerifyMode::None;
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
 
                 // dry_run_passed is true because verify_mode=None skips it
                 assert!(report.packages[0].dry_run_passed);
@@ -4103,12 +4103,12 @@ mod tests {
                     ]),
                     2,
                 );
-                let mut ws = planned_workspace(td.path(), server.base_url.clone());
+                let ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.verify_mode = crate::types::VerifyMode::Package;
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
 
                 assert!(report.packages[0].dry_run_passed);
                 assert!(

--- a/crates/shipper-core/src/engine/mod.rs
+++ b/crates/shipper-core/src/engine/mod.rs
@@ -36,7 +36,17 @@ pub(crate) fn policy_effects(opts: &RuntimeOptions) -> crate::runtime::policy::P
     crate::runtime::policy::policy_effects(opts)
 }
 
+fn init_registry_client(registry: Registry, state_dir: &Path) -> Result<RegistryClient> {
+    let cache_dir = state_dir.join("cache");
+    RegistryClient::new(registry).map(|c| c.with_cache_dir(cache_dir))
+}
+
 /// Run preflight verification checks before publishing.
+///
+/// This is the backward-compatible read-only entry point for embedders.
+/// Call [`run_preflight_in_place`] if you want preflight to stamp the detected
+/// [`PublishRegime`] onto each `PlannedPackage` for a subsequent publish in
+/// the same process.
 ///
 /// This function performs various pre-publish checks to catch issues early:
 /// - Git cleanliness (if `allow_dirty` is false)
@@ -61,25 +71,29 @@ pub(crate) fn policy_effects(opts: &RuntimeOptions) -> crate::runtime::policy::P
 /// # Example
 ///
 /// ```ignore
-/// let mut ws = plan::build_plan(&spec)?;
+/// let ws = plan::build_plan(&spec)?;
 /// let opts = types::RuntimeOptions { /* ... */ };
 /// let mut reporter = MyReporter::default();
-/// let report = engine::run_preflight(&mut ws, &opts, &mut reporter)?;
+/// let report = engine::run_preflight(&ws, &opts, &mut reporter)?;
 /// println!("Finishability: {:?}", report.finishability);
 /// ```
-fn init_registry_client(registry: Registry, state_dir: &Path) -> Result<RegistryClient> {
-    let cache_dir = state_dir.join("cache");
-    RegistryClient::new(registry).map(|c| c.with_cache_dir(cache_dir))
+pub fn run_preflight(
+    ws: &PlannedWorkspace,
+    opts: &RuntimeOptions,
+    reporter: &mut dyn Reporter,
+) -> Result<PreflightReport> {
+    let mut ws = ws.clone();
+    run_preflight_in_place(&mut ws, opts, reporter)
 }
 
-/// Run preflight checks for a planned workspace.
+/// Run preflight checks for a planned workspace and stamp regime metadata.
 ///
 /// Takes `&mut PlannedWorkspace` so preflight can stamp the detected
 /// [`PublishRegime`] onto each `PlannedPackage` once it has queried the
 /// registry (#106 PR 1). The mutation is additive: the new `regime`
 /// field defaults to `None` and is skipped in serialization when unset,
 /// so older readers of `state.json` / plan files stay compatible.
-pub fn run_preflight(
+pub fn run_preflight_in_place(
     ws: &mut PlannedWorkspace,
     opts: &RuntimeOptions,
     reporter: &mut dyn Reporter,
@@ -2564,7 +2578,7 @@ mod tests {
             opts.strict_ownership = true;
 
             let mut reporter = CollectingReporter::default();
-            let rep = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
+            let rep = run_preflight_in_place(&mut ws, &opts, &mut reporter).expect("preflight");
             assert_eq!(rep.packages.len(), 1);
             assert!(!rep.packages[0].ownership_verified);
             assert!(rep.packages[0].is_new_crate);
@@ -2581,6 +2595,45 @@ mod tests {
                 ws.plan.packages[0].regime,
                 Some(PublishRegime::FirstPublish),
                 "preflight should stamp FirstPublish regime on new crates"
+            );
+            server.join();
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn run_preflight_legacy_entry_point_preserves_immutable_api() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        let mut env_vars = fake_program_env_vars(&bin);
+        env_vars.extend([("SHIPPER_CARGO_EXIT", Some("0".to_string()))]);
+        temp_env::with_vars(env_vars, || {
+            let server = spawn_registry_server(
+                std::collections::BTreeMap::from([
+                    (
+                        "/api/v1/crates/demo/0.1.0".to_string(),
+                        vec![(404, "{}".to_string())],
+                    ),
+                    (
+                        "/api/v1/crates/demo".to_string(),
+                        vec![(404, "{}".to_string())],
+                    ),
+                ]),
+                2,
+            );
+
+            let ws = planned_workspace(td.path(), server.base_url.clone());
+            let opts = default_opts(PathBuf::from(".shipper"));
+            let mut reporter = CollectingReporter::default();
+
+            let rep = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
+
+            assert_eq!(rep.packages.len(), 1);
+            assert!(rep.packages[0].is_new_crate);
+            assert_eq!(
+                ws.plan.packages[0].regime, None,
+                "legacy immutable API should not mutate the caller's plan"
             );
             server.join();
         });
@@ -2628,7 +2681,7 @@ mod tests {
             opts.strict_ownership = false;
 
             let mut reporter = CollectingReporter::default();
-            let rep = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
+            let rep = run_preflight_in_place(&mut ws, &opts, &mut reporter).expect("preflight");
             assert_eq!(rep.packages.len(), 1);
             assert!(!rep.packages[0].is_new_crate);
             assert_eq!(

--- a/crates/shipper-core/src/engine/mod.rs
+++ b/crates/shipper-core/src/engine/mod.rs
@@ -22,7 +22,7 @@ use crate::state::execution_state as state;
 use crate::types::{
     AttemptEvidence, ErrorClass, EventType, ExecutionResult, ExecutionState, Finishability,
     PackageProgress, PackageReceipt, PackageState, PreflightPackage, PreflightReport, PublishEvent,
-    ReadinessEvidence, Receipt, ReconciliationOutcome, Registry, RuntimeOptions,
+    PublishRegime, ReadinessEvidence, Receipt, ReconciliationOutcome, Registry, RuntimeOptions,
 };
 use crate::webhook::{self, WebhookEvent};
 
@@ -61,10 +61,10 @@ pub(crate) fn policy_effects(opts: &RuntimeOptions) -> crate::runtime::policy::P
 /// # Example
 ///
 /// ```ignore
-/// let ws = plan::build_plan(&spec)?;
+/// let mut ws = plan::build_plan(&spec)?;
 /// let opts = types::RuntimeOptions { /* ... */ };
 /// let mut reporter = MyReporter::default();
-/// let report = engine::run_preflight(&ws, &opts, &mut reporter)?;
+/// let report = engine::run_preflight(&mut ws, &opts, &mut reporter)?;
 /// println!("Finishability: {:?}", report.finishability);
 /// ```
 fn init_registry_client(registry: Registry, state_dir: &Path) -> Result<RegistryClient> {
@@ -72,8 +72,15 @@ fn init_registry_client(registry: Registry, state_dir: &Path) -> Result<Registry
     RegistryClient::new(registry).map(|c| c.with_cache_dir(cache_dir))
 }
 
+/// Run preflight checks for a planned workspace.
+///
+/// Takes `&mut PlannedWorkspace` so preflight can stamp the detected
+/// [`PublishRegime`] onto each `PlannedPackage` once it has queried the
+/// registry (#106 PR 1). The mutation is additive: the new `regime`
+/// field defaults to `None` and is skipped in serialization when unset,
+/// so older readers of `state.json` / plan files stay compatible.
 pub fn run_preflight(
-    ws: &PlannedWorkspace,
+    ws: &mut PlannedWorkspace,
     opts: &RuntimeOptions,
     reporter: &mut dyn Reporter,
 ) -> Result<PreflightReport> {
@@ -241,9 +248,21 @@ pub fn run_preflight(
     let mut packages: Vec<PreflightPackage> = Vec::new();
     let mut any_ownership_unverified = false;
 
-    for p in &ws.plan.packages {
+    for p in ws.plan.packages.iter_mut() {
         let already_published = reg.version_exists(&p.name, &p.version)?;
         let is_new_crate = reg.check_new_crate(&p.name)?;
+
+        // #106 PR 1: stamp the detected regime onto the plan so the
+        // publish retry loop can consume it without re-querying the
+        // registry. Classification is based purely on registry
+        // presence here; finer-grained variants (e.g. Patch) can be
+        // layered on in later PRs without breaking this contract.
+        p.regime = Some(if is_new_crate {
+            PublishRegime::FirstPublish
+        } else {
+            PublishRegime::Update
+        });
+
         if is_new_crate {
             event_log.record(PublishEvent {
                 timestamp: Utc::now(),
@@ -877,10 +896,15 @@ pub fn run_publish(
 
         reporter.info(&format!("{}@{}: publishing...", p.name, p.version));
 
-        // Registry-aware backoff (#94): lazy-cached "is this a new crate?"
-        // Only queried when a retry's error message looks like a rate limit,
-        // so the happy path costs zero extra registry calls.
-        let mut is_new_crate_cached: Option<bool> = None;
+        // Registry-aware backoff (#94 / #106 PR 1): prefer the `PublishRegime`
+        // that preflight stamped onto the `PlannedPackage`. That answer is
+        // authoritative; when present, we never re-query the registry
+        // mid-retry.
+        //
+        // `None` here means the plan predates the regime field (old
+        // state.json, legacy test harness). In that case we fall back to the
+        // historical lazy-cached behavior for backward compatibility.
+        let mut is_new_crate_cached: Option<bool> = p.regime.map(PublishRegime::is_new_crate);
 
         let mut attempt = st
             .packages
@@ -1324,7 +1348,7 @@ pub fn run_publish(
 /// # Example
 ///
 /// ```ignore
-/// let ws = plan::build_plan(&spec)?;
+/// let mut ws = plan::build_plan(&spec)?;
 /// let opts = types::RuntimeOptions { /* ... */ };
 /// let mut reporter = MyReporter::default();
 /// let receipt = engine::run_resume(&ws, &opts, &mut reporter)?;
@@ -2080,6 +2104,7 @@ mod tests {
                     name: "demo".to_string(),
                     version: "0.1.0".to_string(),
                     manifest_path: workspace_root.join("demo").join("Cargo.toml"),
+                    regime: None,
                 }],
                 dependencies: std::collections::BTreeMap::new(),
             },
@@ -2319,7 +2344,7 @@ mod tests {
     #[serial]
     fn run_preflight_errors_in_strict_mode_without_token() {
         let td = tempdir().expect("tempdir");
-        let ws = planned_workspace(td.path(), "http://127.0.0.1:9".to_string());
+        let mut ws = planned_workspace(td.path(), "http://127.0.0.1:9".to_string());
         let mut opts = default_opts(PathBuf::from(".shipper"));
         opts.strict_ownership = true;
         opts.skip_ownership_check = false;
@@ -2334,7 +2359,7 @@ mod tests {
             ],
             || {
                 let mut reporter = CollectingReporter::default();
-                let err = run_preflight(&ws, &opts, &mut reporter).expect_err("must fail");
+                let err = run_preflight(&mut ws, &opts, &mut reporter).expect_err("must fail");
                 assert!(
                     format!("{err:#}").contains("strict ownership requested but no token found")
                 );
@@ -2376,13 +2401,13 @@ mod tests {
                 3,
             );
 
-            let ws = planned_workspace(td.path(), server.base_url.clone());
+            let mut ws = planned_workspace(td.path(), server.base_url.clone());
             let mut opts = default_opts(PathBuf::from(".shipper"));
             opts.skip_ownership_check = false;
             opts.strict_ownership = false;
 
             let mut reporter = CollectingReporter::default();
-            let rep = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
+            let rep = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
             assert!(rep.token_detected);
             assert_eq!(rep.packages.len(), 1);
             assert!(!rep.packages[0].already_published);
@@ -2440,13 +2465,13 @@ mod tests {
                 3,
             );
 
-            let ws = planned_workspace(td.path(), server.base_url.clone());
+            let mut ws = planned_workspace(td.path(), server.base_url.clone());
             let mut opts = default_opts(PathBuf::from(".shipper"));
             opts.skip_ownership_check = false;
             opts.strict_ownership = false;
 
             let mut reporter = CollectingReporter::default();
-            let rep = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
+            let rep = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
             assert_eq!(rep.packages.len(), 1);
             assert!(reporter.warns.is_empty());
             server.join();
@@ -2489,13 +2514,13 @@ mod tests {
                 3,
             );
 
-            let ws = planned_workspace(td.path(), server.base_url.clone());
+            let mut ws = planned_workspace(td.path(), server.base_url.clone());
             let mut opts = default_opts(PathBuf::from(".shipper"));
             opts.skip_ownership_check = false;
             opts.strict_ownership = true;
 
             let mut reporter = CollectingReporter::default();
-            let err = run_preflight(&ws, &opts, &mut reporter).expect_err("must fail");
+            let err = run_preflight(&mut ws, &opts, &mut reporter).expect_err("must fail");
             assert!(format!("{err:#}").contains("forbidden when querying owners"));
             server.join();
         });
@@ -2533,13 +2558,13 @@ mod tests {
                 2,
             );
 
-            let ws = planned_workspace(td.path(), server.base_url.clone());
+            let mut ws = planned_workspace(td.path(), server.base_url.clone());
             let mut opts = default_opts(PathBuf::from(".shipper"));
             opts.skip_ownership_check = false;
             opts.strict_ownership = true;
 
             let mut reporter = CollectingReporter::default();
-            let rep = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
+            let rep = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
             assert_eq!(rep.packages.len(), 1);
             assert!(!rep.packages[0].ownership_verified);
             assert!(rep.packages[0].is_new_crate);
@@ -2548,6 +2573,68 @@ mod tests {
                     .infos
                     .iter()
                     .any(|i| i.contains("new crate, skipping ownership check"))
+            );
+            // #106 PR 1: preflight must stamp PublishRegime::FirstPublish
+            // on the plan so the downstream publish retry loop can
+            // consume it without re-querying the registry.
+            assert_eq!(
+                ws.plan.packages[0].regime,
+                Some(PublishRegime::FirstPublish),
+                "preflight should stamp FirstPublish regime on new crates"
+            );
+            server.join();
+        });
+    }
+
+    /// #106 PR 1: preflight stamps `PublishRegime::Update` on crates
+    /// that already have at least one published version. Ensures the
+    /// downstream retry loop can distinguish update vs. first-publish
+    /// backoff windows without re-querying the registry.
+    #[test]
+    #[serial]
+    fn run_preflight_stamps_update_regime_on_existing_crate() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        let mut env_vars = fake_program_env_vars(&bin);
+        env_vars.extend([
+            ("SHIPPER_CARGO_EXIT", Some("0".to_string())),
+            (
+                "CARGO_HOME",
+                Some(td.path().to_str().expect("utf8").to_string()),
+            ),
+        ]);
+        temp_env::with_vars(env_vars, || {
+            // Crate root returns 200 (crate exists), specific version 404
+            // (this version is not yet published). This is the canonical
+            // "publishing a new version of an existing crate" preflight.
+            let server = spawn_registry_server(
+                std::collections::BTreeMap::from([
+                    (
+                        "/api/v1/crates/demo/0.1.0".to_string(),
+                        vec![(404, "{}".to_string())],
+                    ),
+                    (
+                        "/api/v1/crates/demo".to_string(),
+                        vec![(200, r#"{"crate":{"name":"demo"}}"#.to_string())],
+                    ),
+                ]),
+                2,
+            );
+
+            let mut ws = planned_workspace(td.path(), server.base_url.clone());
+            let mut opts = default_opts(PathBuf::from(".shipper"));
+            opts.skip_ownership_check = true;
+            opts.strict_ownership = false;
+
+            let mut reporter = CollectingReporter::default();
+            let rep = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
+            assert_eq!(rep.packages.len(), 1);
+            assert!(!rep.packages[0].is_new_crate);
+            assert_eq!(
+                ws.plan.packages[0].regime,
+                Some(PublishRegime::Update),
+                "preflight should stamp Update regime on existing crates"
             );
             server.join();
         });
@@ -2576,13 +2663,13 @@ mod tests {
                 2,
             );
 
-            let ws = planned_workspace(td.path(), server.base_url.clone());
+            let mut ws = planned_workspace(td.path(), server.base_url.clone());
             let mut opts = default_opts(PathBuf::from(".shipper"));
             opts.allow_dirty = true;
             opts.skip_ownership_check = true;
 
             let mut reporter = CollectingReporter::default();
-            let _ = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
+            let _ = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
 
             let events_path = td.path().join(".shipper").join("events.jsonl");
             let log =
@@ -2657,13 +2744,13 @@ mod tests {
                 2,
             );
 
-            let ws = planned_workspace(td.path(), server.base_url.clone());
+            let mut ws = planned_workspace(td.path(), server.base_url.clone());
             let mut opts = default_opts(PathBuf::from(".shipper"));
             opts.allow_dirty = true;
             opts.skip_ownership_check = true;
 
             let mut reporter = CollectingReporter::default();
-            let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
+            let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
 
             assert!(!report.token_detected);
             assert_eq!(
@@ -2697,13 +2784,13 @@ mod tests {
                 2,
             );
 
-            let ws = planned_workspace(td.path(), server.base_url.clone());
+            let mut ws = planned_workspace(td.path(), server.base_url.clone());
             let mut opts = default_opts(PathBuf::from(".shipper"));
             opts.allow_dirty = false;
             opts.skip_ownership_check = true;
 
             let mut reporter = CollectingReporter::default();
-            let rep = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
+            let rep = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
             assert_eq!(rep.packages.len(), 1);
             server.join();
         });
@@ -3525,13 +3612,13 @@ mod tests {
                     ]),
                     2,
                 );
-                let ws = planned_workspace(td.path(), server.base_url.clone());
+                let mut ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.allow_dirty = true;
                 opts.skip_ownership_check = true;
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
 
                 assert_eq!(report.packages.len(), 1);
                 assert!(report.packages[0].already_published);
@@ -3566,13 +3653,13 @@ mod tests {
                     ]),
                     2,
                 );
-                let ws = planned_workspace(td.path(), server.base_url.clone());
+                let mut ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.allow_dirty = true;
                 opts.skip_ownership_check = true;
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
 
                 assert_eq!(report.packages.len(), 1);
                 assert!(!report.packages[0].already_published);
@@ -3614,13 +3701,13 @@ mod tests {
                     ]),
                     3,
                 );
-                let ws = planned_workspace(td.path(), server.base_url.clone());
+                let mut ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.allow_dirty = true;
                 opts.skip_ownership_check = false;
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
 
                 assert_eq!(report.packages.len(), 1);
                 assert!(!report.packages[0].ownership_verified);
@@ -3657,13 +3744,13 @@ mod tests {
                     ]),
                     2,
                 );
-                let ws = planned_workspace(td.path(), server.base_url.clone());
+                let mut ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.allow_dirty = true;
                 opts.skip_ownership_check = true;
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
 
                 assert_eq!(report.packages.len(), 1);
                 assert!(!report.packages[0].dry_run_passed);
@@ -3692,14 +3779,14 @@ mod tests {
                 ("CARGO_REGISTRIES_CRATES_IO_TOKEN", None),
             ],
             || {
-                let ws = planned_workspace(td.path(), "http://127.0.0.1:9".to_string());
+                let mut ws = planned_workspace(td.path(), "http://127.0.0.1:9".to_string());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.allow_dirty = true;
                 opts.strict_ownership = true;
                 // No token set
 
                 let mut reporter = CollectingReporter::default();
-                let err = run_preflight(&ws, &opts, &mut reporter).expect_err("must fail");
+                let err = run_preflight(&mut ws, &opts, &mut reporter).expect_err("must fail");
                 assert!(
                     format!("{err:#}").contains("strict ownership requested but no token found")
                 );
@@ -3738,13 +3825,13 @@ mod tests {
                     ]),
                     3,
                 );
-                let ws = planned_workspace(td.path(), server.base_url.clone());
+                let mut ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.allow_dirty = true;
                 opts.skip_ownership_check = false;
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
 
                 assert_eq!(report.packages.len(), 1);
                 assert!(report.packages[0].ownership_verified);
@@ -3780,12 +3867,12 @@ mod tests {
                     ]),
                     2,
                 );
-                let ws = planned_workspace(td.path(), server.base_url.clone());
+                let mut ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.policy = crate::types::PublishPolicy::Fast;
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
 
                 // dry_run_passed should be true (skipped), not false (cargo would have failed)
                 assert!(report.packages[0].dry_run_passed);
@@ -3831,13 +3918,13 @@ mod tests {
                     ]),
                     2,
                 );
-                let ws = planned_workspace(td.path(), server.base_url.clone());
+                let mut ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.policy = crate::types::PublishPolicy::Balanced;
                 opts.skip_ownership_check = false; // would check in Safe, but Balanced overrides
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
 
                 // ownership_verified false (Balanced skips ownership)
                 assert!(!report.packages[0].ownership_verified);
@@ -3879,13 +3966,13 @@ mod tests {
                     ]),
                     3,
                 );
-                let ws = planned_workspace(td.path(), server.base_url.clone());
+                let mut ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.policy = crate::types::PublishPolicy::Safe;
                 opts.skip_ownership_check = false;
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
 
                 // All checks ran
                 assert!(report.packages[0].dry_run_passed);
@@ -3920,12 +4007,12 @@ mod tests {
                     ]),
                     2,
                 );
-                let ws = planned_workspace(td.path(), server.base_url.clone());
+                let mut ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.verify_mode = crate::types::VerifyMode::None;
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
 
                 // dry_run_passed is true because verify_mode=None skips it
                 assert!(report.packages[0].dry_run_passed);
@@ -3963,12 +4050,12 @@ mod tests {
                     ]),
                     2,
                 );
-                let ws = planned_workspace(td.path(), server.base_url.clone());
+                let mut ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
                 opts.verify_mode = crate::types::VerifyMode::Package;
 
                 let mut reporter = CollectingReporter::default();
-                let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
+                let report = run_preflight(&mut ws, &opts, &mut reporter).expect("preflight");
 
                 assert!(report.packages[0].dry_run_passed);
                 assert!(
@@ -4118,11 +4205,13 @@ mod tests {
                     name: "pkg1".to_string(),
                     version: "0.1.0".to_string(),
                     manifest_path: td.path().join("pkg1/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "pkg2".to_string(),
                     version: "0.1.0".to_string(),
                     manifest_path: td.path().join("pkg2/Cargo.toml"),
+                    regime: None,
                 },
             ];
 
@@ -4187,16 +4276,19 @@ mod tests {
                 name: "alpha".to_string(),
                 version: "1.0.0".to_string(),
                 manifest_path: td.path().join("alpha/Cargo.toml"),
+                regime: None,
             },
             PlannedPackage {
                 name: "beta".to_string(),
                 version: "2.0.0".to_string(),
                 manifest_path: td.path().join("beta/Cargo.toml"),
+                regime: None,
             },
             PlannedPackage {
                 name: "gamma".to_string(),
                 version: "0.3.0".to_string(),
                 manifest_path: td.path().join("gamma/Cargo.toml"),
+                regime: None,
             },
         ];
         let state_dir = td.path().join(".shipper");
@@ -4493,11 +4585,13 @@ mod tests {
                     name: "alpha".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: td.path().join("alpha/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "beta".to_string(),
                     version: "2.0.0".to_string(),
                     manifest_path: td.path().join("beta/Cargo.toml"),
+                    regime: None,
                 },
             ];
             let opts = default_opts(PathBuf::from(".shipper"));
@@ -4811,11 +4905,13 @@ mod tests {
                     name: "alpha".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: td.path().join("alpha/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "beta".to_string(),
                     version: "2.0.0".to_string(),
                     manifest_path: td.path().join("beta/Cargo.toml"),
+                    regime: None,
                 },
             ];
             let mut opts = default_opts(PathBuf::from(".shipper"));
@@ -4864,11 +4960,13 @@ mod tests {
                     name: "alpha".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: td.path().join("alpha/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "beta".to_string(),
                     version: "2.0.0".to_string(),
                     manifest_path: td.path().join("beta/Cargo.toml"),
+                    regime: None,
                 },
             ];
 
@@ -5528,6 +5626,7 @@ mod tests {
                         name: name.to_string(),
                         version: ver.to_string(),
                         manifest_path: workspace_root.join(*name).join("Cargo.toml"),
+                        regime: None,
                     })
                     .collect(),
                 dependencies: std::collections::BTreeMap::new(),
@@ -6511,16 +6610,19 @@ mod tests {
                 name: "alpha".to_string(),
                 version: "1.0.0".to_string(),
                 manifest_path: td.path().join("alpha/Cargo.toml"),
+                regime: None,
             },
             PlannedPackage {
                 name: "beta".to_string(),
                 version: "2.0.0".to_string(),
                 manifest_path: td.path().join("beta/Cargo.toml"),
+                regime: None,
             },
             PlannedPackage {
                 name: "gamma".to_string(),
                 version: "0.3.0".to_string(),
                 manifest_path: td.path().join("gamma/Cargo.toml"),
+                regime: None,
             },
         ];
         let state_dir = td.path().join(".shipper");
@@ -6553,11 +6655,13 @@ mod tests {
                 name: "alpha".to_string(),
                 version: "1.0.0".to_string(),
                 manifest_path: td.path().join("alpha/Cargo.toml"),
+                regime: None,
             },
             PlannedPackage {
                 name: "beta".to_string(),
                 version: "2.0.0".to_string(),
                 manifest_path: td.path().join("beta/Cargo.toml"),
+                regime: None,
             },
         ];
         let state_dir = td.path().join(".shipper");

--- a/crates/shipper-core/src/engine/parallel/publish.rs
+++ b/crates/shipper-core/src/engine/parallel/publish.rs
@@ -23,8 +23,8 @@ use crate::state::execution_state as state;
 use shipper_registry::HttpRegistryClient as RegistryClient;
 use shipper_types::{
     AttemptEvidence, ErrorClass, EventType, ExecutionState, PackageEvidence, PackageReceipt,
-    PackageState, PlannedPackage, PublishEvent, PublishLevel, ReadinessConfig, ReadinessEvidence,
-    ReconciliationOutcome, RuntimeOptions,
+    PackageState, PlannedPackage, PublishEvent, PublishLevel, PublishRegime, ReadinessConfig,
+    ReadinessEvidence, ReconciliationOutcome, RuntimeOptions,
 };
 
 use super::Reporter;
@@ -341,11 +341,16 @@ pub(super) fn publish_package(
         }
     }
 
-    // Registry-aware backoff (#94): lazy-cached answer to "is this a brand-new
-    // crate?" — only consulted when a retry's error message looks like a
-    // rate-limit signal. Lazy so the happy path costs zero extra registry
-    // calls, cached so we don't re-query across retries of the same package.
-    let mut is_new_crate_cached: Option<bool> = None;
+    // Registry-aware backoff (#94 / #106 PR 1): prefer the `PublishRegime`
+    // that preflight stamped onto the `PlannedPackage`. That answer is
+    // authoritative; when it is present we never re-query the registry
+    // mid-retry for "is this a brand-new crate?"
+    //
+    // `None` here means an older plan / state.json predating the regime
+    // field, or a test harness that constructed a `PlannedPackage`
+    // directly without populating it. In that case we fall back to the
+    // legacy lazy-cached behavior so we remain backward compatible.
+    let mut is_new_crate_cached: Option<bool> = p.regime.map(PublishRegime::is_new_crate);
 
     while attempt < opts.max_attempts {
         attempt += 1;

--- a/crates/shipper-core/src/engine/parallel/tests.rs
+++ b/crates/shipper-core/src/engine/parallel/tests.rs
@@ -148,6 +148,7 @@ fn planned_workspace(workspace_root: &Path, api_base: String) -> PlannedWorkspac
                 name: "demo".to_string(),
                 version: "0.1.0".to_string(),
                 manifest_path: workspace_root.join("demo").join("Cargo.toml"),
+                regime: None,
             }],
             dependencies: BTreeMap::new(),
         },
@@ -527,11 +528,13 @@ fn test_run_publish_level_processes_packages() {
                     name: "alpha".to_string(),
                     version: "0.1.0".to_string(),
                     manifest_path: td.path().join("alpha").join("Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "beta".to_string(),
                     version: "0.2.0".to_string(),
                     manifest_path: td.path().join("beta").join("Cargo.toml"),
+                    regime: None,
                 },
             ],
             dependencies: BTreeMap::new(),
@@ -714,11 +717,13 @@ fn test_run_publish_parallel_multiple_levels() {
                     name: "base".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: td.path().join("base").join("Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "dependent".to_string(),
                     version: "2.0.0".to_string(),
                     manifest_path: td.path().join("dependent").join("Cargo.toml"),
+                    regime: None,
                 },
             ],
             dependencies: BTreeMap::from([("dependent".to_string(), vec!["base".to_string()])]),
@@ -985,6 +990,7 @@ fn test_run_publish_level_respects_max_concurrent() {
             name: name.to_string(),
             version: "0.1.0".to_string(),
             manifest_path: td.path().join(name).join("Cargo.toml"),
+            regime: None,
         })
         .collect();
 
@@ -1126,16 +1132,19 @@ fn test_levels_execute_in_dependency_order() {
                     name: "a".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: td.path().join("a").join("Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "b".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: td.path().join("b").join("Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "c".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: td.path().join("c").join("Cargo.toml"),
+                    regime: None,
                 },
             ],
             dependencies: BTreeMap::from([
@@ -1245,11 +1254,13 @@ fn test_failed_level_stops_subsequent_levels() {
                     name: "base".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: td.path().join("base").join("Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "dependent".to_string(),
                     version: "2.0.0".to_string(),
                     manifest_path: td.path().join("dependent").join("Cargo.toml"),
+                    regime: None,
                 },
             ],
             dependencies: BTreeMap::from([("dependent".to_string(), vec!["base".to_string()])]),
@@ -1350,11 +1361,13 @@ fn test_partial_success_within_level() {
             name: "alpha".to_string(),
             version: "0.1.0".to_string(),
             manifest_path: td.path().join("alpha").join("Cargo.toml"),
+            regime: None,
         },
         PlannedPackage {
             name: "beta".to_string(),
             version: "0.1.0".to_string(),
             manifest_path: td.path().join("beta").join("Cargo.toml"),
+            regime: None,
         },
     ];
 
@@ -1572,11 +1585,13 @@ fn test_resume_from_skips_earlier_levels() {
                     name: "base".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: td.path().join("base").join("Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "dependent".to_string(),
                     version: "2.0.0".to_string(),
                     manifest_path: td.path().join("dependent").join("Cargo.toml"),
+                    regime: None,
                 },
             ],
             dependencies: BTreeMap::from([("dependent".to_string(), vec!["base".to_string()])]),
@@ -1707,16 +1722,19 @@ fn test_all_packages_already_published() {
                     name: "core".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: td.path().join("core").join("Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "utils".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: td.path().join("utils").join("Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "app".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: td.path().join("app").join("Cargo.toml"),
+                    regime: None,
                 },
             ],
             dependencies: BTreeMap::from([(
@@ -1828,6 +1846,7 @@ fn test_max_concurrency_one_serializes_execution() {
             name: name.to_string(),
             version: "0.1.0".to_string(),
             manifest_path: td.path().join(name).join("Cargo.toml"),
+            regime: None,
         })
         .collect();
 
@@ -2188,16 +2207,19 @@ mod snapshot_tests {
                     name: "a".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("/ws/a/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "b".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("/ws/b/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "c".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("/ws/c/Cargo.toml"),
+                    regime: None,
                 },
             ],
             dependencies: BTreeMap::from([
@@ -2238,21 +2260,25 @@ mod snapshot_tests {
                     name: "a".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("/ws/a/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "b".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("/ws/b/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "c".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("/ws/c/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "d".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("/ws/d/Cargo.toml"),
+                    regime: None,
                 },
             ],
             dependencies: BTreeMap::from([
@@ -2293,31 +2319,37 @@ mod snapshot_tests {
                     name: "core".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("/ws/core/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "cli".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("/ws/cli/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "web".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("/ws/web/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "api".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("/ws/api/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "worker".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("/ws/worker/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "bench".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("/ws/bench/Cargo.toml"),
+                    regime: None,
                 },
             ],
             dependencies: BTreeMap::from([
@@ -2360,21 +2392,25 @@ mod snapshot_tests {
                     name: "utils-a".to_string(),
                     version: "0.1.0".to_string(),
                     manifest_path: PathBuf::from("/ws/utils-a/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "utils-b".to_string(),
                     version: "0.2.0".to_string(),
                     manifest_path: PathBuf::from("/ws/utils-b/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "utils-c".to_string(),
                     version: "0.3.0".to_string(),
                     manifest_path: PathBuf::from("/ws/utils-c/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "utils-d".to_string(),
                     version: "0.4.0".to_string(),
                     manifest_path: PathBuf::from("/ws/utils-d/Cargo.toml"),
+                    regime: None,
                 },
             ],
             dependencies: BTreeMap::new(),
@@ -2457,21 +2493,25 @@ fn test_levels_are_sequentially_numbered() {
                 name: "a".to_string(),
                 version: "1.0.0".to_string(),
                 manifest_path: PathBuf::from("a/Cargo.toml"),
+                regime: None,
             },
             PlannedPackage {
                 name: "b".to_string(),
                 version: "1.0.0".to_string(),
                 manifest_path: PathBuf::from("b/Cargo.toml"),
+                regime: None,
             },
             PlannedPackage {
                 name: "c".to_string(),
                 version: "1.0.0".to_string(),
                 manifest_path: PathBuf::from("c/Cargo.toml"),
+                regime: None,
             },
             PlannedPackage {
                 name: "d".to_string(),
                 version: "1.0.0".to_string(),
                 manifest_path: PathBuf::from("d/Cargo.toml"),
+                regime: None,
             },
         ],
         dependencies: BTreeMap::from([
@@ -2505,16 +2545,19 @@ fn test_level_ordering_dependencies_precede_dependents() {
                 name: "core".to_string(),
                 version: "1.0.0".to_string(),
                 manifest_path: PathBuf::from("core/Cargo.toml"),
+                regime: None,
             },
             PlannedPackage {
                 name: "utils".to_string(),
                 version: "1.0.0".to_string(),
                 manifest_path: PathBuf::from("utils/Cargo.toml"),
+                regime: None,
             },
             PlannedPackage {
                 name: "app".to_string(),
                 version: "1.0.0".to_string(),
                 manifest_path: PathBuf::from("app/Cargo.toml"),
+                regime: None,
             },
         ],
         dependencies: BTreeMap::from([
@@ -2569,16 +2612,19 @@ fn test_all_packages_same_level_no_deps() {
                 name: "foo".to_string(),
                 version: "1.0.0".to_string(),
                 manifest_path: PathBuf::from("foo/Cargo.toml"),
+                regime: None,
             },
             PlannedPackage {
                 name: "bar".to_string(),
                 version: "1.0.0".to_string(),
                 manifest_path: PathBuf::from("bar/Cargo.toml"),
+                regime: None,
             },
             PlannedPackage {
                 name: "baz".to_string(),
                 version: "1.0.0".to_string(),
                 manifest_path: PathBuf::from("baz/Cargo.toml"),
+                regime: None,
             },
         ],
         dependencies: BTreeMap::new(),
@@ -2608,26 +2654,31 @@ fn test_linear_chain_produces_n_levels() {
                 name: "l1".to_string(),
                 version: "0.1.0".to_string(),
                 manifest_path: PathBuf::from("l1/Cargo.toml"),
+                regime: None,
             },
             PlannedPackage {
                 name: "l2".to_string(),
                 version: "0.1.0".to_string(),
                 manifest_path: PathBuf::from("l2/Cargo.toml"),
+                regime: None,
             },
             PlannedPackage {
                 name: "l3".to_string(),
                 version: "0.1.0".to_string(),
                 manifest_path: PathBuf::from("l3/Cargo.toml"),
+                regime: None,
             },
             PlannedPackage {
                 name: "l4".to_string(),
                 version: "0.1.0".to_string(),
                 manifest_path: PathBuf::from("l4/Cargo.toml"),
+                regime: None,
             },
             PlannedPackage {
                 name: "l5".to_string(),
                 version: "0.1.0".to_string(),
                 manifest_path: PathBuf::from("l5/Cargo.toml"),
+                regime: None,
             },
         ],
         dependencies: BTreeMap::from([
@@ -2684,16 +2735,19 @@ fn test_error_in_first_level_prevents_all_subsequent() {
                     name: "a".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: td.path().join("a").join("Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "b".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: td.path().join("b").join("Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "c".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: td.path().join("c").join("Cargo.toml"),
+                    regime: None,
                 },
             ],
             dependencies: BTreeMap::from([
@@ -2831,6 +2885,7 @@ fn test_all_independent_packages_single_level() {
             name: format!("pkg-{i}"),
             version: "1.0.0".to_string(),
             manifest_path: PathBuf::from(format!("pkg-{i}/Cargo.toml")),
+            regime: None,
         })
         .collect();
 
@@ -2858,6 +2913,7 @@ fn test_wide_fan_out_two_levels() {
         name: "root".to_string(),
         version: "1.0.0".to_string(),
         manifest_path: PathBuf::from("root/Cargo.toml"),
+        regime: None,
     }];
     let mut deps = BTreeMap::new();
     for i in 0..6 {
@@ -2866,6 +2922,7 @@ fn test_wide_fan_out_two_levels() {
             name: name.clone(),
             version: "1.0.0".to_string(),
             manifest_path: PathBuf::from(format!("{name}/Cargo.toml")),
+            regime: None,
         });
         deps.insert(name, vec!["root".to_string()]);
     }
@@ -2897,6 +2954,7 @@ fn test_deep_chain_produces_n_levels() {
             name: format!("c{i}"),
             version: "1.0.0".to_string(),
             manifest_path: PathBuf::from(format!("c{i}/Cargo.toml")),
+            regime: None,
         })
         .collect();
     let mut deps = BTreeMap::new();
@@ -2956,6 +3014,7 @@ fn test_max_concurrent_exceeds_package_count() {
             name: n.to_string(),
             version: "0.1.0".to_string(),
             manifest_path: td.path().join(n).join("Cargo.toml"),
+            regime: None,
         })
         .collect();
 
@@ -3067,6 +3126,7 @@ fn test_independent_failures_both_reported() {
             name: n.to_string(),
             version: "0.1.0".to_string(),
             manifest_path: td.path().join(n).join("Cargo.toml"),
+            regime: None,
         })
         .collect();
 
@@ -3180,6 +3240,7 @@ fn test_concurrent_state_updates_consistent() {
             name: n.to_string(),
             version: "0.1.0".to_string(),
             manifest_path: td.path().join(n).join("Cargo.toml"),
+            regime: None,
         })
         .collect();
 
@@ -3485,6 +3546,7 @@ fn test_level_message_includes_max_concurrent() {
             name: n.to_string(),
             version: "0.1.0".to_string(),
             manifest_path: td.path().join(n).join("Cargo.toml"),
+            regime: None,
         })
         .collect();
 
@@ -3589,6 +3651,7 @@ fn test_state_persisted_to_disk_after_level() {
                 name: "saved".to_string(),
                 version: "0.1.0".to_string(),
                 manifest_path: td.path().join("saved").join("Cargo.toml"),
+                regime: None,
             }],
             ..ws.plan
         },
@@ -3664,6 +3727,7 @@ mod property_tests_extra {
                     name: n.clone(),
                     version: "0.1.0".to_string(),
                     manifest_path: PathBuf::from(format!("{}/Cargo.toml", n)),
+                    regime: None,
                 })
                 .collect();
 
@@ -3690,6 +3754,7 @@ mod property_tests_extra {
                     name: n.clone(),
                     version: "0.1.0".to_string(),
                     manifest_path: PathBuf::from(format!("{}/Cargo.toml", n)),
+                    regime: None,
                 })
                 .collect();
 
@@ -3719,6 +3784,7 @@ mod property_tests_extra {
                     name: format!("p{i}"),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from(format!("p{i}/Cargo.toml")),
+                    regime: None,
                 })
                 .collect();
 
@@ -3782,6 +3848,7 @@ mod property_tests_extra {
                     name: format!("ind{i}"),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from(format!("ind{i}/Cargo.toml")),
+                    regime: None,
                 })
                 .collect();
 

--- a/crates/shipper-core/src/plan/mod.rs
+++ b/crates/shipper-core/src/plan/mod.rs
@@ -199,6 +199,7 @@ pub fn build_plan(spec: &ReleaseSpec) -> Result<PlannedWorkspace> {
                 name: pkg.name.to_string(),
                 version: pkg.version.to_string(),
                 manifest_path: pkg.manifest_path.clone().into_std_path_buf(),
+                regime: None,
             }
         })
         .collect();
@@ -846,11 +847,13 @@ edition = "2021"
             name: "foo".to_string(),
             version: "1.0.0".to_string(),
             manifest_path: PathBuf::from("foo/Cargo.toml"),
+            regime: None,
         }];
         let pkgs_b = vec![PlannedPackage {
             name: "bar".to_string(),
             version: "1.0.0".to_string(),
             manifest_path: PathBuf::from("bar/Cargo.toml"),
+            regime: None,
         }];
         let id_a = compute_plan_id("https://crates.io", &pkgs_a);
         let id_b = compute_plan_id("https://crates.io", &pkgs_b);
@@ -863,6 +866,7 @@ edition = "2021"
             name: "foo".to_string(),
             version: "1.0.0".to_string(),
             manifest_path: PathBuf::from("foo/Cargo.toml"),
+            regime: None,
         }];
         let id1 = compute_plan_id("https://crates.io", &pkgs);
         let id2 = compute_plan_id("https://private.example.com", &pkgs);
@@ -875,11 +879,13 @@ edition = "2021"
             name: "foo".to_string(),
             version: "1.0.0".to_string(),
             manifest_path: PathBuf::from("foo/Cargo.toml"),
+            regime: None,
         }];
         let pkgs2 = vec![PlannedPackage {
             name: "foo".to_string(),
             version: "2.0.0".to_string(),
             manifest_path: PathBuf::from("foo/Cargo.toml"),
+            regime: None,
         }];
         let id1 = compute_plan_id("https://crates.io", &pkgs1);
         let id2 = compute_plan_id("https://crates.io", &pkgs2);
@@ -2093,11 +2099,13 @@ core = { path = "../core", version = "2.5.0" }
             name: "foo".to_string(),
             version: "1.0.0".to_string(),
             manifest_path: PathBuf::from("a/Cargo.toml"),
+            regime: None,
         }];
         let pkgs_b = vec![PlannedPackage {
             name: "fo".to_string(),
             version: "o1.0.0".to_string(),
             manifest_path: PathBuf::from("b/Cargo.toml"),
+            regime: None,
         }];
         let id_a = compute_plan_id("https://crates.io", &pkgs_a);
         let id_b = compute_plan_id("https://crates.io", &pkgs_b);
@@ -2112,11 +2120,13 @@ core = { path = "../core", version = "2.5.0" }
             name: "aaa".to_string(),
             version: "1.0.0".to_string(),
             manifest_path: PathBuf::from("a/Cargo.toml"),
+            regime: None,
         };
         let pkg_b = PlannedPackage {
             name: "bbb".to_string(),
             version: "1.0.0".to_string(),
             manifest_path: PathBuf::from("b/Cargo.toml"),
+            regime: None,
         };
         let id_ab = compute_plan_id("https://crates.io", &[pkg_a.clone(), pkg_b.clone()]);
         let id_ba = compute_plan_id("https://crates.io", &[pkg_b, pkg_a]);
@@ -2132,11 +2142,13 @@ core = { path = "../core", version = "2.5.0" }
                 name: "x".to_string(),
                 version: "0.0.1".to_string(),
                 manifest_path: PathBuf::from("x/Cargo.toml"),
+                regime: None,
             },
             PlannedPackage {
                 name: "y".to_string(),
                 version: "0.0.2".to_string(),
                 manifest_path: PathBuf::from("y/Cargo.toml"),
+                regime: None,
             },
         ];
         let id = compute_plan_id("https://example.com", &pkgs);
@@ -2196,6 +2208,7 @@ core = { path = "../core", version = "2.5.0" }
                     name: name.clone(),
                     version: format!("{}.{}.{}", major, minor, patch),
                     manifest_path: Path::new("x").join(format!("{name}.toml")),
+                    regime: None,
                 })
                 .collect();
 
@@ -2217,6 +2230,7 @@ core = { path = "../core", version = "2.5.0" }
                     name: format!("crate-{i}"),
                     version: format!("{i}.0.0"),
                     manifest_path: Path::new("x").join(format!("crate-{i}.toml")),
+                    regime: None,
                 })
                 .collect();
 
@@ -2292,11 +2306,13 @@ core = { path = "../core", version = "2.5.0" }
                 name: name_a,
                 version: format!("{ver_a}.0.0"),
                 manifest_path: Path::new("a").join("Cargo.toml"),
+                regime: None,
             }];
             let pkgs_b = vec![PlannedPackage {
                 name: name_b,
                 version: format!("{ver_b}.0.0"),
                 manifest_path: Path::new("b").join("Cargo.toml"),
+                regime: None,
             }];
             let id_a = compute_plan_id("https://crates.io", &pkgs_a);
             let id_b = compute_plan_id("https://crates.io", &pkgs_b);
@@ -3283,6 +3299,7 @@ resolver = "2"
             name: "foo".to_string(),
             version: "1.0.0".to_string(),
             manifest_path: PathBuf::from("foo/Cargo.toml"),
+            regime: None,
         };
         let id_one = compute_plan_id("https://crates.io", std::slice::from_ref(&pkg));
         let id_two = compute_plan_id("https://crates.io", &[pkg.clone(), pkg]);

--- a/crates/shipper-core/src/property_tests.rs
+++ b/crates/shipper-core/src/property_tests.rs
@@ -205,6 +205,7 @@ mod topo_invariant_tests {
             name: name.to_string(),
             version: version.to_string(),
             manifest_path: PathBuf::from(format!("crates/{}/Cargo.toml", name)),
+            regime: None,
         }
     }
 

--- a/crates/shipper-core/src/stress_tests.rs
+++ b/crates/shipper-core/src/stress_tests.rs
@@ -21,6 +21,7 @@ mod tests {
             name: name.to_string(),
             version: version.to_string(),
             manifest_path: PathBuf::from(format!("crates/{}/Cargo.toml", name)),
+            regime: None,
         }
     }
 

--- a/crates/shipper-types/src/lib.rs
+++ b/crates/shipper-types/src/lib.rs
@@ -602,6 +602,49 @@ pub struct RuntimeOptions {
     pub rehearsal_smoke_install: Option<String>,
 }
 
+/// Classification of a publish operation, used by the runtime to make
+/// registry-aware decisions (backoff windows, duration estimation,
+/// per-regime telemetry).
+///
+/// Preflight already determines whether a crate has ever been published
+/// by querying the registry; that answer is captured here and propagated
+/// through the [`ReleasePlan`] so the publish retry loop does not have
+/// to re-query the registry to recover it.
+///
+/// # Variants
+///
+/// - [`PublishRegime::FirstPublish`]: the crate has never been published.
+///   Triggers the documented crates.io new-crate rate-limit window.
+/// - [`PublishRegime::Update`]: the crate already exists; this is a new
+///   version upload.
+///
+/// # Example
+///
+/// ```ignore
+/// use shipper::types::PublishRegime;
+///
+/// let regime = PublishRegime::FirstPublish;
+/// assert_eq!(regime.is_new_crate(), true);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PublishRegime {
+    /// Crate has never been published to this registry.
+    FirstPublish,
+    /// Crate exists; publishing a new version.
+    Update,
+}
+
+impl PublishRegime {
+    /// Convenience: `true` iff this is a first-publish regime.
+    ///
+    /// Equivalent to the preflight `is_new_crate` boolean, but carried
+    /// through the plan so later phases do not have to re-query.
+    pub fn is_new_crate(self) -> bool {
+        matches!(self, PublishRegime::FirstPublish)
+    }
+}
+
 /// A package in the publish plan.
 ///
 /// This represents a single crate that will be published as part of
@@ -618,6 +661,7 @@ pub struct RuntimeOptions {
 ///     name: "my-crate".to_string(),
 ///     version: "1.2.3".to_string(),
 ///     manifest_path: PathBuf::from("crates/my-crate/Cargo.toml"),
+///     regime: None,
 /// };
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -625,6 +669,15 @@ pub struct PlannedPackage {
     pub name: String,
     pub version: String,
     pub manifest_path: PathBuf,
+    /// Publish-regime classification produced by preflight (#106).
+    ///
+    /// Optional for backward compatibility with state.json / plan files
+    /// written by earlier versions that predate this field. When
+    /// `None`, the publish retry loop falls back to re-querying the
+    /// registry on rate-limit errors; when `Some`, no re-query is
+    /// performed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub regime: Option<PublishRegime>,
 }
 
 /// A group of packages that can be published in parallel.
@@ -2028,6 +2081,77 @@ mod tests {
         }
     }
 
+    // ===== PublishRegime / PlannedPackage backward compatibility (#106 PR 1) =====
+
+    /// A plan serialized before the `regime` field existed must still
+    /// deserialize cleanly. The field is `Option`, `serde(default)`, and
+    /// `skip_serializing_if = Option::is_none`, which together guarantee
+    /// forward and backward compatibility with existing state.json and
+    /// plan files.
+    #[test]
+    fn planned_package_backward_compat_no_regime_field() {
+        // Simulate a plan written by an older version of shipper that
+        // did not emit the `regime` field at all.
+        let legacy_json = r#"{
+            "name": "legacy-crate",
+            "version": "0.1.0",
+            "manifest_path": "crates/legacy-crate/Cargo.toml"
+        }"#;
+        let parsed: PlannedPackage = serde_json::from_str(legacy_json).unwrap();
+        assert_eq!(parsed.name, "legacy-crate");
+        assert_eq!(parsed.version, "0.1.0");
+        assert!(
+            parsed.regime.is_none(),
+            "missing regime should deserialize to None for backward compat"
+        );
+    }
+
+    /// When `regime` is `None`, serialization must omit the field
+    /// entirely (not emit `"regime": null`). This preserves byte-for-byte
+    /// compatibility of plan / state snapshots for readers that do not
+    /// know about the field.
+    #[test]
+    fn planned_package_regime_none_is_skipped_in_serialization() {
+        let pkg = PlannedPackage {
+            name: "demo".to_string(),
+            version: "0.1.0".to_string(),
+            manifest_path: PathBuf::from("Cargo.toml"),
+            regime: None,
+        };
+        let json = serde_json::to_string(&pkg).unwrap();
+        assert!(
+            !json.contains("regime"),
+            "None regime should be skipped, got: {json}"
+        );
+    }
+
+    /// When `regime` is `Some(...)`, it must round-trip cleanly and use
+    /// the documented snake_case wire format.
+    #[test]
+    fn planned_package_regime_some_round_trips() {
+        for regime in [PublishRegime::FirstPublish, PublishRegime::Update] {
+            let pkg = PlannedPackage {
+                name: "demo".to_string(),
+                version: "0.1.0".to_string(),
+                manifest_path: PathBuf::from("Cargo.toml"),
+                regime: Some(regime),
+            };
+            let json = serde_json::to_string(&pkg).unwrap();
+            assert!(
+                json.contains("\"regime\""),
+                "regime must be present: {json}"
+            );
+            let parsed: PlannedPackage = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed.regime, Some(regime));
+        }
+    }
+
+    #[test]
+    fn publish_regime_is_new_crate_matches_variant() {
+        assert!(PublishRegime::FirstPublish.is_new_crate());
+        assert!(!PublishRegime::Update.is_new_crate());
+    }
+
     // ===== ReleasePlan determinism =====
 
     #[test]
@@ -2042,11 +2166,13 @@ mod tests {
                     name: "alpha".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("crates/alpha/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "beta".to_string(),
                     version: "2.0.0".to_string(),
                     manifest_path: PathBuf::from("crates/beta/Cargo.toml"),
+                    regime: None,
                 },
             ],
             dependencies: BTreeMap::from([("beta".to_string(), vec!["alpha".to_string()])]),
@@ -2074,6 +2200,7 @@ mod tests {
                 name: "standalone".to_string(),
                 version: "0.1.0".to_string(),
                 manifest_path: PathBuf::from("Cargo.toml"),
+                regime: None,
             }],
             dependencies: BTreeMap::new(),
         };
@@ -2093,6 +2220,7 @@ mod tests {
                 name: "solo".to_string(),
                 version: "1.0.0".to_string(),
                 manifest_path: PathBuf::from("Cargo.toml"),
+                regime: None,
             }],
             dependencies: BTreeMap::new(),
         };
@@ -2115,16 +2243,19 @@ mod tests {
                     name: "a".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("a/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "b".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("b/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "c".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("c/Cargo.toml"),
+                    regime: None,
                 },
             ],
             dependencies: BTreeMap::from([
@@ -2154,16 +2285,19 @@ mod tests {
                     name: "x".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("x/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "y".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("y/Cargo.toml"),
+                    regime: None,
                 },
                 PlannedPackage {
                     name: "z".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("z/Cargo.toml"),
+                    regime: None,
                 },
             ],
             dependencies: BTreeMap::new(),
@@ -2928,11 +3062,13 @@ mod tests {
                         name: "core-lib".to_string(),
                         version: "0.1.0".to_string(),
                         manifest_path: PathBuf::from("crates/core-lib/Cargo.toml"),
+                        regime: None,
                     },
                     PlannedPackage {
                         name: "my-cli".to_string(),
                         version: "0.2.0".to_string(),
                         manifest_path: PathBuf::from("crates/my-cli/Cargo.toml"),
+                        regime: None,
                     },
                 ],
                 dependencies: BTreeMap::from([(
@@ -3112,6 +3248,7 @@ mod tests {
                     name: "solo-crate".to_string(),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("Cargo.toml"),
+                    regime: None,
                 }],
                 dependencies: BTreeMap::new(),
             };
@@ -3134,11 +3271,13 @@ mod tests {
                         name: "internal-utils".to_string(),
                         version: "2.1.0".to_string(),
                         manifest_path: PathBuf::from("crates/internal-utils/Cargo.toml"),
+                        regime: None,
                     },
                     PlannedPackage {
                         name: "internal-api".to_string(),
                         version: "3.0.0".to_string(),
                         manifest_path: PathBuf::from("crates/internal-api/Cargo.toml"),
+                        regime: None,
                     },
                 ],
                 dependencies: BTreeMap::from([(
@@ -3161,21 +3300,25 @@ mod tests {
                         name: "foundation".to_string(),
                         version: "0.1.0".to_string(),
                         manifest_path: PathBuf::from("crates/foundation/Cargo.toml"),
+                        regime: None,
                     },
                     PlannedPackage {
                         name: "middleware".to_string(),
                         version: "0.2.0".to_string(),
                         manifest_path: PathBuf::from("crates/middleware/Cargo.toml"),
+                        regime: None,
                     },
                     PlannedPackage {
                         name: "service".to_string(),
                         version: "0.3.0".to_string(),
                         manifest_path: PathBuf::from("crates/service/Cargo.toml"),
+                        regime: None,
                     },
                     PlannedPackage {
                         name: "gateway".to_string(),
                         version: "1.0.0".to_string(),
                         manifest_path: PathBuf::from("crates/gateway/Cargo.toml"),
+                        regime: None,
                     },
                 ],
                 dependencies: BTreeMap::from([
@@ -4193,6 +4336,7 @@ mod tests {
                     name,
                     version,
                     manifest_path: PathBuf::from("crates/test/Cargo.toml"),
+                    regime: None,
                 };
                 let json = serde_json::to_string(&pkg).unwrap();
                 let parsed: PlannedPackage = serde_json::from_str(&json).unwrap();
@@ -4212,6 +4356,7 @@ mod tests {
                         name: format!("crate-{i}"),
                         version: format!("{i}.0.0"),
                         manifest_path: PathBuf::from(format!("crates/crate-{i}/Cargo.toml")),
+                        regime: None,
                     })
                     .collect();
                 let lvl = PublishLevel { level, packages };
@@ -4232,6 +4377,7 @@ mod tests {
                         name: format!("crate-{i}"),
                         version: format!("{i}.0.0"),
                         manifest_path: PathBuf::from(format!("crates/crate-{i}/Cargo.toml")),
+                        regime: None,
                     })
                     .collect();
                 let mut deps = BTreeMap::new();
@@ -4672,6 +4818,7 @@ mod tests {
                         name: format!("crate-{}-{}", seed, i),
                         version: format!("{}.0.0", i),
                         manifest_path: PathBuf::from(format!("crates/crate-{i}/Cargo.toml")),
+                        regime: None,
                     })
                     .collect();
 
@@ -4702,11 +4849,13 @@ mod tests {
                     name: format!("crate-a-{seed}"),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("Cargo.toml"),
+                    regime: None,
                 }];
                 let pkgs_b = vec![PlannedPackage {
                     name: format!("crate-b-{seed}"),
                     version: "1.0.0".to_string(),
                     manifest_path: PathBuf::from("Cargo.toml"),
+                    regime: None,
                 }];
 
                 let id_a = compute_plan_id(&pkgs_a, "crates-io");
@@ -4911,6 +5060,7 @@ mod tests {
                     name: "test-crate".to_string(),
                     version: version.clone(),
                     manifest_path: PathBuf::from("Cargo.toml"),
+                    regime: None,
                 };
                 let json = serde_json::to_string(&pkg).unwrap();
                 let parsed: PlannedPackage = serde_json::from_str(&json).unwrap();
@@ -4936,6 +5086,7 @@ mod tests {
                         name: format!("crate-{i}"),
                         version: format!("{}.0.0", i + 1),
                         manifest_path: PathBuf::from(format!("crates/crate-{i}/Cargo.toml")),
+                        regime: None,
                     })
                     .collect();
                 let mut deps = BTreeMap::new();
@@ -5474,6 +5625,7 @@ mod tests {
                         name: format!("crate-{i}"),
                         version: format!("0.{i}.0"),
                         manifest_path: PathBuf::from(format!("crates/crate-{i}/Cargo.toml")),
+                        regime: None,
                     })
                     .collect();
 
@@ -5516,6 +5668,7 @@ mod tests {
                         name: format!("crate-{i}"),
                         version: format!("0.{i}.0"),
                         manifest_path: PathBuf::from(format!("crates/crate-{i}/Cargo.toml")),
+                        regime: None,
                     })
                     .collect();
 
@@ -5573,6 +5726,7 @@ mod tests {
                         name: format!("crate-{i}"),
                         version: format!("0.{i}.0"),
                         manifest_path: PathBuf::from(format!("crates/crate-{i}/Cargo.toml")),
+                        regime: None,
                     })
                     .collect();
 

--- a/crates/shipper-types/tests/release_levels_integration.rs
+++ b/crates/shipper-types/tests/release_levels_integration.rs
@@ -9,6 +9,7 @@ fn pkg(name: &str) -> PlannedPackage {
         name: name.to_string(),
         version: "0.1.0".to_string(),
         manifest_path: PathBuf::from(format!("crates/{name}/Cargo.toml")),
+        regime: None,
     }
 }
 


### PR DESCRIPTION
## Summary

PR 1 of the 5-PR sequence outlined by the scout on issue #106. Threads a new `PublishRegime` enum (`FirstPublish` | `Update`) from preflight onto each `PlannedPackage` so the publish retry loop can answer "is this a brand-new crate?" by reading the plan instead of re-querying the registry on every rate-limit retry.

This eliminates the `is_new_crate_cached` re-query waste called out by the scout's plan and unblocks PRs 2-5 (RegistryProfile, Retry-After parsing, duration estimation, per-crate tuning).

## Changes

- **`shipper-types`**: new `PublishRegime` enum (`FirstPublish` | `Update`) with `is_new_crate()` helper and round-trip serde tests.
- **`PlannedPackage`**: gains `regime: Option<PublishRegime>`.
- **`engine::run_preflight`**: now takes `&mut PlannedWorkspace` and stamps the detected regime onto each package after the existing registry probes; new tests cover both FirstPublish and Update stamping.
- **`engine::publish_package`** (sequential and parallel): seeds `is_new_crate_cached` from `p.regime` when present, falling back to the legacy lazy-cached re-query when `None`.
- **CLI**: passes `&mut planned` to `run_preflight`.
- All call sites and constructors of `PlannedPackage` (production + tests + property/stress tests) updated with `regime: None` to remain compilable.

## Backward compatibility

The new field is gated by `#[serde(default, skip_serializing_if = \"Option::is_none\")]`:

- **Read**: legacy `state.json` / plan files written before this PR deserialize cleanly with `regime: None`.
- **Write**: when `regime` is `None`, the field is omitted entirely (no `\"regime\": null`), so snapshots stay byte-for-byte identical for callers that never set it.
- **Behavior**: the `None` branch in publish_package preserves the legacy `is_new_crate_cached` re-query path verbatim, so any embedder constructing `PlannedPackage` directly retains today's behavior.

Three serde tests in `shipper-types` lock this in:
- `planned_package_backward_compat_no_regime_field` — legacy JSON deserializes cleanly with `regime: None`.
- `planned_package_regime_none_is_skipped_in_serialization` — `None` is omitted on serialize.
- `planned_package_regime_some_round_trips` — both variants round-trip via snake_case wire format.

## Acceptance criteria (from #106 PR 1)

- [x] `PublishRegime` defined with `FirstPublish` and `Update` variants
- [x] `PlannedPackage.regime` plumbed through plan -> preflight -> publish
- [x] Preflight stamps regime based on registry probes (FirstPublish vs Update)
- [x] Publish retry loop consumes regime instead of re-querying when present
- [x] Backward-compat: missing `regime` deserializes to `None` and is omitted on serialize
- [x] No regressions in plan-id computation or release-level integration tests

## Out of scope (future PRs in this sequence)

- PR 2: `RegistryProfile` abstraction encoding crates.io rate-limit constants
- PR 3: Retry-After header parsing layered above exponential backoff
- PR 4: Preflight duration estimation in user output
- PR 5: Per-crate tuning via `.shipper.toml` (defer if scope creep)
- `PublishRegime::Patch` granularity (open question from the scout's plan)

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace` — all suites pass except one pre-existing Windows-parallelism flake in `shipper-cli::cli_e2e::preflight_command_snapshot` that also fails on `main` (cargo `failed to rename .demo-0.1.0.crate to demo-0.1.0.crate` race in shared target dir); the test passes in isolation with this diff applied.
- [x] New regime tests pass:
  - `planned_package_backward_compat_no_regime_field`
  - `planned_package_regime_none_is_skipped_in_serialization`
  - `planned_package_regime_some_round_trips`
  - `publish_regime_is_new_crate_matches_variant`
  - `run_preflight_stamps_update_regime_on_existing_crate`
  - existing `run_preflight_*` first-publish test extended to assert `regime == FirstPublish`

Refs #106