### PR TITLE
chore(msrv): raise MSRV 1.92 → 1.95, add rust-toolchain.toml and clippy.toml

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,7 +38,7 @@ Formatting & linting:
 - Clippy (recommended flags): `cargo clippy --workspace --all-targets --all-features -- -D warnings`
 
 Toolchain:
-- The workspace declares `rust-version = "1.92"` in `Cargo.toml`.
+- The workspace declares `rust-version = "1.95"` in `Cargo.toml`.
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,8 @@ jobs:
           restore-keys: ${{ runner.os }}-fuzz-
 
       - name: Run fuzz targets briefly
+        env:
+          RUSTUP_TOOLCHAIN: nightly
         run: |
           cargo fuzz run load_state --target x86_64-unknown-linux-gnu -- -max_total_time=60
           cargo fuzz run resolve_token --target x86_64-unknown-linux-gnu -- -max_total_time=60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,7 @@ jobs:
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
         with:
+          toolchain: nightly
           components: rust-src
 
       - name: Install cargo-fuzz
@@ -293,6 +294,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Add cross-compilation target
+        run: rustup target add ${{ matrix.target }}
 
       - name: Cache Cargo
         uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Install Rust (MSRV)
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.92.0
+          toolchain: 1.95.0
 
       - name: Cache Cargo
         uses: actions/cache@v5

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.92.0"
+          toolchain: "1.95.0"
           components: llvm-tools-preview
 
       - name: Use larger target dir

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,10 +113,10 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # MSRV sanity check gates the publish train. The published crates declare
-  # rust-version = 1.92; the publish job should not run if MSRV is broken.
+  # rust-version = 1.95; the publish job should not run if MSRV is broken.
   # ---------------------------------------------------------------------------
   msrv-gate:
-    name: MSRV gate (1.92)
+    name: MSRV gate (1.95)
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
@@ -124,7 +124,7 @@ jobs:
       - name: Install Rust (MSRV)
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.92.0
+          toolchain: 1.95.0
       - name: Cache Cargo
         uses: actions/cache@v5
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ Cargo 1.90 stabilized multi-package workspace publishing. Shipper's value is wha
 ## Conventions
 
 - **`unsafe_code = "forbid"`** is enforced workspace-wide. No unsafe blocks.
-- Edition 2024, MSRV 1.92, resolver v3.
+- Edition 2024, MSRV 1.95, resolver v3.
 - Tests that mutate environment variables or filesystem use `#[serial]` from `serial_test` for isolation.
 - Registry interactions in tests use `tiny_http` mock servers, never real registries.
 - Snapshot tests use `insta`. Property-based tests use `proptest`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **MSRV raised from 1.92 to 1.95.** `[workspace.package] rust-version` updated to `"1.95"`. `rust-toolchain.toml` pins the toolchain to `1.95.0` (minimal profile + rustfmt + clippy). `clippy.toml` sets `msrv = "1.95"`, cognitive-complexity threshold 40, too-many-arguments threshold 8. All CI MSRV references (ci.yml, coverage.yml, release.yml) updated. Documentation and badge updated accordingly.
+
 - **`shipper` crate:** the `shipper-cli` dependency is now behind a default `cli` feature. `cargo install shipper` and the `shipper` binary still work unchanged (the feature is on by default). Library consumers that only want the curated `shipper-core` re-export can opt out with `shipper = { version = "...", default-features = false }`, which drops the `clap` graph. `shipper-core` remains the canonical lean embedding surface.
 
 ### Planned — Rust 1.95 / 0.4.0 Quality Rollout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ Cargo 1.90 stabilized multi-package workspace publishing. Shipper's value is wha
 ## Conventions
 
 - **`unsafe_code = "forbid"`** is enforced workspace-wide. No unsafe blocks.
