### PR TITLE
chore(policy): receipt high-risk non-Rust surfaces (#203, rollout PR 3/12)

### DIFF
--- a/policy/network-allowlist.toml
+++ b/policy/network-allowlist.toml
@@ -4,30 +4,77 @@
 # policy. Workflows in policy/workflow-allowlist.toml reference one of these
 # profiles via `network_policy = "..."`.
 #
-# This file ships as a scaffold in PR 2 with the `ci` and `release` profiles
-# stubbed but empty. PR 3 (#203) populates the actual endpoint lists by
-# scanning the current workflows.
+# Entries are honest first-pass receipts based on what each workflow profile
+# actually contacts today. PR 8 (#207) adds the checker that scans workflows
+# for endpoint references and reconciles against these profiles.
 
 schema_version = "1.0"
 policy = "network-allowlist"
 owner = "EffortlessMetrics"
 status = "active"
 
-# Scaffold profiles. PR 3 fills these in once workflow receipts are written.
-#
-# [[policy]]
-# name = "ci"
-# allowed_endpoints = ["github.com", "githubusercontent.com", "crates.io", "static.crates.io"]
-# owner = "release/ci"
-# reason = "CI fetches actions, toolchains, crates, and registry metadata."
-#
-# [[policy]]
-# name = "release"
-# allowed_endpoints = [
-#   "crates.io",
-#   "static.crates.io",
-#   "token.actions.githubusercontent.com",
-#   "api.github.com",
-# ]
-# owner = "release/ci"
-# reason = "Trusted Publishing and release artifact workflows require crates.io and GitHub API/OIDC endpoints."
+# ─── ci ─────────────────────────────────────────────────────────────────────
+
+[[profile]]
+name = "ci"
+allowed_endpoints = [
+  "github.com",
+  "api.github.com",
+  "raw.githubusercontent.com",
+  "objects.githubusercontent.com",
+  "ghcr.io",
+  "crates.io",
+  "static.crates.io",
+  "index.crates.io",
+  "static.rust-lang.org",
+  "win.rustup.rs",
+  "sh.rustup.rs",
+  "codecov.io",
+  "app.codecov.io",
+  "cli.codecov.io",
+]
+owner = "release/ci"
+reason = "CI fetches actions, toolchains (rustup), crates (crates.io + sparse index), and uploads coverage reports to Codecov. dtolnay/rust-toolchain and taiki-e/install-action add the rustup and ghcr endpoints."
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+# ─── release ────────────────────────────────────────────────────────────────
+
+[[profile]]
+name = "release"
+allowed_endpoints = [
+  "github.com",
+  "api.github.com",
+  "uploads.github.com",
+  "objects.githubusercontent.com",
+  "token.actions.githubusercontent.com",
+  "crates.io",
+  "static.crates.io",
+  "index.crates.io",
+  "static.rust-lang.org",
+  "sh.rustup.rs",
+  "win.rustup.rs",
+]
+owner = "release/ci"
+reason = "Release workflow contacts crates.io for Trusted Publishing (token.actions.githubusercontent.com for the OIDC exchange + crates.io / index.crates.io / static.crates.io for the publish + visibility verification), GitHub for artifact uploads and release creation, and the standard rustup/toolchain endpoints."
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+# ─── droid ──────────────────────────────────────────────────────────────────
+
+[[profile]]
+name = "droid"
+allowed_endpoints = [
+  "github.com",
+  "api.github.com",
+  "raw.githubusercontent.com",
+  "objects.githubusercontent.com",
+  "token.actions.githubusercontent.com",
+  "app.factory.ai",
+  "api.factory.ai",
+  "api.minimax.io",
+]
+owner = "release/ci"
+reason = "Droid workflows fetch the Factory CLI from app.factory.ai/cli, exchange the GitHub OIDC token for a Factory app token (token.actions.githubusercontent.com -> api.factory.ai), and route MiniMax-M2.7 BYOK requests to api.minimax.io/anthropic. The actions/checkout + droid-action-safe action also need GitHub endpoints."
+created = "2026-05-11"
+review_after = "2026-08-11"

--- a/policy/process-allowlist.toml
+++ b/policy/process-allowlist.toml
@@ -4,25 +4,79 @@
 # under that policy. Workflows in policy/workflow-allowlist.toml reference one
 # of these profiles via `process_policy = "..."`.
 #
-# This file ships as a scaffold in PR 2 with the `ci` and `release` profiles
-# stubbed but empty. PR 3 (#203) populates the actual command lists by
-# scanning the current workflows.
+# These lists are intentionally honest first-pass receipts: they cover what is
+# actually invoked today. PR 8 (#207) adds the checker that scans workflows
+# for command usage and reconciles against these profiles.
 
 schema_version = "1.0"
 policy = "process-allowlist"
 owner = "EffortlessMetrics"
 status = "active"
 
-# Scaffold profiles. PR 3 fills these in once workflow receipts are written.
+# ─── ci ─────────────────────────────────────────────────────────────────────
 #
-# [[policy]]
-# name = "ci"
-# allowed_processes = ["cargo", "rustup"]
-# owner = "release/ci"
-# reason = "CI compiles, lints, and tests the Rust workspace."
+# Default CI profile: build, lint, test the Rust workspace. Also covers
+# coverage, architecture-guard, fuzz (nightly variant of cargo), and mutation
+# (cargo-mutants installs via taiki-e/install-action).
+
+[[profile]]
+name = "ci"
+allowed_processes = [
+  "cargo",
+  "rustup",
+  "rustc",
+  "cargo-fuzz",
+  "cargo-mutants",
+  "cargo-llvm-cov",
+  "cargo-nextest",
+]
+owner = "release/ci"
+reason = "CI compiles, lints, tests, fuzzes, and measures coverage on the Rust workspace. Tools (cargo-fuzz, cargo-mutants, cargo-llvm-cov, cargo-nextest) are installed via taiki-e/install-action."
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+# ─── release ────────────────────────────────────────────────────────────────
 #
-# [[policy]]
-# name = "release"
-# allowed_processes = ["cargo", "rustup", "shipper", "gh", "tar", "sha256sum"]
-# owner = "release/ci"
-# reason = "Release workflow builds shipper, publishes crates, uploads artifacts, and verifies registry visibility."
+# Release workflow: builds shipper, runs it as a CLI, publishes via Trusted
+# Publishing, produces signed/checksummed binary artifacts, creates the GitHub
+# release.
+
+[[profile]]
+name = "release"
+allowed_processes = [
+  "cargo",
+  "rustup",
+  "rustc",
+  "shipper",
+  "gh",
+  "tar",
+  "sha256sum",
+  "install",
+  "sudo",
+]
+owner = "release/ci"
+reason = "Release workflow dogfoods shipper itself, builds the release binary, packages it (tar + sha256sum), installs it to PATH (via install / sudo), and creates the GitHub release with gh. Trusted Publishing supplies registry credentials via OIDC."
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+# ─── droid ──────────────────────────────────────────────────────────────────
+#
+# Droid workflows: fetch the Factory CLI via curl + sh, configure MiniMax BYOK,
+# invoke the EffortlessMetrics/droid-action-safe action (which uses bun
+# internally for prepare.ts).
+
+[[profile]]
+name = "droid"
+allowed_processes = [
+  "bash",
+  "curl",
+  "sh",
+  "bun",
+  "mkdir",
+  "cat",
+  "jq",
+]
+owner = "release/ci"
+reason = "Droid workflows write the BYOK settings file (mkdir, cat heredoc), fetch the Factory CLI (curl --proto =https | sh), and invoke the safe Droid action wrapper which uses bun for its prepare.ts entrypoint."
+created = "2026-05-11"
+review_after = "2026-08-11"

--- a/policy/workflow-allowlist.toml
+++ b/policy/workflow-allowlist.toml
@@ -4,17 +4,116 @@
 # `.github/**` wildcard. Each workflow declares the process and network
 # policies it operates under (see policy/process-allowlist.toml and
 # policy/network-allowlist.toml).
-#
-# This file ships as a scaffold in PR 2. PR 3 (#203) sweeps every current
-# workflow into a real receipt with `process_policy` and `network_policy`
-# named explicitly.
 
 schema_version = "1.0"
 policy = "workflow-allowlist"
 owner = "EffortlessMetrics"
 status = "active"
 
-# No workflows are receipted at scaffold time. PR 3 enumerates each of the
-# current workflows under .github/workflows/ and assigns its process and
-# network policies. The release workflow must explicitly use
-# `process_policy = "release"` and `network_policy = "release"`.
+# ─── CI workflows ───────────────────────────────────────────────────────────
+
+[[workflow]]
+path = ".github/workflows/ci.yml"
+kind = "required_ci"
+owner = "release/ci"
+reason = "Primary CI workflow: fmt, clippy, build matrix, nextest matrix, MSRV check, security audit, docs, BDD, fuzz smoke, release build."
+process_policy = "ci"
+network_policy = "ci"
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+[[workflow]]
+path = ".github/workflows/coverage.yml"
+kind = "ci"
+owner = "release/ci"
+reason = "Code coverage via cargo-llvm-cov uploaded to Codecov. Runs on main and PRs."
+process_policy = "ci"
+network_policy = "ci"
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+[[workflow]]
+path = ".github/workflows/architecture-guard.yml"
+kind = "ci"
+owner = "rust/architecture"
+reason = "Enforces the plan/state/runtime/ops/engine layering rules documented in crate CLAUDE.md files."
+process_policy = "ci"
+network_policy = "ci"
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+[[workflow]]
+path = ".github/workflows/fuzz.yml"
+kind = "ci_scheduled"
+owner = "fuzz/tests"
+reason = "Scheduled cargo-fuzz runs using nightly toolchain. Out of the default PR critical path."
+process_policy = "ci"
+network_policy = "ci"
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+[[workflow]]
+path = ".github/workflows/mutation.yml"
+kind = "ci_scheduled"
+owner = "rust/tests"
+reason = "Scheduled cargo-mutants runs for targeted mutation testing of trust-critical crates."
+process_policy = "ci"
+network_policy = "ci"
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+# ─── Release workflow (high risk: secrets, Trusted Publishing, registry) ────
+
+[[workflow]]
+path = ".github/workflows/release.yml"
+kind = "release"
+owner = "release/ci"
+reason = "Primary release workflow. Dogfoods shipper itself: cargo build, shipper plan/preflight/publish/resume, crates.io Trusted Publishing via OIDC, binary artifact build + upload, gh release create."
+process_policy = "release"
+network_policy = "release"
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+# ─── Droid workflows (BYOK MiniMax, external Factory CLI fetch) ─────────────
+
+[[workflow]]
+path = ".github/workflows/droid-review.yml"
+kind = "droid_auto_review"
+owner = "release/ci"
+reason = "Automatic Factory Droid review on same-repo PRs. BYOK MiniMax M2.7. Same-repo guard + allowed_bots: dependabot[bot]. See #172, #174."
+process_policy = "droid"
+network_policy = "droid"
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+[[workflow]]
+path = ".github/workflows/droid.yml"
+kind = "droid_manual"
+owner = "release/ci"
+reason = "Manual @droid command handling. Trusted-actor guard (OWNER/MEMBER/COLLABORATOR) on every event branch. BYOK MiniMax M2.7."
+process_policy = "droid"
+network_policy = "droid"
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+[[workflow]]
+path = ".github/workflows/droid-security-scan.yml"
+kind = "droid_scheduled_security"
+owner = "release/ci"
+reason = "Scheduled (Mon 08:00 UTC) and workflow_dispatch Factory Droid security scan. 7-day window, medium threshold, critical blocking."
+process_policy = "droid"
+network_policy = "droid"
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+# ─── Dependabot configuration (not a workflow, but governs the bot itself) ──
+
+[[workflow]]
+path = ".github/dependabot.yml"
+kind = "dependabot_config"
+owner = "release/ci"
+reason = "Dependabot configuration for cargo and github-actions ecosystems."
+process_policy = "ci"
+network_policy = "ci"
+created = "2026-05-11"
+review_after = "2026-08-11"


### PR DESCRIPTION
## Summary

Third PR in the 12-PR file-policy rollout. Populates the high-risk ledgers that #214 (PR 2) left as documented scaffolds: workflow, process, network. **No checker, no enforcement, no CI wiring** — pure first-pass receipts.

## Issue

Closes #203. Depends on #202 (merged scaffolds). Refines #180. Tracks #109.

## What's receipted

**`workflow-allowlist.toml`** — every `.github/workflows/*.yml` listed explicitly (no `.github/**` wildcard), 9 workflows + `dependabot.yml`. Each declares its `process_policy` and `network_policy`:

- `ci` profile: ci.yml, coverage.yml, architecture-guard.yml, fuzz.yml, mutation.yml
- `release` profile: release.yml
- `droid` profile: droid-review.yml, droid.yml, droid-security-scan.yml

**`process-allowlist.toml`** — three named profiles with commands actually invoked today:

- `ci`: cargo, rustup, rustc, cargo-fuzz, cargo-mutants, cargo-llvm-cov, cargo-nextest
- `release`: + shipper, gh, tar, sha256sum, install, sudo
- `droid`: bash, curl, sh, bun, mkdir, cat, jq (BYOK heredoc + Factory CLI fetch + droid-action-safe)

**`network-allowlist.toml`** — three named profiles with endpoints actually contacted today:

- `ci`: github.com + crates.io family, rustup endpoints, codecov
- `release`: + Trusted Publishing OIDC + uploads.github.com
- `droid`: + app.factory.ai, api.factory.ai, api.minimax.io

## Decisions

- **Decision:** Use `[[profile]]` for the array-of-tables in process/network allowlists.
  - **Rationale:** The top-level `policy = "process-allowlist"` field is a string identifying the policy itself; reusing `policy` as the array name collides ("Cannot overwrite a value"). Each array entry IS a named profile, so `[[profile]]` is also semantically clearer.
- **Decision:** Separate `droid` profile rather than folding Droid commands into `ci`.
  - **Rationale:** Droid workflows have a substantively different command/endpoint surface (curl|sh fetch, bun, MiniMax/Factory APIs) and live under different secrets (Dependabot-scoped). Mixing into `ci` would understate what's being authorized.

## Validation

- [x] All 8 `policy/*.toml` files parse as valid TOML (Python `tomllib`).
- [x] `cargo check --workspace --locked` passes.
- [x] No source code touched.
- [x] No workflow files touched.

## Follow-ups

PR 4 (#212) — add the xtask skeleton + `cargo xtask non-rust inventory`. After that, PR 5–8 implement the checkers that consume these ledgers.