### PR TITLE
docs(agents): simplify local repo guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,107 +2,26 @@
 
 Use this file with [CLAUDE.md](./CLAUDE.md) before making changes in this directory.
 
-This file provides repository guidance for agentic coding tools working in this repository.
+## Purpose
 
-## Orientation
+This is the workspace entrypoint. Use it to orient yourself before diving into a crate or docs subtree.
 
-- [**MISSION.md**](MISSION.md) — north star: mission, vision, audience, beliefs. Read before scoping non-trivial work.
-- [**ROADMAP.md**](ROADMAP.md) — five pillars + nine-competency thesis, current status, now/next/later sequencing.
-- [**docs/README.md**](docs/README.md) — documentation index (Diátaxis: tutorials/how-to/reference/explanation).
-- [**docs/explanation/why-shipper.md**](docs/explanation/why-shipper.md) — the *why*, distilled.
-- [**docs/product.md**](docs/product.md), [**docs/structure.md**](docs/structure.md), [**docs/tech.md**](docs/tech.md) — steering docs.
-- [**docs/INVARIANTS.md**](docs/INVARIANTS.md) — events-as-truth contract.
+## Key areas
 
-## Useful command entry points
+- `MISSION.md`, `ROADMAP.md`, `docs/README.md` — product intent, priorities, and docs map.
+- `crates/shipper-core` — publish engine and stateful release logic.
+- `crates/shipper-cli` — clap types, command dispatch, help text, and terminal output.
+- `crates/shipper` — install-facing facade and curated re-exports.
+- `docs/` — operator, product, and architecture docs.
 
