### PR TITLE
fix(plan,cargo-failure): build publish graph from manifest deps; classify dep-resolution failures as permanent (#173)

### DIFF
--- a/crates/shipper-cargo-failure/src/lib.rs
+++ b/crates/shipper-cargo-failure/src/lib.rs
@@ -46,7 +46,7 @@ const RETRYABLE_PATTERNS: [&str; 20] = [
     "network unreachable",
 ];
 
-const PERMANENT_PATTERNS: [&str; 22] = [
+const PERMANENT_PATTERNS: [&str; 26] = [
     "failed to parse manifest",
     "invalid",
     "missing",
@@ -69,6 +69,14 @@ const PERMANENT_PATTERNS: [&str; 22] = [
     "token is invalid",
     "invalid credentials",
     "checksum mismatch",
+    // Dep-resolution failures. These fire when cargo cannot find a
+    // required dep on the registry — the exact failure mode of a wrong
+    // publish order (#173). Without these the classifier falls through
+    // to Ambiguous and the retry loop hides the real Cargo stderr.
+    "failed to select a version for the requirement",
+    "no matching package named",
+    "candidate versions found which didn't match",
+    "required dependency is missing from the registry",
 ];
 
 /// Classify cargo publish output into retry behavior categories.
@@ -1171,6 +1179,37 @@ mod tests {
             "error: failed to publish to registry crates-io\n\
              Caused by:\n  the remote server responded with an error (status 200 OK): \
              crate version already exists: `my-crate@1.2.3`",
+            "",
+        );
+        assert_eq!(o.class, CargoFailureClass::Permanent);
+    }
+
+    #[test]
+    fn realworld_dep_resolution_without_verify_framing() {
+        // Regression for #173: cargo publish can emit a dep-resolution
+        // failure WITHOUT the surrounding "failed to verify package tarball"
+        // framing — typically when the failure happens before the
+        // verify-package stage. Before the fix, this stderr contained no
+        // existing permanent pattern and was misclassified as Ambiguous,
+        // hiding the real cause behind 12 retries.
+        let o = classify_publish_failure(
+            "error: failed to select a version for the requirement `uselesskey-ecdsa = \"^0.7.0\"`\n\
+             candidate versions found which didn't match: 0.6.5, 0.6.4\n\
+             location searched: crates.io index\n\
+             required by package `uselesskey-aws-lc-rs v0.1.0 (/path/uselesskey-aws-lc-rs)`",
+            "",
+        );
+        assert_eq!(o.class, CargoFailureClass::Permanent);
+    }
+
+    #[test]
+    fn realworld_no_matching_package_named() {
+        // Different cargo error shape: the package itself was not found on
+        // the registry (vs. a version-mismatch on a found package).
+        let o = classify_publish_failure(
+            "error: no matching package named `uselesskey-ed25519` found\n\
+             location searched: registry `crates-io`\n\
+             required by package `uselesskey-aws-lc-rs v0.1.0`",
             "",
         );
         assert_eq!(o.class, CargoFailureClass::Permanent);

--- a/crates/shipper-cargo-failure/src/snapshots/shipper_cargo_failure__tests__permanent_pattern_exhaustive.snap
+++ b/crates/shipper-cargo-failure/src/snapshots/shipper_cargo_failure__tests__permanent_pattern_exhaustive.snap
@@ -25,3 +25,7 @@ is already uploaded => Permanent
 token is invalid => Permanent
 invalid credentials => Permanent
 checksum mismatch => Permanent
+failed to select a version for the requirement => Permanent
+no matching package named => Permanent
+candidate versions found which didn't match => Permanent
+required dependency is missing from the registry => Permanent

--- a/crates/shipper-core/src/plan/mod.rs
+++ b/crates/shipper-core/src/plan/mod.rs
@@ -79,40 +79,72 @@ pub fn build_plan(spec: &ReleaseSpec) -> Result<PlannedWorkspace> {
         })
         .collect();
 
-    // Build dependency edges A->deps (restricted to publishable workspace members).
-    let resolve = metadata
-        .resolve
-        .as_ref()
-        .context("cargo metadata did not include a resolve graph")?;
+    // Build dependency edges A->deps from manifest-level Package.dependencies.
+    //
+    // We intentionally do NOT use metadata.resolve.nodes here. resolve.nodes
+    // is feature-resolved and omits optional path+version dependencies that
+    // are not active under the default feature set. cargo publish, however,
+    // still needs every optional workspace path+version dep to be resolvable
+    // from the registry at publish time, so those edges must participate in
+    // publish ordering. See #173.
+    //
+    // We keep Normal + Build deps, including optional and target-specific
+    // ones, and exclude Dev.
+
+    // Map workspace package directory -> PackageId, used to resolve path
+    // dependencies to the workspace members they reference.
+    let pkg_dir_to_id: BTreeMap<std::path::PathBuf, PackageId> = workspace_ids
+        .iter()
+        .filter_map(|id| {
+            let pkg = pkg_map.get(id)?;
+            let dir = pkg
+                .manifest_path
+                .parent()?
+                .to_path_buf()
+                .into_std_path_buf();
+            Some((dir, id.clone()))
+        })
+        .collect();
 
     let mut deps_of: BTreeMap<PackageId, BTreeSet<PackageId>> = BTreeMap::new();
     let mut dependents_of: BTreeMap<PackageId, BTreeSet<PackageId>> = BTreeMap::new();
+    // Tracked separately so the "publishable must not depend on a
+    // non-publishable workspace member" guard can run against the same
+    // manifest-level source as the edges themselves.
+    let mut non_publishable_workspace_deps: BTreeMap<PackageId, BTreeSet<PackageId>> =
+        BTreeMap::new();
 
-    for node in &resolve.nodes {
-        if !publishable.contains(&node.id) {
-            continue;
-        }
-        for dep in &node.deps {
-            if !publishable.contains(&dep.pkg) {
+    for id in &workspace_ids {
+        let pkg = pkg_map
+            .get(id)
+            .context("workspace package missing from metadata")?;
+        for dep in &pkg.dependencies {
+            if !matches!(dep.kind, DependencyKind::Normal | DependencyKind::Build) {
                 continue;
             }
-
-            let is_relevant = dep
-                .dep_kinds
-                .iter()
-                .any(|k| matches!(k.kind, DependencyKind::Normal | DependencyKind::Build));
-            if !is_relevant {
+            let Some(dep_path) = dep.path.as_ref() else {
                 continue;
-            }
+            };
+            let dep_dir = dep_path.clone().into_std_path_buf();
+            let Some(dep_id) = pkg_dir_to_id.get(&dep_dir) else {
+                continue;
+            };
 
-            deps_of
-                .entry(node.id.clone())
-                .or_default()
-                .insert(dep.pkg.clone());
-            dependents_of
-                .entry(dep.pkg.clone())
-                .or_default()
-                .insert(node.id.clone());
+            if publishable.contains(id) && publishable.contains(dep_id) {
+                deps_of
+                    .entry(id.clone())
+                    .or_default()
+                    .insert(dep_id.clone());
+                dependents_of
+                    .entry(dep_id.clone())
+                    .or_default()
+                    .insert(id.clone());
+            } else if publishable.contains(id) && !publishable.contains(dep_id) {
+                non_publishable_workspace_deps
+                    .entry(id.clone())
+                    .or_default()
+                    .insert(dep_id.clone());
+            }
         }
     }
 
@@ -156,36 +188,31 @@ pub fn build_plan(spec: &ReleaseSpec) -> Result<PlannedWorkspace> {
         publishable.clone()
     };
 
-    // Validate: included crates must not have normal/build deps on non-publishable workspace members.
-    for node in &resolve.nodes {
-        if !included.contains(&node.id) {
+    // Validate: included crates must not have normal/build deps on
+    // non-publishable workspace members. Uses the same manifest-level source
+    // as the edge construction above so optional and target-specific deps
+    // are checked.
+    for (id, dep_ids) in &non_publishable_workspace_deps {
+        if !included.contains(id) {
             continue;
         }
-        for dep in &node.deps {
-            // Skip deps that are publishable or not workspace members
-            if publishable.contains(&dep.pkg) || !workspace_ids.contains(&dep.pkg) {
-                continue;
-            }
-            let is_normal_or_build = dep
-                .dep_kinds
-                .iter()
-                .any(|k| matches!(k.kind, DependencyKind::Normal | DependencyKind::Build));
-            if is_normal_or_build {
-                let pkg_name = pkg_map
-                    .get(&node.id)
-                    .map(|p| p.name.as_str())
-                    .unwrap_or("unknown");
-                let dep_name = pkg_map
-                    .get(&dep.pkg)
-                    .map(|p| p.name.as_str())
-                    .unwrap_or("unknown");
-                bail!(
-                    "publishable package '{}' depends on non-publishable workspace member '{}'",
-                    pkg_name,
-                    dep_name
-                );
-            }
-        }
+        let dep_id = dep_ids
+            .iter()
+            .next()
+            .expect("non_publishable_workspace_deps entries are non-empty by construction");
+        let pkg_name = pkg_map
+            .get(id)
+            .map(|p| p.name.as_str())
+            .unwrap_or("unknown");
+        let dep_name = pkg_map
+            .get(dep_id)
+            .map(|p| p.name.as_str())
+            .unwrap_or("unknown");
+        bail!(
+            "publishable package '{}' depends on non-publishable workspace member '{}'",
+            pkg_name,
+            dep_name
+        );
     }
 
     // Topological sort on included nodes.
@@ -516,6 +543,120 @@ c = { path = "../c", version = "0.1.0" }
                 "publishable package 'npdep' depends on non-publishable workspace member 'c'"
             ),
             "unexpected error: {msg2}"
+        );
+    }
+
+    #[test]
+    fn build_plan_orders_optional_workspace_dependencies() {
+        // Regression for #173. aaa-adapter has an optional path+version dep
+        // on zzz-core. cargo_metadata's feature-resolved resolve.nodes omits
+        // optional deps that aren't activated by the default feature set, so
+        // before the fix Shipper saw aaa-adapter as having indegree zero and
+        // ordered it alphabetically before zzz-core. cargo publish, however,
+        // still needs zzz-core to exist on the registry first.
+        let td = tempdir().expect("tempdir");
+        write_file(
+            &td.path().join("Cargo.toml"),
+            r#"
+[workspace]
+members = ["aaa-adapter", "zzz-core"]
+resolver = "2"
+"#,
+        );
+        write_file(
+            &td.path().join("aaa-adapter/Cargo.toml"),
+            r#"
+[package]
+name = "aaa-adapter"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+zzz-core = { path = "../zzz-core", version = "0.1.0", optional = true }
+
+[features]
+default = []
+core = ["dep:zzz-core"]
+"#,
+        );
+        write_file(&td.path().join("aaa-adapter/src/lib.rs"), "");
+        write_file(
+            &td.path().join("zzz-core/Cargo.toml"),
+            r#"
+[package]
+name = "zzz-core"
+version = "0.1.0"
+edition = "2021"
+"#,
+        );
+        write_file(&td.path().join("zzz-core/src/lib.rs"), "");
+
+        let ws = build_plan(&spec_for(td.path())).expect("plan");
+        let names: Vec<String> = ws.plan.packages.iter().map(|p| p.name.clone()).collect();
+        assert_eq!(
+            names,
+            vec!["zzz-core".to_string(), "aaa-adapter".to_string()],
+            "optional path dep should still establish publish order"
+        );
+
+        let adapter_deps = ws
+            .plan
+            .dependencies
+            .get("aaa-adapter")
+            .expect("aaa-adapter in dependencies map");
+        assert_eq!(adapter_deps, &vec!["zzz-core".to_string()]);
+    }
+
+    #[test]
+    fn build_plan_rejects_optional_normal_dep_on_non_publishable_workspace_member() {
+        // Regression for #173 validation path. The same graph-source bug
+        // also let optional normal deps on non-publishable workspace members
+        // slip past the "publishable depends on non-publishable" guard.
+        let td = tempdir().expect("tempdir");
+        write_file(
+            &td.path().join("Cargo.toml"),
+            r#"
+[workspace]
+members = ["adapter", "internal"]
+resolver = "2"
+"#,
+        );
+        write_file(
+            &td.path().join("adapter/Cargo.toml"),
+            r#"
+[package]
+name = "adapter"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+internal = { path = "../internal", version = "0.1.0", optional = true }
+
+[features]
+default = []
+internal-fn = ["dep:internal"]
+"#,
+        );
+        write_file(&td.path().join("adapter/src/lib.rs"), "");
+        write_file(
+            &td.path().join("internal/Cargo.toml"),
+            r#"
+[package]
+name = "internal"
+version = "0.1.0"
+edition = "2021"
+publish = false
+"#,
+        );
+        write_file(&td.path().join("internal/src/lib.rs"), "");
+
+        let err = build_plan(&spec_for(td.path())).expect_err("must fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains(
+                "publishable package 'adapter' depends on non-publishable workspace member 'internal'"
+            ),
+            "unexpected error: {msg}"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #173. Two related bugs, one root cause:

### Primary: planning graph misses optional workspace deps

`build_plan` in `crates/shipper-core/src/plan/mod.rs` constructed the workspace dependency DAG from `cargo_metadata`'s feature-resolved `resolve.nodes`. That graph omits optional path+version dependencies that are not active under the default feature set. `cargo publish`, however, still needs every optional workspace path+version dep to be resolvable from the registry at publish time, so those edges must participate in publish ordering.

Concretely, `uselesskey-aws-lc-rs` declares optional normal path+version deps on `uselesskey-rsa`/`uselesskey-ecdsa`/`uselesskey-ed25519`. Because those edges were absent from `resolve.nodes`, Shipper saw `uselesskey-aws-lc-rs` as indegree zero, the deterministic `BTreeSet<(name, id)>` ready queue emitted it early by name, and the plan looked alphabetical. **It was a correct topological sort of an incomplete graph.**

The "publishable depends on non-publishable workspace member" guard at the same site (`mod.rs:160-189`) had the same defect — same iteration source.

**Fix:** switch both edge construction and the validation guard to manifest-level `Package.dependencies`. Include `DependencyKind::Normal | DependencyKind::Build`, including optional and target-specific deps; exclude `Dev`. Path deps are resolved to workspace members via a directory→`PackageId` map.

**Not switching to `cargo metadata --all-features`:** that would surface optional deps but couples planning to "all features build", an unrelated and expensive constraint.

### Secondary: ambiguous classification on dep-resolution failures

`crates/shipper-cargo-failure/src/lib.rs` did not match Cargo's dep-resolution error messages, so a publish failure caused by a missing registry dep (exactly the failure mode produced by the planning bug above) fell through to `Ambiguous`. The retry loop then hid the actionable Cargo stderr behind a sequence of "publish outcome ambiguous; registry did not show version" retries.

Adds four permanent patterns:
- `failed to select a version for the requirement`
- `no matching package named`
- `candidate versions found which didn't match`
- `required dependency is missing from the registry`

## Tests

New regression tests:
- `build_plan_orders_optional_workspace_dependencies` — `aaa-adapter` optional-depends on `zzz-core`. Alphabetical order is `aaa-adapter, zzz-core`; correct publish order is `zzz-core, aaa-adapter`. **Fails on the prior implementation.**
- `build_plan_rejects_optional_normal_dep_on_non_publishable_workspace_member` — same defect in the validation path.
- `realworld_dep_resolution_without_verify_framing` — Cargo dep-resolution stderr without the surrounding "failed to verify package tarball" framing. Misclassified as `Ambiguous` before this PR.
- `realworld_no_matching_package_named` — the package-not-found shape.

Existing 234 plan tests and 190 classifier tests continue to pass.

## Validation performed locally

- `cargo check --workspace --all-targets --locked` — clean
- `cargo clippy -p shipper-core -p shipper-cargo-failure --all-targets --locked -- -D warnings` — no issues
- `cargo fmt --all -- --check` — clean
- `cargo test -p shipper-core --lib plan::` — 236 passed (234 existing + 2 new)
- `cargo test -p shipper-cargo-failure` — 192 passed (190 existing + 2 new)

Snapshot `permanent_pattern_exhaustive.snap` updated with the four new patterns.

## Test plan

- [ ] CI green.
- [ ] Spot-check that the new tests run on CI and fail without the source-side fix (i.e., that they are real regression tests).
- [ ] After merge, retry the `uselesskey` workspace publish that surfaced #173 (or the smallest reproducer the user has) to confirm the plan now orders the optional deps correctly.