### PR TITLE
ci(codecov): complete Codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,55 +211,6 @@ jobs:
         env:
           RUSTDOCFLAGS: -Dwarnings
 
-  coverage:
-    name: Coverage (llvm-cov)
-    runs-on: ubuntu-latest
-    needs: [lint]
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools-preview
-
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-llvm-cov
-
-      - name: Cache Cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-coverage-
-
-      - name: Generate coverage (lcov)
-        run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
-        env:
-          INSTA_UPDATE: "no"
-          # llvm-cov instrumentation + Argon2 proptests is a bad combination.
-          # Coverage signal does not need max-strength property exploration.
-          PROPTEST_CASES: "16"
-
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: lcov
-          path: lcov.info
-          retention-days: 14
-
-      - name: Upload to Codecov
-        uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
-
   bdd:
     name: BDD Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,138 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
+      - "fuzz/**"
+      - ".github/workflows/coverage.yml"
+      - "codecov.yml"
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
+      - "fuzz/**"
+      - ".github/workflows/coverage.yml"
+      - "codecov.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coverage-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  RUSTFLAGS: "-C debuginfo=0"
+
+jobs:
+  coverage:
+    name: Codecov Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'coverage') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.92.0"
+          components: llvm-tools-preview
+
+      - name: Use larger target dir
+        run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/target" >> "$GITHUB_ENV"
+
+      - name: Cache Cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ${{ runner.temp }}/target
+          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-coverage-
+
+      - name: Install coverage tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov,cargo-nextest
+
+      - name: Generate coverage
+        env:
+          INSTA_UPDATE: "no"
+          PROPTEST_CASES: "16"
+        run: |
+          set -euo pipefail
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov nextest \
+            --workspace \
+            --locked \
+            --all-features \
+            --profile ci \
+            --no-report
+          cargo llvm-cov report --json --output-path coverage.json
+          cargo llvm-cov report --lcov --output-path lcov.info
+          cargo llvm-cov report --text | tee coverage.txt
+
+      - name: Validate coverage output
+        run: |
+          set -euo pipefail
+          test -s coverage.json
+          test -s coverage.txt
+          test -s lcov.info
+
+      - name: Detect Codecov token
+        id: codecov-token
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          if [ -n "${CODECOV_TOKEN:-}" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload coverage to Codecov (main)
+        if: ${{ always() && github.event_name == 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-core
+          name: shipper-rust-core
+          fail_ci_if_error: true
+
+      - name: Upload coverage to Codecov (advisory)
+        if: ${{ always() && github.event_name != 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-core
+          name: shipper-rust-core
+          fail_ci_if_error: false
+
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: |
+            coverage.json
+            coverage.txt
+            lcov.info
+          retention-days: 14

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -126,6 +126,56 @@ jobs:
           name: shipper-rust-core
           fail_ci_if_error: false
 
+      - name: Write coverage receipt
+        if: always()
+        run: |
+          mkdir -p target/coverage
+          python3 - <<'PY'
+          import json
+          import pathlib
+          receipt = {
+              "schema_version": 1,
+              "repo": "shipper",
+              "lane": "coverage",
+              "flag": "rust-core",
+              "workflow": "Coverage",
+              "artifacts": {
+                  "coverage_json": pathlib.Path("coverage.json").exists(),
+                  "coverage_text": pathlib.Path("coverage.txt").exists(),
+                  "lcov": pathlib.Path("lcov.info").exists(),
+              },
+              "claim_boundary": [
+                  "execution_surface_only",
+                  "not_publish_correctness",
+                  "not_registry_reconciliation",
+                  "not_token_redaction_safety",
+                  "not_encrypted_state_safety",
+                  "not_full_strength_crypto_proptests",
+                  "not_release_readiness"
+              ],
+          }
+          pathlib.Path("target/coverage/coverage-receipt.json").write_text(
+              json.dumps(receipt, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Summarize coverage artifacts
+        if: always()
+        run: |
+          {
+            echo "## Coverage"
+            echo ""
+            echo "| Artifact | Present |"
+            echo "| --- | ---: |"
+            echo "| coverage.json | $([ -s coverage.json ] && echo yes || echo no) |"
+            echo "| coverage.txt | $([ -s coverage.txt ] && echo yes || echo no) |"
+            echo "| lcov.info | $([ -s lcov.info ] && echo yes || echo no) |"
+            echo "| coverage-receipt.json | $([ -s target/coverage/coverage-receipt.json ] && echo yes || echo no) |"
+            echo ""
+            echo "Codecov flag: \`rust-core\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload coverage artifacts
         if: always()
         uses: actions/upload-artifact@v7
@@ -135,4 +185,5 @@ jobs:
             coverage.json
             coverage.txt
             lcov.info
+            target/coverage/coverage-receipt.json
           retention-days: 14

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,9 +1995,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # shipper
 
+[![CI](https://github.com/EffortlessMetrics/shipper/actions/workflows/ci.yml/badge.svg)](https://github.com/EffortlessMetrics/shipper/actions/workflows/ci.yml)
+[![Codecov](https://codecov.io/gh/EffortlessMetrics/shipper/branch/main/graph/badge.svg)](https://codecov.io/gh/EffortlessMetrics/shipper)
+[![MSRV](https://img.shields.io/badge/MSRV-1.92-blue.svg)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
+[![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
+
 Publishing a multi-crate Rust workspace is easy to start and hard to trust. Shipper gives you a deterministic plan, resumable execution, and an audit trail you can actually use when something goes sideways.
 
 ## What Shipper does

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+coverage:
+  precision: 2
+  round: down
+  range: "50...85"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+        informational: true
+        flags:
+          - rust-core
+    patch:
+      default:
+        target: 70%
+        threshold: 20%
+        informational: true
+        flags:
+          - rust-core
+comment: false
+github_checks:
+  annotations: false
+ignore:
+  - "target/**"
+  - "fuzz/**"

--- a/docs/ci/coverage.md
+++ b/docs/ci/coverage.md
@@ -1,0 +1,60 @@
+# Coverage
+
+Codecov coverage is execution-surface evidence. It answers:
+
+> Did tests execute this Rust surface?
+
+## What coverage does not answer
+
+- Whether publish execution is correct
+- Whether registry visibility reconciliation is correct
+- Whether ambiguous `cargo publish` recovery is correct
+- Whether token redaction is safe
+- Whether encrypted state handling is safe
+- Whether full-strength crypto property tests are adequate
+- Whether fuzzing is sufficient
+- Whether release readiness is proven
+
+Those are separate proof lanes, tracked independently.
+
+## Workflow triggers
+
+The Coverage workflow runs on:
+
+- Push to `main`
+- `workflow_dispatch` (manual trigger)
+- PRs labeled `coverage` or `full-ci`
+
+Runs are conditional on the label check, so ordinary PRs do not trigger coverage.
+
+## Durable receipts
+
+Coverage evidence persists in:
+
+- `coverage.json` — machine-readable coverage data
+- `coverage.txt` — human-readable summary
+- `lcov.info` — LCOV format for external tools
+- GitHub Actions coverage artifact (14-day retention)
+- Codecov dashboard
+
+## Configuration
+
+Coverage is configured via:
+
+- `.github/workflows/coverage.yml` — workflow definition
+- `codecov.yml` — Codecov status and reporting settings (advisory, not blocking)
+
+## Safety boundary
+
+Coverage statements apply only to:
+
+- Code paths exercised by the test suite
+- Under the current instrumentation configuration (PROPTEST_CASES=16 for cost control)
+
+Claims do not extend to:
+
+- Untested code paths
+- Theoretical correctness of the shipper publishing pipeline
+- Safety guarantees about registry state reconciliation
+- Correctness of token handling or encrypted state
+- Readiness for production release


### PR DESCRIPTION
## Summary
Implements Codecov for shipper through six focused, SRP commits:
1. Extract coverage from required CI into dedicated advisory workflow
2. Add quiet Codecov config (advisory-only, no comments)
3. Add README badges (CI, Codecov, MSRV, License)
4. Add coverage documentation with claim boundaries
5. Add coverage receipt artifact for audit trail
6. Fix security vulnerability (rustls-webpki RUSTSEC-2026-0104)

Coverage is now **opt-in for ordinary PRs** (labeled `coverage` or `full-ci`), reducing CI cost while preserving execution-surface visibility on main and dispatch.

## CI economics
- **Default PR LEM impact:** 0 → Coverage no longer required
- **Main branch impact:** Consistent; runs on every push
- **Branch protection impact:** None — Codecov is advisory-only
- **Failure mode caught:** Coverage regressions visible on demand
- **Cost reduction:** ~15 min per ordinary PR (llvm-cov + instrumentation)
- **Rollback path:** Delete coverage.yml and codecov.yml; restore job to ci.yml

## Technical details

### Extract coverage workflow
- Triggers: main push, `workflow_dispatch`, labeled PRs
- Path filters prevent spurious runs (Cargo files, workflows, codecov config)
- Preserves `PROPTEST_CASES=16` (instrumentation cost control)
- Uses `cargo-llvm-cov nextest` with structured output
- Conditional Codecov upload: required on main, optional on PRs
- Produces: coverage.json, coverage.txt, lcov.info, coverage-receipt.json

### Configuration
- **codecov.yml:** Advisory project status (5% threshold), patch coverage 70% target, no comments/annotations
- **docs/ci/coverage.md:** Clear claim boundary documentation
- **coverage-receipt.json:** Local audit evidence (schema v1, artifact presence, claim boundary markers)

### Security
- Upgraded rustls-webpki 0.103.12 → 0.103.13 to fix RUSTSEC-2026-0104
- All security checks pass

## Claim boundary
Codecov coverage is **execution-surface evidence only**. It answers: "Did tests exercise this surface?"

Coverage does **NOT** prove:
- Publish execution correctness
- Registry visibility reconciliation correctness
- Ambiguous `cargo publish` recovery correctness
- Token redaction safety
- Encrypted state safety
- Full-strength crypto property adequacy
- Fuzz robustness
- Release readiness

Those are separate proof lanes, tracked independently per [MISSION.md](MISSION.md).

## What's not included (by design)
- PR 6: Policy file registration (awaits policy structure)
- PR 7: Threshold ratcheting (awaits real main-branch data)
- Making Codecov required (left as advisory)

## Validation
- ✓ All YAML validates
- ✓ `cargo check --workspace --all-features` passes
- ✓ `cargo audit` passes (security patch applied)
- ✓ `git diff --check` passes
- ✓ All 6 commits have clear SRP scope

---
_Codecov implementation for EffortlessMetrics/shipper_  
_Branch: `claude/fix-codecov-shipper-SNm1l`_  
_Commits: 6 | Changes: +281 lines, -51 lines | Files: 6_