### PR TITLE
docs(policy): clarify non-Rust allowlist rollout status (#201, rollout PR 1/12)

### DIFF
--- a/docs/FILE_POLICY.md
+++ b/docs/FILE_POLICY.md
@@ -89,4 +89,26 @@ cargo xtask policy-report
 
 ## Rollout
 
-The file policy checker starts in advisory mode (PR 9). It is promoted to blocking-allowlist mode in the release dry-run proof (PR 15) once the initial inventory is complete and reviewed.
+The file-policy work is decomposed into a 12-PR ladder of small, separately reviewable changes rather than one large policy-infrastructure PR. The full tracker, with issue numbers and current disposition, lives in [docs/policy/NON_RUST_ROLLOUT.md](policy/NON_RUST_ROLLOUT.md).
+
+In short:
+
+1. **PRs 1–3** are docs and ledger scaffolding. No checker, no enforcement.
+2. **PR 4** adds an `xtask` skeleton and `cargo xtask non-rust inventory`.
+3. **PRs 5–9** add the checker subcommands and the unified report. All run in advisory mode initially.
+4. **PR 10** wires the advisory checks into CI and uploads the policy report as an artifact. No merge blocking yet.
+5. **PR 11** promotes file/generated/executable/dependency/workflow checks to `blocking-allowlist`.
+6. **PR 12** promotes process and network checks to `blocking-allowlist`.
+
+`blocking-strict` mode (which fails on unused entries and stale review dates) is explicitly out of scope for the initial rollout and is deferred until after a stale/unused cleanup pass.
+
+## Receipts, not burn-down
+
+The allowlists do not mean "approved forever." They mean **known surface, owner, reason, and current disposition.** A receipt with an explicit owner and a reason that says *why* the file exists is acceptable even when the long-term plan is to remove the file.
+
+Valid `reason` values include:
+
+- A durable explanation of why the surface exists (e.g., "Codecov status and reporting configuration").
+- **"Scheduled to be converted to Rust/xtask"** when the current file exists for legacy compatibility or migration staging. Pair this reason with an `expires` date so the receipt does not silently outlive its rationale.
+
+This rule keeps the policy goal — visibility and ownership — separate from any individual cleanup deadline. Non-Rust is allowed; non-Rust is never invisible.

--- a/docs/POLICY_ALLOWLISTS.md
+++ b/docs/POLICY_ALLOWLISTS.md
@@ -140,21 +140,41 @@ Every suppression in code must have a corresponding entry in `policy/clippy-debt
 
 ## Rollout Status
 
-| Allowlist | Introduced in PR | Status |
+The 0.4.0 quality rollout is split into a ladder of small, separately reviewable PRs rather than one large policy-infrastructure PR. The full tracker for the non-Rust file-policy subset (PRs 1–12 below) lives in [docs/policy/NON_RUST_ROLLOUT.md](policy/NON_RUST_ROLLOUT.md). The broader 0.4.0 rollout (Clippy, no-panic, ripr, CI lanes, release dry-run) is tracked under [#109](https://github.com/EffortlessMetrics/shipper/issues/109).
+
+A receipt in any of these allowlists is **not** "approved forever." It is "known surface, owner, reason, and current disposition." A valid `reason` may include `"scheduled to be converted to Rust/xtask"` when the file exists for legacy compatibility or migration staging, paired with an `expires` date.
+
+### Non-Rust file-policy ladder (12 SRP PRs)
+
+| Allowlist / change | Rollout PR | Issue | Status |
+|---|---|---|---|
+| Docs: rollout-status clarification | 1/12 | [#201](https://github.com/EffortlessMetrics/shipper/issues/201) | planned |
+| All policy TOML ledgers (scaffold + receipts) | 2/12 | [#202](https://github.com/EffortlessMetrics/shipper/issues/202) | planned |
+| High-risk receipts (workflow/process/network/dep/exec/generated) | 3/12 | [#203](https://github.com/EffortlessMetrics/shipper/issues/203) | planned |
+| `xtask` skeleton + `cargo xtask non-rust inventory` | 4/12 | [#212](https://github.com/EffortlessMetrics/shipper/issues/212) | planned |
+| `cargo xtask check-file-policy` | 5/12 | [#204](https://github.com/EffortlessMetrics/shipper/issues/204) | planned |
+| `cargo xtask non-rust propose` | 6/12 | [#205](https://github.com/EffortlessMetrics/shipper/issues/205) | planned |
+| `check-generated` / `check-executable-files` / `check-dependency-surfaces` | 7/12 | [#206](https://github.com/EffortlessMetrics/shipper/issues/206) | planned |
+| `check-workflow-surfaces` / `check-process-policy` / `check-network-policy` | 8/12 | [#207](https://github.com/EffortlessMetrics/shipper/issues/207) | planned |
+| `cargo xtask policy-report` (unified) | 9/12 | [#208](https://github.com/EffortlessMetrics/shipper/issues/208) | planned |
+| CI: run all checks in advisory mode + upload artifact | 10/12 | [#209](https://github.com/EffortlessMetrics/shipper/issues/209) | planned |
+| CI: promote file/generated/executable/dependency/workflow to blocking | 11/12 | [#210](https://github.com/EffortlessMetrics/shipper/issues/210) | planned |
+| CI: promote process and network to blocking | 12/12 | [#211](https://github.com/EffortlessMetrics/shipper/issues/211) | planned |
+
+Umbrella tracking issue for the file-policy work: [#180](https://github.com/EffortlessMetrics/shipper/issues/180).
+
+### Other 0.4.0 rollout PRs (parallel work)
+
+| Allowlist / change | Issue | Status |
 |---|---|---|
-| `clippy-lints.toml` | PR 5 | planned |
-| `clippy-debt.toml` | PR 5 | planned |
-| `clippy-exceptions.toml` | PR 5 | planned |
-| `no-panic-allowlist.toml` | PR 8 | planned |
-| `no-panic-baseline.toml` | PR 8 | planned |
-| `non-rust-allowlist.toml` | PR 9 | planned |
-| `generated-allowlist.toml` | PR 9 | planned |
-| `executable-allowlist.toml` | PR 9 | planned |
-| `dependency-surface-allowlist.toml` | PR 9 | planned |
-| `workflow-allowlist.toml` | PR 9 | planned |
-| `process-allowlist.toml` | PR 9 | planned |
-| `network-allowlist.toml` | PR 9 | planned |
-| `ripr-suppressions.toml` | PR 10 | planned |
-| `ci-budget.toml` | PR 11 | planned |
-| `ci-lanes.toml` | PR 11 | planned |
-| `ci-risk-packs.toml` | PR 11 | planned |
+| `xtask` policy foundation (`package-surface`, `policy-report` stub) | [#176](https://github.com/EffortlessMetrics/shipper/issues/176) | planned |
+| `clippy-lints.toml` / `clippy-debt.toml` / `clippy-exceptions.toml` ledgers | [#179](https://github.com/EffortlessMetrics/shipper/issues/179) | planned |
+| Rust 1.95 rustc lint floor | [#198](https://github.com/EffortlessMetrics/shipper/issues/198) | planned |
+| Clippy 1.94/1.95 ratchets | [#191](https://github.com/EffortlessMetrics/shipper/issues/191) | planned |
+| `no-panic-baseline.toml` + checker | [#187](https://github.com/EffortlessMetrics/shipper/issues/187) | planned |
+| ripr advisory lane + targeted mutation scoping | [#182](https://github.com/EffortlessMetrics/shipper/issues/182) | planned |
+| CI lane policy | [#189](https://github.com/EffortlessMetrics/shipper/issues/189) | planned |
+| Rust 1.95 API cleanup | [#184](https://github.com/EffortlessMetrics/shipper/issues/184) | planned |
+| First debt burn-down (narrow owner lane) | [#190](https://github.com/EffortlessMetrics/shipper/issues/190) | planned |
+| 0.4.0-rc.1 version + changelog | [#192](https://github.com/EffortlessMetrics/shipper/issues/192) | planned |
+| 0.4.0-rc.1 release dry-run proof | [#195](https://github.com/EffortlessMetrics/shipper/issues/195) | planned |

--- a/docs/policy/NON_RUST_ROLLOUT.md
+++ b/docs/policy/NON_RUST_ROLLOUT.md
@@ -1,0 +1,97 @@
+# Non-Rust File-Policy Rollout
+
+This is the working tracker for the 12-PR rollout that turns Shipper's planned file-policy infrastructure into a real, enforceable system. The umbrella issue is [#180](https://github.com/EffortlessMetrics/shipper/issues/180); each PR below has its own issue.
+
+## Operating rules
+
+- **Receipts, not burn-down.** Every current non-Rust file is allowed to remain if it has a receipt with `owner` and `reason`. The receipt is the contract, not the cleanup ticket.
+- **Reason `"scheduled to be converted to Rust/xtask"` is acceptable** when the file exists for legacy compatibility or migration staging. Pair it with an `expires` date so the receipt does not silently outlive its rationale.
+- **Strict default, owned exception.** The allowlist means "known surface, owner, reason, and current disposition" — never "approved forever."
+- **One SRP PR per issue.** Do not bury docs, ledgers, enforcement, proposal generation, workflow receipts, and `xtask` scaffolding in one review.
+- **Advisory before blocking.** Every new check ships in advisory mode and graduates only after the receipt set is in place.
+- **No `blocking-strict` in this rollout.** Strict mode (fails on unused entries and stale review dates) waits until after a dedicated cleanup pass.
+
+## Ladder
+
+| PR | Issue | Title | Status | Depends on |
+|---:|---|---|---|---|
+| 1/12 | [#201](https://github.com/EffortlessMetrics/shipper/issues/201) | `docs(policy): clarify non-Rust allowlist rollout status` | in flight | — |
+| 2/12 | [#202](https://github.com/EffortlessMetrics/shipper/issues/202) | `chore(policy): add non-Rust policy allowlist ledgers` | planned | PR 1 |
+| 3/12 | [#203](https://github.com/EffortlessMetrics/shipper/issues/203) | `chore(policy): receipt high-risk non-Rust surfaces` | planned | PR 2 |
+| 4/12 | [#212](https://github.com/EffortlessMetrics/shipper/issues/212) | `feat(xtask): add non-Rust inventory command` | planned | — (relates to [#176](https://github.com/EffortlessMetrics/shipper/issues/176)) |
+| 5/12 | [#204](https://github.com/EffortlessMetrics/shipper/issues/204) | `feat(policy): check non-Rust file allowlist` | planned | PR 2, PR 4 |
+| 6/12 | [#205](https://github.com/EffortlessMetrics/shipper/issues/205) | `feat(policy): propose non-Rust allowlist entries` | planned | PR 2, PR 4, PR 5 |
+| 7/12 | [#206](https://github.com/EffortlessMetrics/shipper/issues/206) | `feat(policy): check generated, executable, and dependency surfaces` | planned | PR 2, PR 4 |
+| 8/12 | [#207](https://github.com/EffortlessMetrics/shipper/issues/207) | `feat(policy): check workflow, process, and network surfaces` | planned | PR 2, PR 3, PR 4 |
+| 9/12 | [#208](https://github.com/EffortlessMetrics/shipper/issues/208) | `feat(policy): add unified policy report` | planned | PR 5–8 |
+| 10/12 | [#209](https://github.com/EffortlessMetrics/shipper/issues/209) | `ci(policy): run file policy checks advisory` | planned | PR 5–9 |
+| 11/12 | [#210](https://github.com/EffortlessMetrics/shipper/issues/210) | `ci(policy): require non-Rust file policy allowlist` | planned | PR 10 |
+| 12/12 | [#211](https://github.com/EffortlessMetrics/shipper/issues/211) | `ci(policy): require process and network policy receipts` | planned | PR 10, PR 11 |
+
+Tracked under milestone [`0.4.0-rc.1`](https://github.com/EffortlessMetrics/shipper/milestone/1).
+
+## Receipt schema
+
+Every allowlist entry should answer four questions:
+
+1. **What surface?** (`kind`, `surface`, `classification`)
+2. **Who owns it?** (`owner`)
+3. **Why does it exist?** (`reason`)
+4. **What covers it?** (`covered_by` — tests, manual review, scheduled `xtask` check)
+
+Plus the operational fields:
+
+- `created` — when this entry was first added.
+- `review_after` — when the receipt should be re-examined.
+- `expires` — optional; when the entry must be removed or renewed.
+
+### Examples
+
+A durable receipt:
+
+```toml
+[[file]]
+path = "codecov.yml"
+kind = "coverage_config"
+surface = "ci"
+classification = "config"
+owner = "release/ci"
+reason = "Codecov status and reporting configuration."
+covered_by = ["codecov upload workflows", "cargo xtask check-file-policy"]
+created = "2026-05-11"
+review_after = "2026-06-11"
+```
+
+A transitional receipt:
+
+```toml
+[[glob]]
+pattern = "scripts/**/*.sh"
+kind = "legacy_shell_tooling"
+surface = "tooling"
+classification = "tooling"
+owner = "release/ci"
+reason = "Legacy shell helper retained for current release workflow; scheduled to be converted to cargo xtask once the release path is stable."
+covered_by = ["cargo xtask policy-report"]
+created = "2026-05-11"
+review_after = "2026-05-25"
+expires = "2026-08-11"
+```
+
+Both are valid. Both are visible. Both have an owner.
+
+## Definition of done for the ladder
+
+- Every current non-Rust file is receipted.
+- Every receipt has `owner` and `reason`.
+- "Scheduled to be converted" entries are accepted but visible.
+- `cargo xtask non-rust inventory` works.
+- `cargo xtask non-rust propose` works.
+- `cargo xtask check-file-policy --mode blocking-allowlist` works.
+- Generated, executable, dependency, and workflow checks are blocking.
+- Process and network checks are at least `blocking-allowlist` after baseline.
+- `cargo xtask policy-report` emits Markdown and JSON.
+- CI uploads the policy report as an artifact.
+- A new anonymous non-Rust file fails CI.
+
+When all twelve PRs land and the above hold, close [#180](https://github.com/EffortlessMetrics/shipper/issues/180) with a comment summarizing the final receipt set.


### PR DESCRIPTION
## Summary

First PR in the 12-PR file-policy rollout decomposition. Docs-only — no policy files yet, no code changes, no enforcement.

Rewrites the rollout-status sections in `docs/FILE_POLICY.md` and `docs/POLICY_ALLOWLISTS.md` to reflect the 12-PR ladder rather than the old single-PR view. Adds explicit "receipts, not burn-down" language so future receipts can legitimately carry `reason = "scheduled to be converted to Rust/xtask"` paired with an `expires` date.

Adds a new tracker `docs/policy/NON_RUST_ROLLOUT.md` with:
- Operating rules (receipts not burn-down; advisory before blocking; no `blocking-strict` in this rollout).
- The full ladder table with issue numbers and dependencies.
- Receipt schema with durable and transitional examples.
- Definition of done for the ladder.

## Issue

Closes #201. Refines #180 (umbrella). Tracks #109.

## Decisions

- **Decision:** Keep `docs/policy/` as a new subdirectory rather than putting the tracker in `docs/ci/` or at `docs/` root.
  - **Rationale:** Future policy docs (per-policy operating guides, audit logs) will accumulate here.
  - **Alternatives rejected:** Single flat `docs/NON_RUST_ROLLOUT.md` — works for one file but doesn't scale.
- **Decision:** Surface "scheduled to be converted to Rust/xtask" as a *named* valid reason in both `FILE_POLICY.md` and the tracker.
  - **Rationale:** Without explicit acceptance, reviewers will treat such entries as inconsistent with the policy. Naming the pattern keeps it visible and bounded (paired with `expires`).
  - **Alternatives rejected:** Implicit acceptance — invites churn arguments in every review.

## Validation

- [x] `cargo check --workspace --locked` passes (no source code touched).
- [x] No `policy/` directory created in this PR (that's PR 2 / #202).
- [x] No `xtask/` directory created (PR 4 / #212).
- [x] Diff is purely docs.

## Follow-ups

PR 2 (issue #202) — add the policy TOML ledger files with first-pass receipts. No checker, no behavior change.