### PR TITLE
ci(droid): allow Dependabot to trigger Droid Auto Review

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -61,6 +61,8 @@ jobs:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           upload_debug_artifacts: false
 
+          allowed_bots: dependabot[bot]
+
           automatic_review: true
           automatic_security_review: true
 

--- a/docs/agent-context/review-invariants.md
+++ b/docs/agent-context/review-invariants.md
@@ -40,6 +40,7 @@ These constrain how Factory Droid review is configured for shipper. A reviewer s
 - `cancel-in-progress: false` on the auto-review and security-scan workflows.
 - `pull_request` types include `opened`, `synchronize`, `ready_for_review`, `reopened`.
 - The auto-review job is guarded by `github.event.pull_request.head.repo.full_name == github.repository` (same-repo guard). Fork PRs are intentionally skipped because secrets must not run on untrusted fork code.
+- `allowed_bots: dependabot[bot]` is set so Dependabot dependency-bump PRs receive Droid Auto Review. The safe action rejects non-human actors by default; this list narrowly re-permits Dependabot. Do not change this to `'*'`. Adding additional bots requires an explicit follow-up PR with justification.
 - Draft PRs are intentionally reviewable.
 - `[skip-review]` in the PR title opts out of automatic review.
 - The manual `@droid` workflow is guarded by `OWNER`, `MEMBER`, or `COLLABORATOR` `author_association` on every event branch, plus the same-repo guard on the `pull_request` event branch.


### PR DESCRIPTION
## Summary

Discovered when running the new BYOK Droid setup against the first real Dependabot PR (#160 assert_cmd 2.2.0 → 2.2.1): the `droid-action-safe` action rejects non-human actors by default with

```
Workflow initiated by non-human actor: dependabot (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

That caused every Dependabot rebase to fail the `droid-review` check — informational (Droid review failures do not block merge), but noisy in the PR check list and confusing during the live dep-queue drain.

This PR adds `allowed_bots: dependabot[bot]` to `droid-review.yml` so Dependabot dependency-bump PRs receive Droid Auto Review. The narrow allow-list is deliberate; adding more bots (or `'*'`) should require an explicit follow-up PR.

Also updates `docs/agent-context/review-invariants.md` to document the rule, so a reviewer who later sees `allowed_bots` knows it is intentional and scoped.

## Why allow rather than skip?

Dependency bumps are exactly the case where Droid review is valuable — a bump can introduce a vulnerable transitive dep, change behavior, or interact with our publish-path code. The alternative (skip-on-bot) saves a small amount of MiniMax tokens but loses that signal. Keeping the security review on Dependabot PRs is worth the spend.

## Safety posture

- Allow-list is narrow (`dependabot[bot]` only), not `'*'`.
- Same-repo guard, trusted-actor guard, `show_full_output: false`, `upload_debug_artifacts: false`, pinned SHAs, and `cancel-in-progress: false` are unchanged.
- The manual workflow (`droid.yml`) and scheduled scan (`droid-security-scan.yml`) are unchanged — they have their own author-association and trigger guards and do not need a bot allow-list.

## Test plan

- [ ] CI green on this PR.
- [ ] Merge.
- [ ] Trigger `@dependabot rebase` on #160 to pick up the new workflow.
- [ ] Confirm the new Droid Auto Review run on #160 either succeeds or produces a real review (no `non-human actor` prepare-step failure).
- [ ] Continue dep-queue drain.