### PR TITLE
feat(narrate): live retry countdown in CLI (#103 PR 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2307,6 +2307,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "console",
+ "humantime",
  "indicatif",
  "insta",
  "predicates",

--- a/crates/shipper-cli/Cargo.toml
+++ b/crates/shipper-cli/Cargo.toml
@@ -33,6 +33,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 toml = "1.0.3"
 chrono = { version = "0.4.44", features = ["serde"] }
+humantime = "2.3.0"
 
 # Shared domain types and typed config (used by CLI arg parsing +
 # surfacing engine types to operators).

--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -26,6 +26,7 @@
 //! [`run`]. For programmatic use without a `clap` dependency, depend
 //! on [`shipper_core`](https://crates.io/crates/shipper-core) instead.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
@@ -436,6 +437,7 @@ struct CliReporter {
     /// fall through to the default `Reporter::retry_wait` behavior (warn +
     /// sleep), matching subcommands that don't own a progress bar.
     progress: Option<ProgressReporter>,
+    package_positions: BTreeMap<String, usize>,
 }
 
 impl CliReporter {
@@ -443,14 +445,21 @@ impl CliReporter {
         Self {
             quiet,
             progress: None,
+            package_positions: BTreeMap::new(),
         }
     }
 
-    fn install_progress(&mut self, progress: ProgressReporter) {
+    fn install_progress(
+        &mut self,
+        progress: ProgressReporter,
+        package_positions: BTreeMap<String, usize>,
+    ) {
         self.progress = Some(progress);
+        self.package_positions = package_positions;
     }
 
     fn take_progress(&mut self) -> Option<ProgressReporter> {
+        self.package_positions.clear();
         self.progress.take()
     }
 }
@@ -488,7 +497,13 @@ impl Reporter for CliReporter {
         // non-TTY mode gets a single line. Otherwise fall back to the
         // default trait impl so callers without a progress bar still see the
         // original warn-line behavior.
-        if let Some(progress) = &self.progress {
+        if let Some(progress) = &mut self.progress {
+            if let Some(index) = self
+                .package_positions
+                .get(&format!("{pkg_name}@{pkg_version}"))
+            {
+                progress.set_package(*index, pkg_name, pkg_version);
+            }
             progress.retry_countdown(
                 pkg_name,
                 pkg_version,
@@ -710,6 +725,13 @@ pub fn run() -> Result<()> {
 
                 let total_packages = current_planned.plan.packages.len();
                 let mut progress = ProgressReporter::new(total_packages, cli.quiet);
+                let package_positions: BTreeMap<String, usize> = current_planned
+                    .plan
+                    .packages
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, pkg)| (format!("{}@{}", pkg.name, pkg.version), idx + 1))
+                    .collect();
 
                 // Show initial progress if we have packages
                 if total_packages > 0 {
@@ -720,7 +742,7 @@ pub fn run() -> Result<()> {
                 // Install the progress handle on the reporter so the engine's
                 // retry-backoff narration (#103) can drive a live TTY
                 // countdown via ProgressReporter::retry_countdown.
-                reporter.install_progress(progress);
+                reporter.install_progress(progress, package_positions);
 
                 let receipt = engine::run_publish(&current_planned, &current_opts, &mut reporter)?;
 
@@ -761,6 +783,13 @@ pub fn run() -> Result<()> {
 
                 let total_packages = current_planned.plan.packages.len();
                 let mut progress = ProgressReporter::new(total_packages, cli.quiet);
+                let package_positions: BTreeMap<String, usize> = current_planned
+                    .plan
+                    .packages
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, pkg)| (format!("{}@{}", pkg.name, pkg.version), idx + 1))
+                    .collect();
 
                 // Show initial progress if we have packages
                 if total_packages > 0 {
@@ -771,7 +800,7 @@ pub fn run() -> Result<()> {
                 // Install the progress handle on the reporter so the engine's
                 // retry-backoff narration (#103) can drive a live TTY
                 // countdown via ProgressReporter::retry_countdown.
-                reporter.install_progress(progress);
+                reporter.install_progress(progress, package_positions);
 
                 let receipt = engine::run_resume(&current_planned, &current_opts, &mut reporter)?;
 
@@ -2332,7 +2361,10 @@ mod tests {
         // delay, with no panic from the set_status path.
         use std::time::Instant;
         let mut rep = CliReporter::new(false);
-        rep.install_progress(crate::output::progress::ProgressReporter::silent(2));
+        rep.install_progress(
+            crate::output::progress::ProgressReporter::silent(2),
+            BTreeMap::from([(String::from("pkg@1.0.0"), 2usize)]),
+        );
         let delay = Duration::from_millis(40);
         let start = Instant::now();
         rep.retry_wait(
@@ -2346,6 +2378,29 @@ mod tests {
         );
         assert!(start.elapsed() >= delay);
         assert!(rep.take_progress().is_some());
+    }
+
+    #[test]
+    fn cli_reporter_retry_wait_updates_progress_to_retrying_package() {
+        let mut rep = CliReporter::new(true);
+        rep.install_progress(
+            crate::output::progress::ProgressReporter::silent(3),
+            BTreeMap::from([(String::from("beta@0.2.0"), 2usize)]),
+        );
+
+        rep.retry_wait(
+            "beta",
+            "0.2.0",
+            1,
+            3,
+            Duration::from_millis(1),
+            shipper_core::types::ErrorClass::Retryable,
+            "server busy",
+        );
+
+        let progress = rep.take_progress().expect("progress handle");
+        assert_eq!(progress.current_package(), 2);
+        assert_eq!(progress.current_name(), "beta@0.2.0");
     }
 
     #[test]

--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -430,6 +430,29 @@ enum ConfigCommands {
 
 struct CliReporter {
     quiet: bool,
+    /// Optional progress handle installed during `publish`/`resume` so
+    /// [`CliReporter::retry_wait`] can render a live countdown via the
+    /// existing `ProgressReporter::retry_countdown`. When `None`, retries
+    /// fall through to the default `Reporter::retry_wait` behavior (warn +
+    /// sleep), matching subcommands that don't own a progress bar.
+    progress: Option<ProgressReporter>,
+}
+
+impl CliReporter {
+    fn new(quiet: bool) -> Self {
+        Self {
+            quiet,
+            progress: None,
+        }
+    }
+
+    fn install_progress(&mut self, progress: ProgressReporter) {
+        self.progress = Some(progress);
+    }
+
+    fn take_progress(&mut self) -> Option<ProgressReporter> {
+        self.progress.take()
+    }
 }
 
 impl Reporter for CliReporter {
@@ -447,6 +470,45 @@ impl Reporter for CliReporter {
 
     fn error(&mut self, msg: &str) {
         eprintln!("[error] {msg}");
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn retry_wait(
+        &mut self,
+        pkg_name: &str,
+        pkg_version: &str,
+        attempt: u32,
+        max_attempts: u32,
+        delay: std::time::Duration,
+        reason: shipper_core::types::ErrorClass,
+        message: &str,
+    ) {
+        // If a progress handle is installed (publish/resume flow), route the
+        // retry narration through it so TTY mode gets a live countdown and
+        // non-TTY mode gets a single line. Otherwise fall back to the
+        // default trait impl so callers without a progress bar still see the
+        // original warn-line behavior.
+        if let Some(progress) = &self.progress {
+            progress.retry_countdown(
+                pkg_name,
+                pkg_version,
+                attempt,
+                max_attempts,
+                delay,
+                &format!("{reason:?}"),
+                message,
+            );
+        } else if !self.quiet {
+            eprintln!(
+                "[warn] {pkg_name}@{pkg_version}: {message} ({reason:?}); next attempt in {} (attempt {}/{})",
+                humantime::format_duration(delay),
+                attempt.saturating_add(1),
+                max_attempts,
+            );
+            std::thread::sleep(delay);
+        } else {
+            std::thread::sleep(delay);
+        }
     }
 }
 
@@ -612,7 +674,7 @@ pub fn run() -> Result<()> {
     let config_for_merge = config.clone().unwrap_or_default();
     let opts: RuntimeOptions = config_for_merge.build_runtime_options(cli_overrides);
 
-    let mut reporter = CliReporter { quiet: cli.quiet };
+    let mut reporter = CliReporter::new(cli.quiet);
 
     match cli.cmd {
         Commands::Plan => {
@@ -655,9 +717,16 @@ pub fn run() -> Result<()> {
                     progress.set_package(1, &first_pkg.name, &first_pkg.version);
                 }
 
+                // Install the progress handle on the reporter so the engine's
+                // retry-backoff narration (#103) can drive a live TTY
+                // countdown via ProgressReporter::retry_countdown.
+                reporter.install_progress(progress);
+
                 let receipt = engine::run_publish(&current_planned, &current_opts, &mut reporter)?;
 
-                progress.finish();
+                if let Some(progress) = reporter.take_progress() {
+                    progress.finish();
+                }
 
                 print_receipt(
                     &receipt,
@@ -699,9 +768,16 @@ pub fn run() -> Result<()> {
                     progress.set_package(1, &first_pkg.name, &first_pkg.version);
                 }
 
+                // Install the progress handle on the reporter so the engine's
+                // retry-backoff narration (#103) can drive a live TTY
+                // countdown via ProgressReporter::retry_countdown.
+                reporter.install_progress(progress);
+
                 let receipt = engine::run_resume(&current_planned, &current_opts, &mut reporter)?;
 
-                progress.finish();
+                if let Some(progress) = reporter.take_progress() {
+                    progress.finish();
+                }
 
                 print_receipt(
                     &receipt,
@@ -2200,10 +2276,80 @@ mod tests {
 
     #[test]
     fn cli_reporter_methods_are_callable() {
-        let mut rep = CliReporter { quiet: false };
+        let mut rep = CliReporter::new(false);
         rep.info("info");
         rep.warn("warn");
         rep.error("error");
+    }
+
+    #[test]
+    fn cli_reporter_retry_wait_without_progress_blocks_for_delay() {
+        // With no progress handle installed, retry_wait falls back to the
+        // legacy warn-line + sleep path. Assert it still blocks for the
+        // full delay (the engine relies on this).
+        use std::time::Instant;
+        let mut rep = CliReporter::new(true); // quiet to suppress stderr
+        let delay = Duration::from_millis(60);
+        let start = Instant::now();
+        rep.retry_wait(
+            "pkg",
+            "0.1.0",
+            1,
+            3,
+            delay,
+            shipper_core::types::ErrorClass::Retryable,
+            "rate limited",
+        );
+        assert!(
+            start.elapsed() >= delay,
+            "retry_wait returned early: {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[test]
+    fn cli_reporter_retry_wait_with_progress_routes_through_countdown() {
+        // Installing a (silent) progress handle should route retry_wait
+        // through ProgressReporter::retry_countdown — still blocks for the
+        // delay, with no panic from the set_status path.
+        use std::time::Instant;
+        let mut rep = CliReporter::new(false);
+        rep.install_progress(crate::output::progress::ProgressReporter::silent(2));
+        let delay = Duration::from_millis(40);
+        let start = Instant::now();
+        rep.retry_wait(
+            "pkg",
+            "1.0.0",
+            2,
+            5,
+            delay,
+            shipper_core::types::ErrorClass::Retryable,
+            "server busy",
+        );
+        assert!(start.elapsed() >= delay);
+        assert!(rep.take_progress().is_some());
+    }
+
+    #[test]
+    fn cli_reporter_default_impl_preserves_warn_line() {
+        // Sanity check: TestReporter uses the default retry_wait, which
+        // should call warn() exactly once with the canonical format.
+        let mut tr = TestReporter::default();
+        tr.retry_wait(
+            "foo",
+            "1.2.3",
+            1,
+            5,
+            Duration::from_millis(1),
+            shipper_core::types::ErrorClass::Retryable,
+            "transient failure",
+        );
+        assert_eq!(tr.warns.len(), 1);
+        let w = &tr.warns[0];
+        assert!(w.contains("foo@1.2.3"));
+        assert!(w.contains("transient failure"));
+        assert!(w.contains("Retryable"));
+        assert!(w.contains("attempt 2/5"));
     }
 
     #[test]

--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -2308,6 +2308,24 @@ mod tests {
     }
 
     #[test]
+    fn cli_reporter_retry_wait_without_progress_warns_and_blocks_for_delay() {
+        use std::time::Instant;
+        let mut rep = CliReporter::new(false);
+        let delay = Duration::from_millis(40);
+        let start = Instant::now();
+        rep.retry_wait(
+            "pkg",
+            "0.1.0",
+            1,
+            3,
+            delay,
+            shipper_core::types::ErrorClass::Retryable,
+            "rate limited",
+        );
+        assert!(start.elapsed() >= delay);
+    }
+
+    #[test]
     fn cli_reporter_retry_wait_with_progress_routes_through_countdown() {
         // Installing a (silent) progress handle should route retry_wait
         // through ProgressReporter::retry_countdown — still blocks for the

--- a/crates/shipper-cli/src/output/progress/mod.rs
+++ b/crates/shipper-cli/src/output/progress/mod.rs
@@ -5,7 +5,8 @@
 //! CLI-only and has no upstream library consumer.
 
 use std::io::IsTerminal;
-use std::time::Instant;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use indicatif::{ProgressBar, ProgressStyle};
 
@@ -154,9 +155,9 @@ impl ProgressReporter {
 
     /// Updates the message for the current package state.
     ///
-    /// Currently only exercised by tests; retained for future intra-package
-    /// status updates (uploading, verifying, etc.).
-    #[allow(dead_code)]
+    /// Used by [`ProgressReporter::retry_countdown`] to render the live retry
+    /// countdown, and available for future intra-package status updates
+    /// (uploading, verifying, etc.).
     pub(crate) fn set_status(&self, status: &str) {
         if self.quiet {
             return;
@@ -170,6 +171,69 @@ impl ProgressReporter {
             }
         } else {
             eprintln!("[status] {status}");
+        }
+    }
+
+    /// Render a live retry-backoff countdown and block for the full `delay`.
+    ///
+    /// In TTY mode, refreshes the progress-bar message every second with a
+    /// ticking `"retrying {pkg}@{ver} in {Ns}... (attempt N/M, reason: ...)"`
+    /// line so operators watching a CI log never see a silent sleep. In
+    /// non-TTY mode, emits a single one-shot `eprintln!` (avoiding stream
+    /// spam in log files) and then sleeps. In quiet mode, skips narration
+    /// entirely but still blocks for the backoff. Closes #103 PR 1 — lifts
+    /// `set_status` off the dead-code list by wiring it to the retry path.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn retry_countdown(
+        &self,
+        pkg_name: &str,
+        pkg_version: &str,
+        attempt: u32,
+        max_attempts: u32,
+        delay: Duration,
+        reason: &str,
+        message: &str,
+    ) {
+        // Quiet mode: preserve the retry wait but emit nothing.
+        if self.quiet {
+            thread::sleep(delay);
+            return;
+        }
+
+        let next_attempt = attempt.saturating_add(1);
+
+        if self.is_tty {
+            let start = Instant::now();
+            let tick = Duration::from_millis(1000);
+            // Tick down once per second. `remaining == 0` ends the loop; we
+            // still call `set_status` once on exit to show "retrying now".
+            loop {
+                let elapsed = start.elapsed();
+                let remaining = delay.saturating_sub(elapsed);
+                let remaining_secs = remaining.as_secs();
+
+                if remaining.is_zero() {
+                    self.set_status(&format!(
+                        "retrying {pkg_name}@{pkg_version} now... (attempt {next_attempt}/{max_attempts}, reason: {reason})"
+                    ));
+                    break;
+                }
+
+                self.set_status(&format!(
+                    "retrying {pkg_name}@{pkg_version} in {remaining_secs}s... (attempt {next_attempt}/{max_attempts}, reason: {reason}) — {message}"
+                ));
+
+                let sleep_for = remaining.min(tick);
+                thread::sleep(sleep_for);
+            }
+        } else {
+            // Non-TTY: one-shot line so pipelines/CI logs don't get spammed
+            // with per-second updates. Matches the pre-#103 warn shape.
+            eprintln!(
+                "[retry] {pkg_name}@{pkg_version}: {message} ({reason}); next attempt in {} (attempt {next_attempt}/{max_attempts})",
+                humantime::format_duration(delay),
+            );
+            thread::sleep(delay);
         }
     }
 

--- a/crates/shipper-cli/src/output/progress/tests.rs
+++ b/crates/shipper-cli/src/output/progress/tests.rs
@@ -884,6 +884,30 @@ fn test_retry_countdown_non_tty_one_shot_line() {
 }
 
 #[test]
+fn test_retry_countdown_tty_branch_updates_status() {
+    let progress_bar = indicatif::ProgressBar::hidden();
+    let reporter = ProgressReporter {
+        is_tty: true,
+        quiet: false,
+        total_packages: 1,
+        current_package: 0,
+        current_name: "tty-crate@1.0.0".to_string(),
+        progress_bar: Some(progress_bar),
+        start_time: Instant::now(),
+    };
+
+    reporter.retry_countdown(
+        "tty-crate",
+        "1.0.0",
+        0,
+        3,
+        Duration::from_millis(1),
+        "Retryable",
+        "server busy",
+    );
+}
+
+#[test]
 fn test_retry_countdown_max_attempts_display() {
     // Smoke check: exotic attempt/max combinations shouldn't panic.
     let reporter = ProgressReporter::silent(1);

--- a/crates/shipper-cli/src/output/progress/tests.rs
+++ b/crates/shipper-cli/src/output/progress/tests.rs
@@ -823,3 +823,78 @@ fn test_display_format_version_with_pre_and_build() {
     reporter.set_package(1, "crate", "1.0.0-alpha.1+build.456");
     assert_eq!(reporter.current_name(), "crate@1.0.0-alpha.1+build.456");
 }
+
+// --- 21. retry_countdown (#103 PR 1) ---
+
+#[test]
+fn test_retry_countdown_silent_mode_blocks_for_delay() {
+    // Quiet reporter emits nothing but still blocks for the full delay so
+    // the engine's retry-backoff semantics are preserved.
+    let reporter = ProgressReporter::silent(1);
+    let delay = Duration::from_millis(80);
+    let start = Instant::now();
+    reporter.retry_countdown(
+        "my-crate",
+        "1.0.0",
+        1,
+        5,
+        delay,
+        "Retryable",
+        "HTTP 429 from registry",
+    );
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed >= delay,
+        "retry_countdown returned too early: {elapsed:?} < {delay:?}"
+    );
+    // And doesn't take absurdly long either (3x tolerance for CI).
+    assert!(
+        elapsed < delay * 10,
+        "retry_countdown took too long: {elapsed:?}"
+    );
+}
+
+#[test]
+fn test_retry_countdown_zero_delay_returns_immediately() {
+    let reporter = ProgressReporter::silent(1);
+    let start = Instant::now();
+    reporter.retry_countdown("pkg", "0.1.0", 1, 3, Duration::ZERO, "Retryable", "ok");
+    assert!(start.elapsed() < Duration::from_millis(500));
+}
+
+#[test]
+fn test_retry_countdown_non_tty_one_shot_line() {
+    // `ProgressReporter::new(total, quiet=false)` is non-TTY in the test
+    // harness (stdout is not a terminal), so this drives the non-TTY
+    // branch — one `eprintln!` line, then sleep. Can't assert on stderr
+    // here but we can assert the call doesn't panic and blocks correctly.
+    let reporter = ProgressReporter::new(2, false);
+    let delay = Duration::from_millis(30);
+    let start = Instant::now();
+    reporter.retry_countdown(
+        "some-crate",
+        "2.0.0",
+        2,
+        5,
+        delay,
+        "Retryable",
+        "rate limited",
+    );
+    assert!(start.elapsed() >= delay);
+}
+
+#[test]
+fn test_retry_countdown_max_attempts_display() {
+    // Smoke check: exotic attempt/max combinations shouldn't panic.
+    let reporter = ProgressReporter::silent(1);
+    reporter.retry_countdown("x", "0", 0, 1, Duration::from_millis(1), "Ambiguous", "m");
+    reporter.retry_countdown(
+        "x",
+        "0",
+        u32::MAX - 1,
+        u32::MAX,
+        Duration::from_millis(1),
+        "Retryable",
+        "m",
+    );
+}

--- a/crates/shipper-core/src/engine/mod.rs
+++ b/crates/shipper-core/src/engine/mod.rs
@@ -30,6 +30,38 @@ pub trait Reporter {
     fn info(&mut self, msg: &str);
     fn warn(&mut self, msg: &str);
     fn error(&mut self, msg: &str);
+
+    /// Narrate a retry-backoff wait to the operator and block until the wait
+    /// has elapsed. Called once per retry backoff site after the
+    /// [`EventType::RetryBackoffStarted`] event has been recorded. The default
+    /// implementation preserves the pre-#103 behavior (a single `warn()` line
+    /// then `thread::sleep(delay)`); richer UIs (e.g., the CLI) override it to
+    /// render a live countdown during the wait window. Overrides MUST block
+    /// for the full `delay` before returning — the engine relies on this
+    /// method to own the retry sleep. See #103 and #91.
+    #[allow(clippy::too_many_arguments)]
+    fn retry_wait(
+        &mut self,
+        pkg_name: &str,
+        pkg_version: &str,
+        attempt: u32,
+        max_attempts: u32,
+        delay: Duration,
+        reason: ErrorClass,
+        message: &str,
+    ) {
+        self.warn(&format!(
+            "{}@{}: {} ({:?}); next attempt in {} (attempt {}/{})",
+            pkg_name,
+            pkg_version,
+            message,
+            reason,
+            humantime::format_duration(delay),
+            attempt.saturating_add(1),
+            max_attempts,
+        ));
+        thread::sleep(delay);
+    }
 }
 
 pub(crate) fn policy_effects(opts: &RuntimeOptions) -> crate::runtime::policy::PolicyEffects {
@@ -1816,18 +1848,20 @@ fn emit_retry_backoff_event(
     event_log.write_to_file(events_path)?;
     event_log.clear();
 
-    reporter.warn(&format!(
-        "{}@{}: {} ({:?}); next attempt in {} (attempt {}/{})",
+    // Delegate the human-facing narration AND the backoff sleep to the
+    // Reporter so TTY-capable UIs can render a live countdown during the
+    // wait. The default `Reporter::retry_wait` impl preserves the pre-#103
+    // behavior (single warn line + `thread::sleep(delay)`), so reporters
+    // that don't override it behave exactly as before.
+    reporter.retry_wait(
         pkg_name,
         pkg_version,
-        message,
-        reason,
-        humantime::format_duration(delay),
-        attempt.saturating_add(1),
+        attempt,
         max_attempts,
-    ));
-
-    thread::sleep(delay);
+        delay,
+        reason,
+        message,
+    );
     Ok(())
 }
 

--- a/crates/shipper-core/src/engine/parallel/mod.rs
+++ b/crates/shipper-core/src/engine/parallel/mod.rs
@@ -6,8 +6,11 @@
 //! Absorbed from the standalone `shipper-engine-parallel` crate. See
 //! `CLAUDE.md` alongside this module for module-level guidance.
 
+use std::collections::VecDeque;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 
@@ -36,6 +39,30 @@ pub trait Reporter {
     fn info(&mut self, msg: &str);
     fn warn(&mut self, msg: &str);
     fn error(&mut self, msg: &str);
+
+    #[allow(clippy::too_many_arguments)]
+    fn retry_wait(
+        &mut self,
+        pkg_name: &str,
+        pkg_version: &str,
+        attempt: u32,
+        max_attempts: u32,
+        delay: Duration,
+        reason: shipper_types::ErrorClass,
+        message: &str,
+    ) {
+        self.warn(&format!(
+            "{}@{}: {} ({:?}); next attempt in {} (attempt {}/{})",
+            pkg_name,
+            pkg_version,
+            message,
+            reason,
+            humantime::format_duration(delay),
+            attempt.saturating_add(1),
+            max_attempts,
+        ));
+        thread::sleep(delay);
+    }
 }
 
 /// Adapter that bridges the host crate's `crate::engine::Reporter` trait into
@@ -54,6 +81,127 @@ impl<'a> Reporter for HostReporterAdapter<'a> {
     }
     fn error(&mut self, msg: &str) {
         self.inner.error(msg);
+    }
+
+    fn retry_wait(
+        &mut self,
+        pkg_name: &str,
+        pkg_version: &str,
+        attempt: u32,
+        max_attempts: u32,
+        delay: Duration,
+        reason: shipper_types::ErrorClass,
+        message: &str,
+    ) {
+        self.inner.retry_wait(
+            pkg_name,
+            pkg_version,
+            attempt,
+            max_attempts,
+            delay,
+            reason,
+            message,
+        );
+    }
+}
+
+pub(super) struct RetryWaitNotice {
+    pub(super) pkg_name: String,
+    pub(super) pkg_version: String,
+    pub(super) attempt: u32,
+    pub(super) max_attempts: u32,
+    pub(super) delay: Duration,
+    pub(super) reason: shipper_types::ErrorClass,
+    pub(super) message: String,
+    pub(super) started_at: Instant,
+}
+
+#[derive(Default)]
+pub(super) struct SendReporter {
+    infos: Mutex<Vec<String>>,
+    warns: Mutex<Vec<String>>,
+    errors: Mutex<Vec<String>>,
+    retry_waits: Mutex<VecDeque<RetryWaitNotice>>,
+}
+
+impl SendReporter {
+    pub(super) fn info(&self, msg: &str) {
+        self.infos.lock().unwrap().push(msg.to_string());
+    }
+
+    pub(super) fn warn(&self, msg: &str) {
+        self.warns.lock().unwrap().push(msg.to_string());
+    }
+
+    pub(super) fn error(&self, msg: &str) {
+        self.errors.lock().unwrap().push(msg.to_string());
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn retry_wait(
+        &self,
+        pkg_name: &str,
+        pkg_version: &str,
+        attempt: u32,
+        max_attempts: u32,
+        delay: Duration,
+        reason: shipper_types::ErrorClass,
+        message: &str,
+    ) {
+        self.retry_waits.lock().unwrap().push_back(RetryWaitNotice {
+            pkg_name: pkg_name.to_string(),
+            pkg_version: pkg_version.to_string(),
+            attempt,
+            max_attempts,
+            delay,
+            reason,
+            message: message.to_string(),
+            started_at: Instant::now(),
+        });
+        thread::sleep(delay);
+    }
+
+    fn drain_infos(&self) -> Vec<String> {
+        std::mem::take(&mut *self.infos.lock().unwrap())
+    }
+
+    fn drain_warns(&self) -> Vec<String> {
+        std::mem::take(&mut *self.warns.lock().unwrap())
+    }
+
+    fn drain_errors(&self) -> Vec<String> {
+        std::mem::take(&mut *self.errors.lock().unwrap())
+    }
+
+    fn drain_retry_waits(&self) -> Vec<RetryWaitNotice> {
+        self.retry_waits.lock().unwrap().drain(..).collect()
+    }
+}
+
+fn replay_buffered_messages(reporter: &mut dyn Reporter, send_reporter: &SendReporter) {
+    for msg in send_reporter.drain_infos() {
+        reporter.info(&msg);
+    }
+    for msg in send_reporter.drain_warns() {
+        reporter.warn(&msg);
+    }
+    for msg in send_reporter.drain_errors() {
+        reporter.error(&msg);
+    }
+}
+
+pub(super) fn drain_retry_waits(reporter: &mut dyn Reporter, send_reporter: &SendReporter) {
+    for notice in send_reporter.drain_retry_waits() {
+        let remaining = notice.delay.saturating_sub(notice.started_at.elapsed());
+        reporter.retry_wait(
+            &notice.pkg_name,
+            &notice.pkg_version,
+            notice.attempt,
+            notice.max_attempts,
+            remaining,
+            notice.reason,
+            &notice.message,
+        );
     }
 }
 
@@ -115,29 +263,12 @@ pub(crate) fn run_publish_parallel_inner(
     // Wrap state and reporter in Arc<Mutex<>> for thread safety
     let st_arc = Arc::new(Mutex::new(st.clone()));
 
-    // Create a thread-safe reporter wrapper
-    struct SendReporter {
-        infos: Mutex<Vec<String>>,
-        warns: Mutex<Vec<String>>,
-        errors: Mutex<Vec<String>>,
-    }
-    impl Reporter for SendReporter {
-        fn info(&mut self, msg: &str) {
-            self.infos.lock().unwrap().push(msg.to_string());
-        }
-        fn warn(&mut self, msg: &str) {
-            self.warns.lock().unwrap().push(msg.to_string());
-        }
-        fn error(&mut self, msg: &str) {
-            self.errors.lock().unwrap().push(msg.to_string());
-        }
-    }
-
-    let send_reporter = Arc::new(Mutex::new(SendReporter {
+    let send_reporter = Arc::new(SendReporter {
         infos: Mutex::new(Vec::new()),
         warns: Mutex::new(Vec::new()),
         errors: Mutex::new(Vec::new()),
-    }));
+        retry_waits: Mutex::new(VecDeque::new()),
+    });
 
     let mut all_receipts: Vec<PackageReceipt> = Vec::new();
 
@@ -226,24 +357,14 @@ pub(crate) fn run_publish_parallel_inner(
             state_dir,
             &event_log,
             &events_path,
-            &(send_reporter.clone() as Arc<Mutex<dyn Reporter + Send>>),
+            reporter,
+            &send_reporter,
         )?;
         all_receipts.extend(level_receipts);
+        replay_buffered_messages(reporter, send_reporter.as_ref());
     }
 
-    // Replay messages to the real reporter
-    {
-        let sr = send_reporter.lock().unwrap();
-        for msg in sr.infos.lock().unwrap().iter() {
-            reporter.info(msg);
-        }
-        for msg in sr.warns.lock().unwrap().iter() {
-            reporter.warn(msg);
-        }
-        for msg in sr.errors.lock().unwrap().iter() {
-            reporter.error(msg);
-        }
-    }
+    replay_buffered_messages(reporter, send_reporter.as_ref());
 
     // Copy updated state back
     let updated_st = st_arc.lock().unwrap();

--- a/crates/shipper-core/src/engine/parallel/mod.rs
+++ b/crates/shipper-core/src/engine/parallel/mod.rs
@@ -36,6 +36,36 @@ pub trait Reporter {
     fn info(&mut self, msg: &str);
     fn warn(&mut self, msg: &str);
     fn error(&mut self, msg: &str);
+
+    /// Narrate a retry-backoff wait to the operator and block until the wait
+    /// has elapsed. Called from the parallel publish retry sites after the
+    /// [`shipper_types::EventType::RetryBackoffStarted`] event has been
+    /// recorded. The default impl preserves the pre-#103 behavior (warn line
+    /// then `thread::sleep(delay)`); overrides MUST block for the full
+    /// `delay` before returning. See #103 / #91.
+    #[allow(clippy::too_many_arguments)]
+    fn retry_wait(
+        &mut self,
+        pkg_name: &str,
+        pkg_version: &str,
+        attempt: u32,
+        max_attempts: u32,
+        delay: std::time::Duration,
+        reason: shipper_types::ErrorClass,
+        message: &str,
+    ) {
+        self.warn(&format!(
+            "{}@{}: {} ({:?}); next attempt in {} (attempt {}/{})",
+            pkg_name,
+            pkg_version,
+            message,
+            reason,
+            humantime::format_duration(delay),
+            attempt.saturating_add(1),
+            max_attempts,
+        ));
+        std::thread::sleep(delay);
+    }
 }
 
 /// Adapter that bridges the host crate's `crate::engine::Reporter` trait into
@@ -54,6 +84,31 @@ impl<'a> Reporter for HostReporterAdapter<'a> {
     }
     fn error(&mut self, msg: &str) {
         self.inner.error(msg);
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn retry_wait(
+        &mut self,
+        pkg_name: &str,
+        pkg_version: &str,
+        attempt: u32,
+        max_attempts: u32,
+        delay: std::time::Duration,
+        reason: shipper_types::ErrorClass,
+        message: &str,
+    ) {
+        // Forward to the host reporter so the CLI's live-countdown override
+        // fires for parallel retries too. (Buffering in SendReporter means
+        // the countdown is only visible in the single-level case, but the
+        // default-impl fallback still emits a warn line.)
+        self.inner.retry_wait(
+            pkg_name,
+            pkg_version,
+            attempt,
+            max_attempts,
+            delay,
+            reason,
+            message,
+        );
     }
 }
 

--- a/crates/shipper-core/src/engine/parallel/mod.rs
+++ b/crates/shipper-core/src/engine/parallel/mod.rs
@@ -36,36 +36,6 @@ pub trait Reporter {
     fn info(&mut self, msg: &str);
     fn warn(&mut self, msg: &str);
     fn error(&mut self, msg: &str);
-
-    /// Narrate a retry-backoff wait to the operator and block until the wait
-    /// has elapsed. Called from the parallel publish retry sites after the
-    /// [`shipper_types::EventType::RetryBackoffStarted`] event has been
-    /// recorded. The default impl preserves the pre-#103 behavior (warn line
-    /// then `thread::sleep(delay)`); overrides MUST block for the full
-    /// `delay` before returning. See #103 / #91.
-    #[allow(clippy::too_many_arguments)]
-    fn retry_wait(
-        &mut self,
-        pkg_name: &str,
-        pkg_version: &str,
-        attempt: u32,
-        max_attempts: u32,
-        delay: std::time::Duration,
-        reason: shipper_types::ErrorClass,
-        message: &str,
-    ) {
-        self.warn(&format!(
-            "{}@{}: {} ({:?}); next attempt in {} (attempt {}/{})",
-            pkg_name,
-            pkg_version,
-            message,
-            reason,
-            humantime::format_duration(delay),
-            attempt.saturating_add(1),
-            max_attempts,
-        ));
-        std::thread::sleep(delay);
-    }
 }
 
 /// Adapter that bridges the host crate's `crate::engine::Reporter` trait into
@@ -84,31 +54,6 @@ impl<'a> Reporter for HostReporterAdapter<'a> {
     }
     fn error(&mut self, msg: &str) {
         self.inner.error(msg);
-    }
-    #[allow(clippy::too_many_arguments)]
-    fn retry_wait(
-        &mut self,
-        pkg_name: &str,
-        pkg_version: &str,
-        attempt: u32,
-        max_attempts: u32,
-        delay: std::time::Duration,
-        reason: shipper_types::ErrorClass,
-        message: &str,
-    ) {
-        // Forward to the host reporter so the CLI's live-countdown override
-        // fires for parallel retries too. (Buffering in SendReporter means
-        // the countdown is only visible in the single-level case, but the
-        // default-impl fallback still emits a warn line.)
-        self.inner.retry_wait(
-            pkg_name,
-            pkg_version,
-            attempt,
-            max_attempts,
-            delay,
-            reason,
-            message,
-        );
     }
 }
 

--- a/crates/shipper-core/src/engine/parallel/publish.rs
+++ b/crates/shipper-core/src/engine/parallel/publish.rs
@@ -81,22 +81,22 @@ fn emit_retry_backoff(
         log.clear();
     }
 
-    // Human line: reason + attempt count + duration
+    // Delegate human-facing narration AND the backoff sleep to the Reporter.
+    // Parallel mode's SendReporter uses the default impl (buffered warn +
+    // thread::sleep), matching pre-#103 behavior. Single-level callers that
+    // use the host reporter directly can provide a live-countdown override.
     {
         let mut rep = reporter.lock().unwrap();
-        rep.warn(&format!(
-            "{}@{}: {} ({:?}); next attempt in {} (attempt {}/{})",
+        rep.retry_wait(
             pkg_name,
             pkg_version,
-            message,
-            reason,
-            humantime::format_duration(delay),
-            attempt.saturating_add(1),
+            attempt,
             max_attempts,
-        ));
+            delay,
+            reason,
+            message,
+        );
     }
-
-    thread::sleep(delay);
 }
 
 /// Publish a single package with retries (parallel-safe version)

--- a/crates/shipper-core/src/engine/parallel/publish.rs
+++ b/crates/shipper-core/src/engine/parallel/publish.rs
@@ -8,7 +8,7 @@
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use anyhow::{Result, bail};
 use chrono::Utc;
@@ -27,11 +27,11 @@ use shipper_types::{
     ReconciliationOutcome, RuntimeOptions,
 };
 
-use super::Reporter;
 use super::policy::policy_effects;
 use super::readiness::is_version_visible_with_backoff;
 use super::reconcile::reconcile_ambiguous_upload;
 use super::webhook::{WebhookEvent, maybe_send_event};
+use super::{Reporter, SendReporter, drain_retry_waits};
 
 use crate::plan::chunking::chunk_by_max_concurrent;
 
@@ -49,7 +49,7 @@ pub(super) struct PackagePublishResult {
 pub(super) fn emit_retry_backoff(
     event_log: &Arc<Mutex<events::EventLog>>,
     events_path: &Path,
-    reporter: &Arc<Mutex<dyn Reporter + Send>>,
+    reporter: &Arc<SendReporter>,
     pkg_label: &str,
     pkg_name: &str,
     pkg_version: &str,
@@ -81,24 +81,15 @@ pub(super) fn emit_retry_backoff(
         log.clear();
     }
 
-    // Emit the warn line while holding the reporter mutex, then release the
-    // lock before sleeping so other worker threads are not blocked from
-    // logging during the backoff window.
-    {
-        let mut rep = reporter.lock().unwrap();
-        rep.warn(&format!(
-            "{}@{}: {} ({:?}); next attempt in {} (attempt {}/{})",
-            pkg_name,
-            pkg_version,
-            message,
-            reason,
-            humantime::format_duration(delay),
-            attempt.saturating_add(1),
-            max_attempts,
-        ));
-    }
-
-    thread::sleep(delay);
+    reporter.retry_wait(
+        pkg_name,
+        pkg_version,
+        attempt,
+        max_attempts,
+        delay,
+        reason,
+        message,
+    );
 }
 
 /// Publish a single package with retries (parallel-safe version)
@@ -112,7 +103,7 @@ pub(super) fn publish_package(
     state_dir: &Path,
     event_log: &Arc<Mutex<events::EventLog>>,
     events_path: &Path,
-    reporter: &Arc<Mutex<dyn Reporter + Send>>,
+    reporter: &Arc<SendReporter>,
 ) -> PackagePublishResult {
     let key = pkg_key(&p.name, &p.version);
     let pkg_label = format!("{}@{}", p.name, p.version);
@@ -136,13 +127,10 @@ pub(super) fn publish_package(
 
     // Check if already published
     if let Ok(true) = reg.version_exists(&p.name, &p.version) {
-        {
-            let mut rep = reporter.lock().unwrap();
-            rep.info(&format!(
-                "{}@{}: already published (skipping)",
-                p.name, p.version
-            ));
-        }
+        reporter.info(&format!(
+            "{}@{}: already published (skipping)",
+            p.name, p.version
+        ));
 
         let skipped = PackageState::Skipped {
             reason: "already published".to_string(),
@@ -187,10 +175,7 @@ pub(super) fn publish_package(
         };
     }
 
-    {
-        let mut rep = reporter.lock().unwrap();
-        rep.info(&format!("{}@{}: publishing...", p.name, p.version));
-    }
+    reporter.info(&format!("{}@{}: publishing...", p.name, p.version));
 
     let mut attempt = 0u32;
     let mut last_err: Option<(ErrorClass, String)> = None;
@@ -231,13 +216,10 @@ pub(super) fn publish_package(
     };
 
     if let Some(prior_reason) = ambiguous_prior {
-        {
-            let mut rep = reporter.lock().unwrap();
-            rep.warn(&format!(
-                "{}@{}: resume found ambiguous state ({}); reconciling against registry",
-                p.name, p.version, prior_reason
-            ));
-        }
+        reporter.warn(&format!(
+            "{}@{}: resume found ambiguous state ({}); reconciling against registry",
+            p.name, p.version, prior_reason
+        ));
         {
             let mut log = event_log.lock().unwrap();
             log.record(PublishEvent {
@@ -272,13 +254,10 @@ pub(super) fn publish_package(
                     update_state_locked(&mut state, &key, PackageState::Published);
                     let _ = state::save_state(state_dir, &state);
                 }
-                {
-                    let mut rep = reporter.lock().unwrap();
-                    rep.info(&format!(
-                        "{}@{}: reconciled as published on resume (no republish)",
-                        p.name, p.version
-                    ));
-                }
+                reporter.info(&format!(
+                    "{}@{}: reconciled as published on resume (no republish)",
+                    p.name, p.version
+                ));
                 return PackagePublishResult {
                     result: Ok(PackageReceipt {
                         name: p.name.clone(),
@@ -304,23 +283,17 @@ pub(super) fn publish_package(
                     update_state_locked(&mut state, &key, PackageState::Pending);
                     let _ = state::save_state(state_dir, &state);
                 }
-                {
-                    let mut rep = reporter.lock().unwrap();
-                    rep.info(&format!(
-                        "{}@{}: reconciled as not published; proceeding with publish",
-                        p.name, p.version
-                    ));
-                }
+                reporter.info(&format!(
+                    "{}@{}: reconciled as not published; proceeding with publish",
+                    p.name, p.version
+                ));
                 // Fall through to the normal retry loop below.
             }
             ReconciliationOutcome::StillUnknown { reason, .. } => {
-                {
-                    let mut rep = reporter.lock().unwrap();
-                    rep.error(&format!(
-                        "{}@{}: resume reconciliation still inconclusive: {}",
-                        p.name, p.version, reason
-                    ));
-                }
+                reporter.error(&format!(
+                    "{}@{}: resume reconciliation still inconclusive: {}",
+                    p.name, p.version, reason
+                ));
                 maybe_send_event(
                     &opts.webhook,
                     WebhookEvent::PublishFailed {
@@ -365,13 +338,10 @@ pub(super) fn publish_package(
             p.name, ws.plan.registry.name
         );
 
-        {
-            let mut rep = reporter.lock().unwrap();
-            rep.info(&format!(
-                "{}@{}: attempt {}/{}",
-                p.name, p.version, attempt, opts.max_attempts
-            ));
-        }
+        reporter.info(&format!(
+            "{}@{}: attempt {}/{}",
+            p.name, p.version, attempt, opts.max_attempts
+        ));
 
         if !cargo_succeeded {
             // Event: PackageAttempted
@@ -398,13 +368,10 @@ pub(super) fn publish_package(
             ) {
                 Ok(o) => o,
                 Err(e) => {
-                    {
-                        let mut rep = reporter.lock().unwrap();
-                        rep.error(&format!(
-                            "{}@{}: cargo publish failed to execute: {}",
-                            p.name, p.version, e
-                        ));
-                    }
+                    reporter.error(&format!(
+                        "{}@{}: cargo publish failed to execute: {}",
+                        p.name, p.version, e
+                    ));
                     return PackagePublishResult { result: Err(e) };
                 }
             };
@@ -443,22 +410,16 @@ pub(super) fn publish_package(
                 }
             } else {
                 // Cargo failed, check registry
-                {
-                    let mut rep = reporter.lock().unwrap();
-                    rep.warn(&format!(
-                        "{}@{}: cargo publish failed (exit={}); checking registry...",
-                        p.name, p.version, out.exit_code
-                    ));
-                }
+                reporter.warn(&format!(
+                    "{}@{}: cargo publish failed (exit={}); checking registry...",
+                    p.name, p.version, out.exit_code
+                ));
 
                 if reg.version_exists(&p.name, &p.version).unwrap_or(false) {
-                    {
-                        let mut rep = reporter.lock().unwrap();
-                        rep.info(&format!(
-                            "{}@{}: version is present on registry; treating as published",
-                            p.name, p.version
-                        ));
-                    }
+                    reporter.info(&format!(
+                        "{}@{}: version is present on registry; treating as published",
+                        p.name, p.version
+                    ));
 
                     {
                         let mut state = st.lock().unwrap();
@@ -498,13 +459,10 @@ pub(super) fn publish_package(
                             package: pkg_label.clone(),
                         });
                     }
-                    {
-                        let mut rep = reporter.lock().unwrap();
-                        rep.warn(&format!(
-                            "{}@{}: cargo exit ambiguous; reconciling against registry",
-                            p.name, p.version
-                        ));
-                    }
+                    reporter.warn(&format!(
+                        "{}@{}: cargo exit ambiguous; reconciling against registry",
+                        p.name, p.version
+                    ));
 
                     let (outcome, reconcile_evidence) =
                         reconcile_ambiguous_upload(reg, &p.name, &p.version, &readiness_config);
@@ -522,13 +480,10 @@ pub(super) fn publish_package(
 
                     match outcome {
                         ReconciliationOutcome::Published { .. } => {
-                            {
-                                let mut rep = reporter.lock().unwrap();
-                                rep.info(&format!(
-                                    "{}@{}: reconciled as published; no retry",
-                                    p.name, p.version
-                                ));
-                            }
+                            reporter.info(&format!(
+                                "{}@{}: reconciled as published; no retry",
+                                p.name, p.version
+                            ));
                             {
                                 let mut state = st.lock().unwrap();
                                 update_state_locked(&mut state, &key, PackageState::Published);
@@ -681,13 +636,10 @@ pub(super) fn publish_package(
         }
 
         // Readiness verification (runs after first cargo success + all retries)
-        {
-            let mut rep = reporter.lock().unwrap();
-            rep.info(&format!(
-                "{}@{}: cargo publish exited successfully; verifying...",
-                p.name, p.version
-            ));
-        }
+        reporter.info(&format!(
+            "{}@{}: cargo publish exited successfully; verifying...",
+            p.name, p.version
+        ));
 
         let verify_result =
             is_version_visible_with_backoff(reg, &p.name, &p.version, &readiness_config);
@@ -955,12 +907,13 @@ pub(super) fn run_publish_level(
     state_dir: &Path,
     event_log: &Arc<Mutex<events::EventLog>>,
     events_path: &Path,
-    reporter: &Arc<Mutex<dyn Reporter + Send>>,
+    reporter: &mut dyn Reporter,
+    send_reporter: &Arc<SendReporter>,
 ) -> Result<Vec<PackageReceipt>> {
     let num_packages = level.packages.len();
     let max_concurrent = opts.parallel.max_concurrent.min(num_packages);
 
-    reporter.lock().unwrap().info(&format!(
+    reporter.info(&format!(
         "Level {}: publishing {} packages (max concurrent: {})",
         level.level, num_packages, max_concurrent
     ));
@@ -982,7 +935,7 @@ pub(super) fn run_publish_level(
             let state_dir = state_dir.to_path_buf();
             let event_log_clone = Arc::clone(event_log);
             let events_path = events_path.to_path_buf();
-            let reporter_clone = Arc::clone(reporter);
+            let reporter_clone = Arc::clone(send_reporter);
 
             let handle = thread::spawn(move || {
                 publish_package(
@@ -1000,6 +953,12 @@ pub(super) fn run_publish_level(
 
             handles.push(handle);
         }
+
+        while handles.iter().any(|handle| !handle.is_finished()) {
+            drain_retry_waits(reporter, send_reporter.as_ref());
+            thread::sleep(Duration::from_millis(25));
+        }
+        drain_retry_waits(reporter, send_reporter.as_ref());
 
         // Wait for all packages in this chunk to complete, collecting all results
         for handle in handles {

--- a/crates/shipper-core/src/engine/parallel/publish.rs
+++ b/crates/shipper-core/src/engine/parallel/publish.rs
@@ -46,7 +46,7 @@ pub(super) struct PackagePublishResult {
 /// retry-backoff site in the publish loop so operators never stare at a
 /// silent CI log during the wait window. See #91.
 #[allow(clippy::too_many_arguments)]
-fn emit_retry_backoff(
+pub(super) fn emit_retry_backoff(
     event_log: &Arc<Mutex<events::EventLog>>,
     events_path: &Path,
     reporter: &Arc<Mutex<dyn Reporter + Send>>,
@@ -81,22 +81,24 @@ fn emit_retry_backoff(
         log.clear();
     }
 
-    // Delegate human-facing narration AND the backoff sleep to the Reporter.
-    // Parallel mode's SendReporter uses the default impl (buffered warn +
-    // thread::sleep), matching pre-#103 behavior. Single-level callers that
-    // use the host reporter directly can provide a live-countdown override.
+    // Emit the warn line while holding the reporter mutex, then release the
+    // lock before sleeping so other worker threads are not blocked from
+    // logging during the backoff window.
     {
         let mut rep = reporter.lock().unwrap();
-        rep.retry_wait(
+        rep.warn(&format!(
+            "{}@{}: {} ({:?}); next attempt in {} (attempt {}/{})",
             pkg_name,
             pkg_version,
-            attempt,
-            max_attempts,
-            delay,
-            reason,
             message,
-        );
+            reason,
+            humantime::format_duration(delay),
+            attempt.saturating_add(1),
+            max_attempts,
+        ));
     }
+
+    thread::sleep(delay);
 }
 
 /// Publish a single package with retries (parallel-safe version)

--- a/crates/shipper-core/src/engine/parallel/tests.rs
+++ b/crates/shipper-core/src/engine/parallel/tests.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::sync::{Arc, Mutex, mpsc};
+use std::time::{Duration, Instant};
 
 use chrono::Utc;
 use serial_test::serial;
@@ -10,7 +10,7 @@ use tempfile::tempdir;
 use tiny_http::{Header, Response, Server, StatusCode};
 
 use super::policy::policy_effects;
-use super::publish::{publish_package, run_publish_level};
+use super::publish::{emit_retry_backoff, publish_package, run_publish_level};
 use super::run_publish_parallel_inner as run_publish_parallel;
 use super::*;
 use crate::plan::PlannedWorkspace;
@@ -42,6 +42,75 @@ impl Reporter for CollectingReporter {
     fn error(&mut self, msg: &str) {
         self.errors.push(msg.to_string());
     }
+}
+
+#[test]
+fn emit_retry_backoff_releases_reporter_lock_before_sleep() {
+    struct SignalingReporter {
+        warned: Option<mpsc::Sender<()>>,
+    }
+
+    impl Reporter for SignalingReporter {
+        fn info(&mut self, _msg: &str) {}
+
+        fn warn(&mut self, _msg: &str) {
+            if let Some(tx) = self.warned.take() {
+                tx.send(()).expect("send warn signal");
+            }
+        }
+
+        fn error(&mut self, _msg: &str) {}
+    }
+
+    let td = tempdir().expect("tempdir");
+    let state_dir = td.path().join(".shipper");
+    fs::create_dir_all(&state_dir).expect("mkdir state dir");
+
+    let event_log = Arc::new(Mutex::new(events::EventLog::new()));
+    let events_path = events::events_path(&state_dir);
+    let (warn_tx, warn_rx) = mpsc::channel();
+    let reporter: Arc<Mutex<dyn Reporter + Send>> = Arc::new(Mutex::new(SignalingReporter {
+        warned: Some(warn_tx),
+    }));
+
+    let event_log_for_retry = Arc::clone(&event_log);
+    let reporter_for_retry = Arc::clone(&reporter);
+    let events_path_for_retry = events_path.clone();
+    let delay = Duration::from_millis(250);
+
+    let retry_thread = std::thread::spawn(move || {
+        emit_retry_backoff(
+            &event_log_for_retry,
+            &events_path_for_retry,
+            &reporter_for_retry,
+            "demo@0.1.0",
+            "demo",
+            "0.1.0",
+            1,
+            3,
+            delay,
+            ErrorClass::Retryable,
+            "rate limited",
+        );
+    });
+
+    warn_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("retry warn should fire");
+
+    let lock_started = Instant::now();
+    {
+        let mut rep = reporter.lock().unwrap();
+        rep.info("other worker thread");
+    }
+
+    assert!(
+        lock_started.elapsed() < Duration::from_millis(100),
+        "reporter mutex stayed locked during retry sleep: {:?}",
+        lock_started.elapsed()
+    );
+
+    retry_thread.join().expect("join retry thread");
 }
 
 fn write_fake_cargo(bin_dir: &Path) {

--- a/crates/shipper-core/src/engine/parallel/tests.rs
+++ b/crates/shipper-core/src/engine/parallel/tests.rs
@@ -23,6 +23,10 @@ use shipper_types::{
     RuntimeOptions,
 };
 
+fn make_send_reporter() -> Arc<SendReporter> {
+    Arc::new(SendReporter::default())
+}
+
 #[derive(Default)]
 struct CollectingReporter {
     infos: Vec<String>,
@@ -45,33 +49,14 @@ impl Reporter for CollectingReporter {
 }
 
 #[test]
-fn emit_retry_backoff_releases_reporter_lock_before_sleep() {
-    struct SignalingReporter {
-        warned: Option<mpsc::Sender<()>>,
-    }
-
-    impl Reporter for SignalingReporter {
-        fn info(&mut self, _msg: &str) {}
-
-        fn warn(&mut self, _msg: &str) {
-            if let Some(tx) = self.warned.take() {
-                tx.send(()).expect("send warn signal");
-            }
-        }
-
-        fn error(&mut self, _msg: &str) {}
-    }
-
+fn emit_retry_backoff_does_not_block_other_reporter_calls_during_sleep() {
     let td = tempdir().expect("tempdir");
     let state_dir = td.path().join(".shipper");
     fs::create_dir_all(&state_dir).expect("mkdir state dir");
 
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
     let events_path = events::events_path(&state_dir);
-    let (warn_tx, warn_rx) = mpsc::channel();
-    let reporter: Arc<Mutex<dyn Reporter + Send>> = Arc::new(Mutex::new(SignalingReporter {
-        warned: Some(warn_tx),
-    }));
+    let reporter = make_send_reporter();
 
     let event_log_for_retry = Arc::clone(&event_log);
     let reporter_for_retry = Arc::clone(&reporter);
@@ -94,20 +79,86 @@ fn emit_retry_backoff_releases_reporter_lock_before_sleep() {
         );
     });
 
-    warn_rx
-        .recv_timeout(Duration::from_secs(1))
-        .expect("retry warn should fire");
+    std::thread::sleep(Duration::from_millis(25));
 
     let lock_started = Instant::now();
-    {
-        let mut rep = reporter.lock().unwrap();
-        rep.info("other worker thread");
-    }
+    reporter.info("other worker thread");
 
     assert!(
         lock_started.elapsed() < Duration::from_millis(100),
-        "reporter mutex stayed locked during retry sleep: {:?}",
+        "retry backoff blocked other reporter calls for {:?}",
         lock_started.elapsed()
+    );
+
+    retry_thread.join().expect("join retry thread");
+
+    let infos = reporter.drain_infos();
+    assert!(
+        infos.iter().any(|msg| msg == "other worker thread"),
+        "concurrent info should still be recorded"
+    );
+}
+
+#[test]
+fn drain_retry_waits_forwards_live_notice_before_worker_sleep_elapses() {
+    struct SignalingReporter {
+        tx: Option<mpsc::Sender<Duration>>,
+    }
+
+    impl Reporter for SignalingReporter {
+        fn info(&mut self, _msg: &str) {}
+
+        fn warn(&mut self, _msg: &str) {}
+
+        fn error(&mut self, _msg: &str) {}
+
+        fn retry_wait(
+            &mut self,
+            _pkg_name: &str,
+            _pkg_version: &str,
+            _attempt: u32,
+            _max_attempts: u32,
+            delay: Duration,
+            _reason: ErrorClass,
+            _message: &str,
+        ) {
+            if let Some(tx) = self.tx.take() {
+                tx.send(delay).expect("send forwarded delay");
+            }
+        }
+    }
+
+    let send_reporter = make_send_reporter();
+    let delay = Duration::from_millis(250);
+    let reporter_for_retry = Arc::clone(&send_reporter);
+    let retry_thread = std::thread::spawn(move || {
+        reporter_for_retry.retry_wait(
+            "demo",
+            "0.1.0",
+            1,
+            3,
+            delay,
+            ErrorClass::Retryable,
+            "rate limited",
+        );
+    });
+
+    std::thread::sleep(Duration::from_millis(25));
+
+    let (tx, rx) = mpsc::channel();
+    let mut host_reporter = SignalingReporter { tx: Some(tx) };
+    drain_retry_waits(&mut host_reporter, send_reporter.as_ref());
+
+    let forwarded_delay = rx
+        .recv_timeout(Duration::from_millis(100))
+        .expect("host reporter should observe retry wait promptly");
+    assert!(
+        forwarded_delay <= delay && forwarded_delay > Duration::ZERO,
+        "forwarded delay should be the remaining live backoff, got {forwarded_delay:?}"
+    );
+    assert!(
+        !retry_thread.is_finished(),
+        "worker retry sleep should still be in progress when the host observes it"
     );
 
     retry_thread.join().expect("join retry thread");
@@ -327,8 +378,7 @@ fn test_publish_package_skips_already_published() {
     )));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
     let events_path = events::events_path(&state_dir);
-    let reporter: Arc<Mutex<dyn Reporter + Send>> =
-        Arc::new(Mutex::new(CollectingReporter::default()));
+    let reporter = make_send_reporter();
 
     temp_env::with_var(
         "SHIPPER_CARGO_BIN",
@@ -387,8 +437,7 @@ fn test_publish_package_publishes_successfully() {
     )));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
     let events_path = events::events_path(&state_dir);
-    let reporter: Arc<Mutex<dyn Reporter + Send>> =
-        Arc::new(Mutex::new(CollectingReporter::default()));
+    let reporter = make_send_reporter();
 
     temp_env::with_vars(
         [
@@ -447,8 +496,7 @@ fn test_publish_package_handles_permanent_failure() {
     )));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
     let events_path = events::events_path(&state_dir);
-    let reporter: Arc<Mutex<dyn Reporter + Send>> =
-        Arc::new(Mutex::new(CollectingReporter::default()));
+    let reporter = make_send_reporter();
 
     temp_env::with_vars(
         [
@@ -524,8 +572,7 @@ fn test_publish_package_retries_on_transient() {
     )));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
     let events_path = events::events_path(&state_dir);
-    let reporter: Arc<Mutex<dyn Reporter + Send>> =
-        Arc::new(Mutex::new(CollectingReporter::default()));
+    let reporter = make_send_reporter();
 
     temp_env::with_vars(
         [
@@ -634,8 +681,8 @@ fn test_run_publish_level_processes_packages() {
     }));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
     let events_path = events::events_path(&state_dir);
-    let reporter: Arc<Mutex<dyn Reporter + Send>> =
-        Arc::new(Mutex::new(CollectingReporter::default()));
+    let mut reporter = CollectingReporter::default();
+    let send_reporter = make_send_reporter();
 
     let level = PublishLevel {
         level: 0,
@@ -655,7 +702,8 @@ fn test_run_publish_level_processes_packages() {
                 &state_dir,
                 &event_log,
                 &events_path,
-                &reporter,
+                &mut reporter,
+                &send_reporter,
             )
             .expect("level publish");
 
@@ -900,8 +948,7 @@ fn test_publish_package_handles_uploaded_resume() {
     }));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
     let events_path = events::events_path(&state_dir);
-    let reporter: Arc<Mutex<dyn Reporter + Send>> =
-        Arc::new(Mutex::new(CollectingReporter::default()));
+    let reporter = make_send_reporter();
 
     temp_env::with_var(
         "SHIPPER_CARGO_BIN",
@@ -969,8 +1016,7 @@ fn test_publish_package_records_attempt_evidence() {
     )));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
     let events_path = events::events_path(&state_dir);
-    let reporter: Arc<Mutex<dyn Reporter + Send>> =
-        Arc::new(Mutex::new(CollectingReporter::default()));
+    let reporter = make_send_reporter();
 
     temp_env::with_vars(
         [
@@ -1103,8 +1149,8 @@ fn test_run_publish_level_respects_max_concurrent() {
     }));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
     let events_path = events::events_path(&state_dir);
-    let reporter: Arc<Mutex<dyn Reporter + Send>> =
-        Arc::new(Mutex::new(CollectingReporter::default()));
+    let mut reporter = CollectingReporter::default();
+    let send_reporter = make_send_reporter();
 
     let level = PublishLevel { level: 0, packages };
 
@@ -1121,7 +1167,8 @@ fn test_run_publish_level_respects_max_concurrent() {
                 &state_dir,
                 &event_log,
                 &events_path,
-                &reporter,
+                &mut reporter,
+                &send_reporter,
             )
             .expect("level publish");
 
@@ -1472,8 +1519,8 @@ fn test_partial_success_within_level() {
     }));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
     let events_path = events::events_path(&state_dir);
-    let reporter: Arc<Mutex<dyn Reporter + Send>> =
-        Arc::new(Mutex::new(CollectingReporter::default()));
+    let mut reporter = CollectingReporter::default();
+    let send_reporter = make_send_reporter();
 
     let level = PublishLevel { level: 0, packages };
 
@@ -1496,7 +1543,8 @@ fn test_partial_success_within_level() {
                 &state_dir,
                 &event_log,
                 &events_path,
-                &reporter,
+                &mut reporter,
+                &send_reporter,
             );
 
             // Level should report error because beta failed
@@ -1945,8 +1993,8 @@ fn test_max_concurrency_one_serializes_execution() {
     }));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
     let events_path = events::events_path(&state_dir);
-    let reporter: Arc<Mutex<dyn Reporter + Send>> =
-        Arc::new(Mutex::new(CollectingReporter::default()));
+    let mut reporter = CollectingReporter::default();
+    let send_reporter = make_send_reporter();
 
     let level = PublishLevel { level: 0, packages };
 
@@ -1963,7 +2011,8 @@ fn test_max_concurrency_one_serializes_execution() {
                 &state_dir,
                 &event_log,
                 &events_path,
-                &reporter,
+                &mut reporter,
+                &send_reporter,
             )
             .expect("level publish");
 
@@ -3073,8 +3122,8 @@ fn test_max_concurrent_exceeds_package_count() {
     }));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
     let events_path = events::events_path(&state_dir);
-    let reporter: Arc<Mutex<dyn Reporter + Send>> =
-        Arc::new(Mutex::new(CollectingReporter::default()));
+    let mut reporter = CollectingReporter::default();
+    let send_reporter = make_send_reporter();
 
     let level = PublishLevel { level: 0, packages };
 
@@ -3091,7 +3140,8 @@ fn test_max_concurrent_exceeds_package_count() {
                 &state_dir,
                 &event_log,
                 &events_path,
-                &reporter,
+                &mut reporter,
+                &send_reporter,
             )
             .expect("level publish");
 
@@ -3184,8 +3234,8 @@ fn test_independent_failures_both_reported() {
     }));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
     let events_path = events::events_path(&state_dir);
-    let reporter: Arc<Mutex<dyn Reporter + Send>> =
-        Arc::new(Mutex::new(CollectingReporter::default()));
+    let mut reporter = CollectingReporter::default();
+    let send_reporter = make_send_reporter();
 
     let level = PublishLevel { level: 0, packages };
 
@@ -3208,7 +3258,8 @@ fn test_independent_failures_both_reported() {
                 &state_dir,
                 &event_log,
                 &events_path,
-                &reporter,
+                &mut reporter,
+                &send_reporter,
             );
 
             assert!(result.is_err());
@@ -3297,8 +3348,8 @@ fn test_concurrent_state_updates_consistent() {
     }));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
     let events_path = events::events_path(&state_dir);
-    let reporter: Arc<Mutex<dyn Reporter + Send>> =
-        Arc::new(Mutex::new(CollectingReporter::default()));
+    let mut reporter = CollectingReporter::default();
+    let send_reporter = make_send_reporter();
 
     let level = PublishLevel { level: 0, packages };
 
@@ -3315,7 +3366,8 @@ fn test_concurrent_state_updates_consistent() {
                 &state_dir,
                 &event_log,
                 &events_path,
-                &reporter,
+                &mut reporter,
+                &send_reporter,
             )
             .expect("level publish");
 
@@ -3951,8 +4003,7 @@ fn reconcile_bdd_ambiguous_resolves_to_published() {
     )));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
     let events_path = events::events_path(&state_dir);
-    let reporter: Arc<Mutex<dyn Reporter + Send>> =
-        Arc::new(Mutex::new(CollectingReporter::default()));
+    let reporter = make_send_reporter();
 
     temp_env::with_vars(
         [
@@ -4063,8 +4114,7 @@ fn reconcile_bdd_ambiguous_resolves_to_not_published_then_retries() {
     )));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
     let events_path = events::events_path(&state_dir);
-    let reporter: Arc<Mutex<dyn Reporter + Send>> =
-        Arc::new(Mutex::new(CollectingReporter::default()));
+    let reporter = make_send_reporter();
 
     temp_env::with_vars(
         [
@@ -4166,8 +4216,7 @@ fn reconcile_bdd_resume_from_ambiguous_state_skips_republish() {
     let st = Arc::new(Mutex::new(initial_state));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
     let events_path = events::events_path(&state_dir);
-    let reporter: Arc<Mutex<dyn Reporter + Send>> =
-        Arc::new(Mutex::new(CollectingReporter::default()));
+    let reporter = make_send_reporter();
 
     // Track whether cargo was invoked via a log file.
     let cargo_log = td.path().join("cargo-calls.log");
@@ -4289,8 +4338,7 @@ fn reconcile_bdd_ambiguous_resolves_to_still_unknown() {
     )));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
     let events_path = events::events_path(&state_dir);
-    let reporter: Arc<Mutex<dyn Reporter + Send>> =
-        Arc::new(Mutex::new(CollectingReporter::default()));
+    let reporter = make_send_reporter();
 
     // Track cargo invocations to assert we did NOT blind-retry after
     // StillUnknown — exactly one attempt should hit cargo.


### PR DESCRIPTION
## Summary

Implements **PR 1** from the [scout's plan on issue #103](https://github.com/EffortlessMetrics/shipper/issues/103) — wires the existing `RetryBackoffStarted` event (landed in PR #113) to a **live CLI countdown** in the publish progress reporter, lifting the previously dead `ProgressReporter::set_status` function and replacing the silent `thread::sleep(delay)` window with per-second narration in TTY mode. Operators watching a CI log no longer stare at a silent terminal during retry-backoff sleeps.

- New `Reporter::retry_wait(...)` default method on both `engine::Reporter` and `engine::parallel::Reporter` — owns the backoff sleep so richer UIs can render live progress. Default impl preserves the pre-#103 behavior (`warn()` line + `thread::sleep`), so every existing reporter implementation keeps working without changes.
- The two retry-backoff helpers (`emit_retry_backoff_event` sequential, `emit_retry_backoff` parallel) record the `RetryBackoffStarted` event and then delegate the human-facing message + sleep to `Reporter::retry_wait`. The `events.jsonl` schema is unchanged.
- `ProgressReporter::set_status` is lifted off `#[allow(dead_code)]` and a new `ProgressReporter::retry_countdown(...)` drives the rendering: TTY ticks once per second via `set_status`; non-TTY emits a single line via `eprintln!`; quiet mode stays silent but still blocks for the full delay.
- `CliReporter` grows an `Option<ProgressReporter>` field installed by the `publish`/`resume` subcommands so the engine's retry narration actually drives the bar.

## Acceptance criteria (from the scout's plan)

- [x] When `RetryBackoffStarted` is emitted, operator sees:
  - **TTY:** \`[1/N] retrying name@ver in 45s... (attempt 2/5, reason: Retryable) - <msg>\` (countdown ticks down live).
  - **Non-TTY (CI):** \`[retry] name@ver: <msg> (Retryable); next attempt in 45s (attempt 2/5)\` (one-shot `eprintln!`, no timer spam).
- [x] Event is still emitted to `events.jsonl`; no changes to event log schema.
- [x] `ProgressReporter::set_status` is no longer dead code.
- [x] Existing reporter implementations (`TestReporter`, `CollectingReporter`, `SendReporter`) keep working via the default trait impl.

## Test plan

- [x] `cargo fmt --all -- --check` passes.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes.
- [x] `cargo test -p shipper-cli` — 113/113 lib tests + 22/22 `cli_e2e` integration tests pass (single-threaded; `cli_e2e` has a known pre-existing flake on parallel `preflight_command_finishability_proven`, unrelated to this change).
- [x] `cargo test -p shipper-core` — 1890/1890 tests pass.
- [x] `cargo test -p shipper` — 39/39 façade tests pass.
- [x] New `progress::tests` cases (4): silent-mode blocks for delay, zero delay returns immediately, non-TTY one-shot path doesn't panic, exotic attempt/max boundaries.
- [x] New `lib::tests` cases (3): `CliReporter::retry_wait` without progress blocks for delay, with progress routes through countdown, default trait impl preserves the canonical warn-line format.

## Out of scope (deferred to later #103 PRs)

- PR 2 — `ExecutionState` per-attempt history enrichment.
- PR 3 — `shipper inspect-events --tail` / `--follow` streaming modes.
- PR 4 — `shipper watch` live TUI subcommand.

Closes (partial): #103.