-```bash
-# Build
-cargo build                    # debug
-cargo build --release          # release (LTO + strip)
+## Invariants
 
-# Run CLI during development (without installing)
-cargo run -p shipper -- <command>       # preferred: runs the `shipper` binary
-cargo run -p shipper-cli -- <command>   # equivalent; same code path
+- Behavior changes belong in `shipper-core`.
+- CLI surface and output changes belong in `shipper-cli`.
+- `shipper` stays thin.
+- `events.jsonl` is the source of truth; `state.json` is a projection; `receipt.json` is a summary.
 
-# Install CLI locally
-cargo install --path crates/shipper --locked
+## Checks
 
-# Tests
-cargo test                                         # all workspace tests
-cargo test -p shipper-core                         # engine crate
-cargo test -p shipper-cli                          # CLI adapter crate
-cargo test -p shipper                              # façade (integration tests)
-cargo test -p shipper-core some_test_name          # substring match
-cargo test -p shipper-core some_test_name -- --exact # exact match
-cargo test --test cli_e2e -p shipper-cli           # CLI integration tests only
-
-# Lint & format
-cargo fmt --all
-cargo fmt --all -- --check
-cargo clippy --workspace --all-targets --all-features -- -D warnings
-```
-
-## Architecture
-
-Three-crate product shape (#95):
-
-```
-shipper (install face — carries the `shipper` binary + curated lib re-export)
-  -> shipper-cli (real CLI adapter; exposes pub fn run())
-       -> shipper-core (engine — no CLI deps, stable embedding surface)
-```
-
-- **`crates/shipper-core`** — all engine/library logic: plan, preflight, publish, resume, state, ops. No `clap`, no `indicatif`. This is where behavior changes land.
-- **`crates/shipper-cli`** — CLI adapter. Owns `clap` derive types, subcommand dispatch, help text, progress rendering. Exposes `pub fn run() -> anyhow::Result<()>` as the embedding entry point.
-- **`crates/shipper`** — install façade. 3-line binary forwarding to `shipper_cli::run()`, plus a library that re-exports a curated subset of `shipper-core` (`engine`, `plan`, `types`, `config`, `state`, `store`) for drivers that prefer the product name. Changes rarely.
-
-When touching code: behavior work lives in `shipper-core`; CLI work (arguments, help text, output) lives in `shipper-cli`; the `shipper` crate mostly shouldn't move.
-
-### Publishing Pipeline
-
-The core flow is: **plan → preflight → publish → (resume if interrupted)**
-
-1. **Plan** (`shipper-core/src/plan/`): Reads workspace via `cargo_metadata`, filters publishable crates, topologically sorts by intra-workspace dependencies (Kahn's algorithm with BTreeSet for determinism), generates a SHA256-based plan ID.
-2. **Preflight** (`shipper-core/src/engine/`): Validates git cleanliness, registry reachability, dry-run, version existence, and optional ownership checks. Produces a `Finishability` assessment (Proven/NotProven/Failed).
-3. **Publish** (`shipper-core/src/engine/`): Executes plan one crate at a time with retry/backoff. After each `cargo publish`, verifies registry visibility (API or sparse index) before proceeding. Persists `ExecutionState` to disk after every step for resumability.
-4. **Resume**: Reloads state from `.shipper/state.json`, validates plan ID match, skips already-published packages, continues from first pending/failed.
-
-### Key Abstractions
-
-- **`StateStore` trait** (`shipper-core/src/state/store/`): Persistence abstraction for state/receipt/events. Currently filesystem-backed; designed for future cloud storage backends.
-- **`Reporter` trait** (`shipper-core/src/engine/`): Pluggable output handler for publish/preflight progress.
-- **`ErrorClass`** enum: Classifies failures as `Retryable` (HTTP 429, network), `Permanent` (auth, version conflict), or `Ambiguous` (upload may have succeeded despite client error). Only retryable errors trigger backoff retries.
-- **`PublishPolicy`/`VerifyMode`/`ReadinessMethod`**: Configuration enums controlling safety vs speed tradeoffs.
-
-### State Files
-
-Written to `.shipper/` (configurable via `--state-dir`):
-- `state.json` — resumable execution state (schema-versioned). **Projection** of events.
-- `receipt.json` — audit receipt with evidence (stdout/stderr, exit codes, git context, environment fingerprint). **Summary** derived at end-of-run.
-- `events.jsonl` — append-only event log. **Authoritative truth.**
-- `lock` — distributed lock preventing concurrent publishes
-
-### Events-as-truth invariant
-
-`events.jsonl` is authoritative; `state.json` is a projection; `receipt.json` is a summary. See [docs/INVARIANTS.md](docs/INVARIANTS.md). When the three disagree, events win — and a drift is a bug. Tooling that needs ground truth should read events; tooling that needs fast "what's done" can read state.
-
-In `state.json`, package status is at `.packages[].state.state`, not `.packages[].status` — common source of misreads.
-
-## Product context
-
-[**MISSION.md**](MISSION.md) is the north star — mission, vision, audience, and the nine convictions that produce every design decision. Read it before scoping non-trivial work.
-
-Cargo 1.90 stabilized multi-package workspace publishing. Shipper's value is what Cargo still doesn't do, organized as nine competencies: **Prove, Survive, Reconcile, Narrate, Remediate, Harden, Profile, Integrate, Ergonomics**. See [ROADMAP.md](ROADMAP.md) and master tracking issue [#109](https://github.com/EffortlessMetrics/shipper/issues/109). The biggest open gap is **Reconcile** ([#102](https://github.com/EffortlessMetrics/shipper/issues/102) / [#99](https://github.com/EffortlessMetrics/shipper/issues/99)): when `cargo publish` exits ambiguously, Shipper currently blind-retries instead of reconciling against the registry.
-
-## Conventions
-
-- **`unsafe_code = "forbid"`** is enforced workspace-wide. No unsafe blocks.
-- Edition 2024, MSRV 1.92, resolver v3.
-- Tests that mutate environment variables or filesystem use `#[serial]` from `serial_test` for isolation.
-- Registry interactions in tests use `tiny_http` mock servers, never real registries.
-- Snapshot tests use `insta`. Property-based tests use `proptest`.
-- Token resolution follows Cargo conventions: `CARGO_REGISTRY_TOKEN` → `CARGO_REGISTRIES_<NAME>_TOKEN` → `$CARGO_HOME/credentials.toml`. Tokens are opaque strings, never logged.
-- Configuration can be set via `.shipper.toml` in workspace root; CLI flags override config file values. Config sections: `[policy]`, `[verify]`, `[readiness]`, `[output]`, `[lock]`, `[retry]`, `[flags]`, `[parallel]`, `[registry]`. Ownership/git settings live in `[flags]`, not a separate `[preflight]` section.
-- `config init` uses `-o`/`--output`; `config validate` uses `-p`/`--path`.
-- `prefer_index` and `index_path` (readiness) are config-file-only settings with no CLI flags.
-
+- Run the smallest relevant crate tests first.
+- Before finishing broader changes, run `cargo fmt --all -- --check` and the relevant `cargo test -p ...` / `cargo clippy -p ...` commands.

--- a/crates/shipper-cli/tests/AGENTS.md
+++ b/crates/shipper-cli/tests/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+## Purpose
+
+This test tree covers the install-facing CLI behavior: parsing, help text, snapshots, and end-to-end command flows.
+
+## Key files
+
+- `cli_snapshots.rs` — help and error output snapshots.
+- `e2e_expanded.rs` — broad CLI snapshot coverage.
+- `bdd_*.rs` — operator-facing workflow tests.
+- `snapshots/` — accepted CLI output fixtures.
+
+## Invariants
+
+- The product-facing command name is `shipper`.
+- Snapshot updates should follow intentional output changes, not test convenience.
+- Keep environment-dependent output normalized so snapshots stay portable across platforms.
+
+## Checks
+
+- Run the smallest affected test target first, for example `cargo test -p shipper-cli --test cli_snapshots` or `--test e2e_expanded`.
+- Review snapshot diffs before finishing any CLI-output change.

--- a/crates/shipper-core/src/engine/AGENTS.md
+++ b/crates/shipper-core/src/engine/AGENTS.md
@@ -2,34 +2,22 @@
 
 Use this file with [CLAUDE.md](./CLAUDE.md) before making changes in this directory.
 
-# Layer: `engine` (orchestration — top of the stack)
+## Purpose
 
-**Position in the architecture:** Layer 5 (top). Coordinates all lower layers.
+This directory orchestrates the release pipeline: plan -> preflight -> publish -> resume.
 
-## Single responsibility
+## Key files
 
-Orchestrate the **plan -> preflight -> publish -> resume** pipeline. Loop
-through the plan, invoke registry/cargo operations, persist state after each
-step, retry on transient failures, classify errors.
+- `mod.rs` — main entrypoints and the `Reporter` trait.
+- `parallel/` — dependency-level parallel publish execution.
 
-## Import rules
+## Invariants
 
-`engine` modules MAY import from any layer below: `crate::plan::*`,
-`crate::state::*`, `crate::runtime::*`, `crate::ops::*`, `crate::types`, plus
-public crates (`shipper_registry`, `shipper_webhook`, `shipper_retry`, etc.).
+- Orchestration belongs here; clap parsing and terminal presentation do not.
+- State persistence, retries, and publish/readiness flow should stay coherent with the serial pipeline.
+- Changes here often affect CLI snapshots and resume/publish behavior across crates.
 
-`engine` is the top of the dependency tree — nothing imports from `engine`
-except `lib.rs` re-exports and `shipper-cli`.
+## Checks
 
-## What lives here
-
-- `engine/mod.rs` — current orchestration entry points (`run_preflight`,
-  `run_publish`, `run_resume`) and the `Reporter` trait. This file was moved
-  verbatim from `crates/shipper/src/engine.rs` when the `engine/` layer dir
-  was introduced.
-- `engine/parallel/` — wave-based parallel publish (was the standalone
-  `shipper-engine-parallel` crate, absorbed in the same PR that created this
-  layer dir).
-- Future: `engine/preflight/`, `engine/publish/`, `engine/resume/`,
-  `engine/readiness/` as `engine/mod.rs` gets split up.
-
+- Run the targeted `shipper-core` tests that cover the changed engine path.
+- If user-visible output or workflow behavior changes, run the relevant `shipper-cli` tests too.

--- a/crates/shipper-core/src/engine/parallel/AGENTS.md
+++ b/crates/shipper-core/src/engine/parallel/AGENTS.md
@@ -2,66 +2,24 @@
 
 Use this file with [CLAUDE.md](./CLAUDE.md) before making changes in this directory.
 
-# Module: `crate::engine::parallel`
+## Purpose
 
-**Layer:** engine (layer 5, top)
+This directory handles wave-based parallel publishing for crates that can be released concurrently.
 
-**Single responsibility:** Wave-based parallel publish engine. Schedules
-independent crates into concurrent publish waves based on the dependency
-graph produced by `ws.plan.group_by_levels()` on the current release plan.
+## Key files
 
-**Was:** standalone crate `shipper-engine-parallel` (absorbed — chosen as
-canonical because it had +1589 LOC of additional functionality vs the
-in-tree duplicate, including the webhook submodule and BDD tests).
-
-## Public API
-
-- `pub fn run_publish_parallel(ws, opts, st, state_dir, reg, reporter)` —
-  main entry point. Takes the host crate's `crate::registry::RegistryClient`
-  and `crate::engine::Reporter` for seamless interop with `engine::mod`.
-- `pub struct ParallelConfig` — re-exported through `shipper_types`.
-- `pub trait Reporter` — local reporter trait used internally; the outer
-  entry point adapts from `crate::engine::Reporter`.
-- `pub use shipper_chunking::chunk_by_max_concurrent;` — re-export of the
-  chunking helper used for wave planning.
-
-## File layout
-
-- `mod.rs` — public entry, `Reporter` trait, adapter, `run_publish_parallel`
-  and its internal counterpart `run_publish_parallel_inner`, plus inline
-  `#[cfg(test)] mod tests;` and `mod property_tests`.
-- `publish.rs` — single-package/single-level primitives
-  (`publish_package`, `run_publish_level`, `PackagePublishResult`).
-- `readiness.rs` — readiness-visibility polling with backoff/jitter and
-  sparse-index fallback.
-- `reconcile.rs` — ambiguous-publish reconciliation against registry truth.
-  Wraps `readiness::is_version_visible_with_backoff` into a three-outcome
-  state machine (`Published` / `NotPublished` / `StillUnknown`) so the
-  publish retry loop can avoid blind retries after an ambiguous `cargo
-  publish` exit. See `shipper-types::ReconciliationOutcome` and issue #99.
-- `policy.rs` — `policy_effects` adapter (translates `PublishPolicy` into
-  resolved effects).
-- `webhook.rs` — engine-specific webhook glue wrapping `shipper_webhook`.
-  Kept as a sub-file because it defines a parallel-publish-specific
-  `WebhookEvent` enum and payload builder that are not reusable outside
-  this module.
-- `tests.rs` — full test suite (unit, snapshot, policy, snapshot_tests
-  submodule).
-- `snapshots/` — insta snapshots for chunking, execution plans, policy
-  effects.
+- `mod.rs` — entrypoint, reporter adapter, and top-level coordination.
+- `publish.rs` — per-package and per-wave execution.
+- `readiness.rs` and `reconcile.rs` — visibility checks and ambiguous publish handling.
+- `tests.rs` and `snapshots/` — scheduling and behavior coverage.
 
 ## Invariants
 
-- Topological wave ordering — crates within a wave have no inter-crate deps.
-- All-or-nothing per wave: if any crate in a wave fails fatally, halt.
-- State persisted after each crate completion (resumability).
+- Waves must still respect dependency order.
+- Persist state after package completion so interrupted runs stay resumable.
+- Keep retry, readiness, and reconciliation behavior aligned with the main engine contracts.
 
-## Internal microcrate dependencies (transitional)
+## Checks
 
-This module currently imports from `crate::runtime::execution`, `crate::ops::cargo`
-(absorbed from `shipper-cargo`), `crate::state::events`,
-`crate::state::execution_state`, `crate::plan`, `shipper_registry`,
-`shipper_types`, `shipper_webhook`, `shipper_sparse_index`. As each of the
-remaining microcrates is absorbed in subsequent PRs, these imports will be
-rewritten to `crate::*` paths.
-
+- Run the parallel `shipper-core` tests and review any changed snapshots.
+- If progress or narration changes, run the affected `shipper-cli` tests too.

--- a/crates/shipper-core/src/ops/AGENTS.md
+++ b/crates/shipper-core/src/ops/AGENTS.md
@@ -2,49 +2,25 @@
 
 Use this file with [CLAUDE.md](./CLAUDE.md) before making changes in this directory.
 
-# Layer: `ops` (I/O primitives)
+## Purpose
 
-**Position in the architecture:** Layer 1 (bottom). The lowest layer of the `shipper-core` crate.
+This directory owns low-level I/O helpers: cargo, git, locks, process execution, auth, and storage primitives.
 
-## Single responsibility
+## Key files
 
-Talk to the outside world: filesystem, git binary, cargo subprocess, OS, network.
+- `auth/` — token resolution.
+- `cargo/` — cargo metadata and publish subprocesses.
+- `git/` — git cleanliness and context capture.
+- `lock/` — advisory lock files.
+- `process/` and `storage/` — subprocess and persistence helpers.
 
-## Import rules
+## Invariants
 
-`ops` modules MUST NOT import from any higher layer:
-- ❌ `use crate::engine::...`
-- ❌ `use crate::plan::...`
-- ❌ `use crate::state::...`
-- ❌ `use crate::runtime::...`
+- Keep this layer free of engine/plan/state/runtime orchestration.
+- Error text that is pinned by CLI snapshots should not drift accidentally.
+- Prefer small wrappers with stable behavior over clever abstractions here.
 
-`ops` modules MAY import from:
-- ✅ `crate::types` (re-exports of `shipper-types`)
-- ✅ External crates (`anyhow`, `serde`, `tokio`, etc.)
-- ✅ Other `crate::ops::*` modules (with care — prefer `mod.rs` facades over deep paths)
+## Checks
 
-These are enforced by `.github/workflows/architecture-guard.yml`.
-
-## What lives here
-
-Each absorbed I/O microcrate gets its own folder under `ops/`:
-
-- `ops/auth/` — Cargo registry token resolution (was `shipper-auth`)
-- `ops/git/` — Git cleanliness checks, context capture (was `shipper-git`)
-- `ops/lock/` — Advisory file lock (was `shipper-lock`)
-- `ops/process/` — Cross-platform command execution (was `shipper-process`)
-- `ops/cargo/` — Cargo metadata + cargo publish invocation (was `shipper-cargo`)
-- `ops/storage/` — Storage backend trait + filesystem impl (was `shipper-storage`)
-
-## What does NOT live here
-
-- `shipper-registry`, `shipper-webhook`, `shipper-sparse-index` — these are public crates that `shipper-core` depends on directly. No internal wrapper inside `ops/`.
-- Domain types — those live in `shipper-types`.
-- Orchestration — that's `engine/`.
-
-## Boundary discipline
-
-- Each subfolder has its own `mod.rs` facade. Other modules talk through the facade, not by reaching into deep paths.
-- Default visibility: `pub(crate)`. Only items truly part of `shipper-core`'s public API get `pub`.
-- Each subfolder has its own local guidance files (`CLAUDE.md` and matching `AGENTS.md`) describing its single responsibility.
-
+- Run the targeted `shipper-core` tests for the touched helper.
+- If boundary rules change, make sure the architecture guard still passes.

--- a/crates/shipper-core/src/ops/git/AGENTS.md
+++ b/crates/shipper-core/src/ops/git/AGENTS.md
@@ -2,70 +2,24 @@
 
 Use this file with [CLAUDE.md](./CLAUDE.md) before making changes in this directory.
 
-# Module: `crate::ops::git`
+## Purpose
 
-**Layer:** ops (layer 1, bottom)
-**Single responsibility:** Git repository operations — cleanliness check, context capture for receipts.
-**Was:** standalone crate `shipper-git` + in-tree `shipper/src/git.rs` shim wrapper (both absorbed during decrating Phase 2).
+This directory owns git cleanliness checks and git context capture for receipts and preflight.
 
-## Public-to-crate API
+## Key files
 
-Public module path: `shipper_core::git`. Inside `shipper-core` itself, use
-`crate::git`. The install-facing `shipper` facade does not re-export this
-module.
-
-- `collect_git_context() -> Option<crate::types::GitContext>` — populate a
-  `GitContext` for the current working directory. Returns `None` when the CWD
-  is not inside a git repo. Defined in `mod.rs`.
-- `is_git_clean(repo_root: &Path) -> anyhow::Result<bool>` — porcelain-status
-  check. Treats any untracked, staged, or modified file as dirty.
-- `ensure_git_clean(repo_root: &Path) -> anyhow::Result<()>` — fail fast if
-  the working tree is dirty. Error phrasing:
-  `"git working tree is not clean; commit/stash changes or use --allow-dirty"`
-  (pinned by the `shipper-cli` snapshot tests).
-
-Crate-internal helpers live in the sibling sub-modules:
-
-- `cleanliness.rs` — `is_git_clean`/`ensure_git_clean` (canonical CLI error
-  phrasing) plus `ensure_git_clean_legacy` (the original shipper-git error
-  wording, still referenced by the preserved snapshot tests).
-- `context.rs` — commit/branch/tag/changed-files/remote queries and the
-  aggregator `get_git_context`. Also retains the ORIGINAL shipper-git
-  `is_git_clean` / `ensure_git_clean` with the legacy error phrasing (used by
-  this module's own tests; the outer facade in `cleanliness.rs` supersedes
-  them for public callers).
-- `bin_override.rs` — `SHIPPER_GIT_BIN` routing: `git_program`, `is_repo_root`,
-  `local_is_git_clean`, plus parallel implementations of commit / branch / tag /
-  dirty helpers that honor the override.
+- `mod.rs` — public entrypoints used by the rest of `shipper-core`.
+- `cleanliness.rs` — clean/dirty checks and error phrasing.
+- `context.rs` — branch, commit, tag, and changed-file capture.
+- `bin_override.rs` — `SHIPPER_GIT_BIN` override handling for tests and custom environments.
 
 ## Invariants
 
-- **`SHIPPER_GIT_BIN` env var** overrides the git executable path (useful for
-  tests and sandboxed environments). `git_program()` returns the env value
-  verbatim (including empty strings, to preserve pre-absorption behavior).
-- **Error-text compatibility.** The outer `is_git_clean` wrapper prefixes the
-  underlying error with an extra `git status failed:` string; the CLI snapshot
-  tests assert against the doubled prefix (`git status failed: git status
-  failed: …`). Do not change this wording without updating
-  `crates/shipper-cli/tests/snapshots/e2e_expanded__preflight_*.snap`.
-- **Short commit slicing.** `GitContext::short_commit` on `shipper-types`
-  slices by BYTE index (not char index). This matches the original
-  `shipper-git` crate — commit hashes are always ASCII hex so byte = char, but
-  arbitrary inputs shorter than 7 bytes are returned verbatim.
-- **Collector is override-strict.** When `SHIPPER_GIT_BIN` is set,
-  `collect_git_context` uses only the override helpers; there is no silent
-  fallback to the default `git` binary for any sub-query.
-- **`is_dirty()` default.** When `GitContext::dirty` is `None`, `is_dirty()`
-  returns `true` (treat unknown as dirty) — matches the safe-by-default
-  semantics pre-absorption.
+- Keep CLI-visible clean/dirty error wording stable unless the snapshot updates are intentional.
+- `SHIPPER_GIT_BIN` must keep working for tests and sandboxed setups.
+- Unknown or partial git state should stay safe-by-default.
 
-## Architectural notes
+## Checks
 
-- Layer-1 pure I/O. Must not import from `engine`, `plan`, `state`, or
-  `runtime` (enforced by `.github/workflows/architecture-guard.yml`).
-- Depends only on `crate::types::GitContext` (re-exported from
-  `shipper-types`) and external crates (`anyhow`).
-- All subprocess spawning uses `std::process::Command` directly (pre-existing
-  behavior; migration to `crate::ops::process` is out of scope for this
-  absorption).
-
+- Run the git-related `shipper-core` tests.
+- If messages change, run the affected `shipper-cli` preflight/help snapshots too.

--- a/crates/shipper-core/src/ops/lock/AGENTS.md
+++ b/crates/shipper-core/src/ops/lock/AGENTS.md
@@ -2,58 +2,21 @@
 
 Use this file with [CLAUDE.md](./CLAUDE.md) before making changes in this directory.
 
-# Module: `crate::ops::lock`
+## Purpose
 
-**Layer:** ops (layer 1, bottom)
-**Single responsibility:** Advisory file-based lock that prevents concurrent `shipper` runs from operating on the same workspace/state directory.
-**Was:** standalone crate `shipper-lock` (absorbed during decrating Phase 2).
+This directory owns the advisory lock file used to prevent concurrent runs from mutating the same state directory.
 
-The lock is a JSON file in the state directory (default `.shipper/lock`) that
-records the PID, hostname, `acquired_at` timestamp, and optional `plan_id` of
-the holder. Acquisition is via atomic `File::create` + `fs::rename` after a
-check-then-create. Release happens on `Drop` (best effort) or via
-`LockFile::release()`. A stale-lock timeout path (`acquire_with_timeout`) lets
-callers reclaim locks whose holders died without releasing.
+## Key files
 
-## Public-to-crate API
+- `mod.rs` — lock path resolution, acquisition, release, and stale-lock handling.
 
-Public module path: `shipper_core::lock`. Inside `shipper-core` itself, use
-`crate::lock`. The install-facing `shipper` facade does not re-export this
-module.
+## Invariants
 
-- `LOCK_FILE` — default lock filename constant.
-- `LockInfo` — serde struct written to the lock file.
-- `LockFile` — RAII handle; `acquire`, `acquire_with_timeout`, `release`,
-  `set_plan_id`, `is_locked`, `read_lock_info`.
-- `lock_path(state_dir, workspace_root)` — resolves the concrete lock path,
-  with an optional `DefaultHasher`-derived suffix when `workspace_root` is
-  `Some` (so multiple workspaces sharing a state dir don't collide).
+- Lock acquisition semantics should stay conservative; do not accidentally weaken concurrent-run protection.
+- Release remains best-effort, including drop-path cleanup.
+- Changes to lock metadata or file naming affect resume/publish coordination across the tool.
 
-## Invariants & gotchas
+## Checks
 
-- **Not a true atomic mutex.** `acquire` does a check-then-create which races
-  under concurrent contention. The engine relies on workspace-level cooperation,
-  not OS-level file locking. See `concurrent_acquire_only_one_succeeds` — at
-  least one thread is guaranteed to win, but more than one *may* succeed in a
-  tight race. Callers that need strict mutual exclusion should layer their own
-  guard on top (or switch to OS advisory locks — a deliberate future option).
-- **Write-then-rename** is used to publish the lock atomically inside a single
-  filesystem. `fsync` of the parent dir is attempted but ignored on failure.
-- **`Drop` is best-effort.** If the file is externally removed, `release`
-  silently succeeds; `set_plan_id` on a released lock returns an error.
-- **Stale-lock detection is wall-clock based.** `acquire_with_timeout`
-  compares `Utc::now() - acquired_at` to the configured timeout. A lock whose
-  age is *exactly* the timeout is NOT considered stale (strictly `>`). Corrupt
-  lock files are treated as stale by `acquire_with_timeout` but as errors by
-  plain `acquire`.
-- **`lock_path` hash is `DefaultHasher`.** Stable for a single Rust build but
-  NOT guaranteed across versions; collisions are extremely rare but possible.
-  This is fine for the workspace-disambiguation use case it serves.
-
-## Architectural notes
-
-- Layer-1 pure I/O. Must not import from `engine`, `plan`, `state`, or
-  `runtime` (enforced by `.github/workflows/architecture-guard.yml`).
-- No async. Synchronous filesystem calls only.
-- Dependencies: `anyhow`, `serde`, `serde_json`, `chrono`, `gethostname`.
-
+- Run the lock-related `shipper-core` tests.
+- If lock behavior changes, also sanity-check the affected publish/resume flows.

--- a/crates/shipper/tests/AGENTS.md
+++ b/crates/shipper/tests/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+## Purpose
+
+This test tree covers the install-facing `shipper` facade as a product surface, not the internal engine implementation.
+
+## Key files
+
+- `facade_integration.rs` and `cross_crate_integration.rs` — facade and re-export expectations.
+- `pipeline_integration.rs` and `integration_plan_engine.rs` — end-to-end behavior through the public crate surface.
+- `schema_version_integration.rs` and `state_integration.rs` — compatibility and persisted-state expectations.
+
+## Invariants
+
+- These tests should exercise `shipper` as a thin facade over `shipper-cli` / `shipper-core`.
+- If a failure points to engine behavior, fix the lower crate rather than adding facade-only workarounds here.
+- Keep tests focused on the public `shipper` surface and product-level integration points.
+
+## Checks
+
+- Run `cargo test -p shipper`.
+- If re-exports move, update the affected integration tests in the same change.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+## Purpose
+
+This directory owns the user-facing docs set: tutorials, how-to guides, reference docs, and explanation docs.
+
+## Key files
+
+- `README.md` — docs index and Diataxis map.
+- `reference/cli.md` — canonical CLI reference.
+- `INVARIANTS.md` — events/state/receipt authority rules.
+- `release-runbook.md` and `how-to/` — operator-facing workflows.
+
+## Invariants
+
+- Keep docs aligned with the install-facing command name: `shipper`.
+- Preserve the Diataxis split: tutorials teach, how-to guides solve tasks, reference docs specify, explanation docs justify.
+- When describing `.shipper/` artifacts, keep the authority order consistent with `INVARIANTS.md`.
+
+## Checks
+
+- Update `docs/README.md` when adding or moving docs.
+- Spot-check commands, file names, and flags against the current CLI help or tests.


### PR DESCRIPTION
## Summary
- collapse the repo-root AGENTS guide into a short workspace entrypoint note
- rewrite the oversized shipper-core engine and ops AGENTS files as small local explainers
- add missing docs and test-tree AGENTS entrypoints for direct agent navigation

## Testing
- not run (docs-only changes)