-- Edition 2024, MSRV 1.92, resolver v3.
+- Edition 2024, MSRV 1.95, resolver v3.
 - Tests that mutate environment variables or filesystem use `#[serial]` from `serial_test` for isolation.
 - Registry interactions in tests use `tiny_http` mock servers, never real registries.
 - Snapshot tests use `insta`. Property-based tests use `proptest`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ We follow the [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-
 
 ### Prerequisites
 
-- **Rust**: 1.92 or later (check with `rustc --version`)
+- **Rust**: 1.95 or later (check with `rustc --version`)
 - **Git**: For version control
 - **cargo-nextest** (optional): For better test output
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ resolver = "3"
 version = "0.3.0-rc.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
-rust-version = "1.92"
+rust-version = "1.95"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/EffortlessMetrics/shipper/actions/workflows/ci.yml/badge.svg)](https://github.com/EffortlessMetrics/shipper/actions/workflows/ci.yml)
 [![Codecov](https://codecov.io/gh/EffortlessMetrics/shipper/branch/main/graph/badge.svg)](https://codecov.io/gh/EffortlessMetrics/shipper)
-[![MSRV](https://img.shields.io/badge/MSRV-1.92-blue.svg)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
+[![MSRV](https://img.shields.io/badge/MSRV-1.95-blue.svg)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 
 Publishing a multi-crate Rust workspace is easy to start and hard to trust. Shipper gives you a deterministic plan, resumable execution, and an audit trail you can actually use when something goes sideways.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,7 +59,7 @@ Per [docs/INVARIANTS.md](docs/INVARIANTS.md): `events.jsonl` is authoritative an
 All domain logic lives in `crates/shipper`. `crates/shipper-cli` parses args and calls into the library. Other frontends (IDP plugins, dashboards, automation) consume the library directly.
 
 ### Forbid unsafe; respect MSRV
-`unsafe_code = "forbid"` workspace-wide. Edition 2024, MSRV 1.92.
+`unsafe_code = "forbid"` workspace-wide. Edition 2024, MSRV 1.95.
 
 ## Now / Next / Later
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,5 @@
+# shipper Clippy configuration.
+msrv = "1.95"
+cognitive-complexity-threshold = 40
+too-many-arguments-threshold = 8
+type-complexity-threshold = 300

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,7 +191,7 @@ Leaf crates (no shipper-* dependencies):
 ## Conventions
 
 - `unsafe_code = "forbid"` workspace-wide. No `unsafe` blocks anywhere.
-- Edition 2024, MSRV 1.92, resolver v3.
+- Edition 2024, MSRV 1.95, resolver v3.
 - Tests touching env vars or filesystem use `#[serial]` from `serial_test` for isolation.
 - Registry interactions in tests use `tiny_http` mock servers — never real registries.
 - Snapshot tests use `insta`. Property-based tests use `proptest`.

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -5,7 +5,7 @@
 ## Language & toolchain
 
 - **Rust edition 2024**
-- **MSRV: 1.92**
+- **MSRV: 1.95**
 - **Resolver v3**
 - `unsafe_code = "forbid"` workspace-wide — no `unsafe` blocks anywhere
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -412,7 +412,7 @@ and every pull request. The pipeline includes:
 | **Tests** | ubuntu, windows, macos | `cargo nextest run` with `INSTA_UPDATE=no`, `PROPTEST_CASES=256` |
 | **Doc tests** | ubuntu, windows, macos | `cargo test --workspace --doc` |
 | **BDD** | ubuntu | BDD suites on the canonical build |
-| **MSRV** | ubuntu | `cargo check` with Rust 1.92 |
+| **MSRV** | ubuntu | `cargo check` with Rust 1.95 |
 | **Security** | ubuntu | `cargo audit` |
 | **Docs** | ubuntu | `cargo doc` with `-Dwarnings` |
 | **Coverage** | ubuntu | `cargo llvm-cov` → Codecov |

--- a/docs/tutorials/first-publish.md
+++ b/docs/tutorials/first-publish.md
@@ -12,7 +12,7 @@ In this tutorial you will publish a two-crate workspace to crates.io using Shipp
 
 ## What you'll need
 
-- Rust toolchain (edition 2024, MSRV 1.92 — `rustup update stable` is fine)
+- Rust toolchain (edition 2024, MSRV 1.95 — `rustup update stable` is fine)
 - A crates.io account and a token (`cargo login`)
 - A git-clean workspace with two crates, one depending on the other
 - About 15 minutes

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+profile = "minimal"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

PR 3 of the [Rust 1.95 / 0.4.0 quality rollout](docs/ci/rust-1.95-rollout.md). Prerequisite: PR 2 (#170, merged) confirmed zero source changes needed under rustc 1.95.0.

### Changes

- **`Cargo.toml`** — `rust-version = "1.95"` (was `"1.92"`)
- **`rust-toolchain.toml`** (new) — pins channel to `1.95.0`, profile `minimal`, components `rustfmt` + `clippy`
- **`clippy.toml`** (new) — `msrv = "1.95"`, cognitive-complexity threshold 40, too-many-arguments threshold 8, type-complexity threshold 300
- **CI workflows** — MSRV gate toolchain updated to `1.95.0` in `ci.yml`, `coverage.yml`, `release.yml` (job name updated: `MSRV gate (1.95)`)
- **Docs and badges** — `README.md` MSRV badge, `docs/tech.md`, `docs/architecture.md`, `docs/testing.md`, `docs/tutorials/first-publish.md`, `ROADMAP.md`, `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `.github/copilot-instructions.md` all updated to 1.95
- **`CHANGELOG.md`** — unreleased entry for the MSRV bump

### What is intentionally not changed

Version-string parsing examples in source comments (`crates/shipper-cli/build.rs`, `crates/shipper-core/src/runtime/environment/`) reference `1.92.0` as a format example — these describe the *shape* of a rustc version string, not the MSRV, and are left unchanged. Historical documents (`docs/HANDOFF.md`, `RELEASE_CHECKLIST_v0.2.0.md`) and rollout tracking docs that explicitly record `1.92` as the *from* value are also unchanged.

### Acceptance gate (from rollout plan)

- [ ] CI green on all three platforms
- [ ] MSRV gate job uses `1.95.0`
- [ ] `rust-toolchain.toml` present and correct
- [ ] `clippy.toml` present with `msrv = "1.95"`
- [ ] No 1.92 references remain in policy-bearing files

## Test plan

- All existing tests pass (no source changes — confirmed by PR 2 probe)
- MSRV Check CI job now installs and validates against 1.95.0
- Clippy runs with the new `clippy.toml` thresholds (cognitive-complexity 40, too-many-args 8)

https://claude.ai/code/session_0144KiDnuVJV9ACganxqHK72

---
_Generated by [Claude Code](https://claude.ai/code/session_0144KiDnuVJV9ACganxqHK72)_