### PR TITLE
feat(policy): check non-Rust file allowlist (#204, rollout PR 5/12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,6 +861,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,6 +2192,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -2334,7 +2356,7 @@ dependencies = [
  "temp-env",
  "tempfile",
  "tiny_http",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -2351,7 +2373,7 @@ dependencies = [
  "shipper-types",
  "shipper-webhook",
  "tempfile",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -2394,7 +2416,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tiny_http",
  "tokio",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "which",
 ]
 
@@ -2407,7 +2429,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -2799,17 +2821,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.1",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2822,13 +2865,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -3476,6 +3539,15 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
@@ -3579,9 +3651,12 @@ name = "xtask"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
+ "globset",
  "serde",
  "serde_json",
+ "toml 0.8.23",
 ]
 
 [[package]]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,6 +13,9 @@ anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 serde = { workspace = true }
 serde_json = "1.0"
+toml = "0.8"
+globset = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [lints]
 workspace = true

--- a/xtask/src/check_file_policy.rs
+++ b/xtask/src/check_file_policy.rs
@@ -1,0 +1,512 @@
+//! `cargo xtask check-file-policy --mode <mode>`
+//!
+//! Reconciles tracked non-Rust files against `policy/non-rust-allowlist.toml`.
+//! Three modes match the operating doctrine documented in
+//! `docs/FILE_POLICY.md`:
+//!
+//! - **advisory**: report violations; never fail. Lets `target/policy/` collect
+//!   evidence before CI is asked to gate on it.
+//! - **blocking-allowlist**: fail on unreceipted files, malformed entries
+//!   (missing required fields), and expired entries.
+//! - **blocking-strict**: also fail on unused entries (no tracked match) and
+//!   stale review dates (`review_after` in the past). Out of scope until a
+//!   dedicated cleanup pass — see `docs/policy/NON_RUST_ROLLOUT.md`.
+//!
+//! Outputs are written to `target/policy/file-policy-report.{md,json}` and
+//! consumed by `cargo xtask policy-report` (rollout PR 9).
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use chrono::NaiveDate;
+use globset::Glob;
+use serde::{Deserialize, Serialize};
+
+const ALLOWLIST_REL: &str = "policy/non-rust-allowlist.toml";
+const OUTPUT_DIR_REL: &str = "target/policy";
+const MD_NAME: &str = "file-policy-report.md";
+const JSON_NAME: &str = "file-policy-report.json";
+
+/// CLI mode for `check-file-policy`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum Mode {
+    Advisory,
+    BlockingAllowlist,
+    BlockingStrict,
+}
+
+// ─── Allowlist deserialization ──────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct AllowlistDoc {
+    #[serde(default)]
+    file: Vec<RawEntry>,
+    #[serde(default)]
+    glob: Vec<RawEntry>,
+}
+
+/// Raw entry shared by `[[file]]` and `[[glob]]`. `path` vs `pattern`
+/// distinguishes the two — exactly one is present per entry.
+#[derive(Debug, Clone, Deserialize)]
+struct RawEntry {
+    path: Option<String>,
+    pattern: Option<String>,
+    kind: Option<String>,
+    surface: Option<String>,
+    classification: Option<String>,
+    owner: Option<String>,
+    reason: Option<String>,
+    covered_by: Option<Vec<String>>,
+    created: Option<String>,
+    review_after: Option<String>,
+    expires: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct Entry {
+    selector: Selector,
+    raw: RawEntry,
+}
+
+#[derive(Debug, Clone)]
+enum Selector {
+    Path(String),
+    Pattern(String),
+}
+
+impl Entry {
+    fn label(&self) -> String {
+        match &self.selector {
+            Selector::Path(p) => format!("file: {p}"),
+            Selector::Pattern(p) => format!("glob: {p}"),
+        }
+    }
+}
+
+// ─── Findings ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+struct Findings {
+    unreceipted: Vec<String>,
+    missing_fields: Vec<MissingFields>,
+    expired: Vec<ExpiredEntry>,
+    stale: Vec<StaleEntry>,
+    unused: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct MissingFields {
+    entry: String,
+    missing: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ExpiredEntry {
+    entry: String,
+    expires: String,
+    today: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct StaleEntry {
+    entry: String,
+    review_after: String,
+    today: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct Report {
+    tool: &'static str,
+    mode: &'static str,
+    today: String,
+    summary: Summary,
+    findings: Findings,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct Summary {
+    tracked_non_rust: usize,
+    allowlist_entries: usize,
+    unreceipted: usize,
+    missing_fields: usize,
+    expired: usize,
+    stale: usize,
+    unused: usize,
+}
+
+// ─── Entry point ────────────────────────────────────────────────────────────
+
+pub fn check(mode: Mode) -> Result<()> {
+    let workspace_root = workspace_root()?;
+    let tracked_non_rust = enumerate_non_rust(&workspace_root)?;
+    let entries = load_allowlist(&workspace_root)?;
+    let today = today_iso();
+
+    let findings = reconcile(&tracked_non_rust, &entries, &today);
+
+    let summary = Summary {
+        tracked_non_rust: tracked_non_rust.len(),
+        allowlist_entries: entries.len(),
+        unreceipted: findings.unreceipted.len(),
+        missing_fields: findings.missing_fields.len(),
+        expired: findings.expired.len(),
+        stale: findings.stale.len(),
+        unused: findings.unused.len(),
+    };
+
+    let report = Report {
+        tool: "cargo xtask check-file-policy",
+        mode: mode_str(mode),
+        today: today.clone(),
+        summary,
+        findings: findings.clone(),
+    };
+
+    write_report(&workspace_root, &report)?;
+    print_stdout_summary(&report);
+
+    let fail_required = mode_fails(mode, &report.findings);
+    if fail_required {
+        bail!(
+            "check-file-policy: {} mode found {} blocking issue(s); see {}/{}",
+            report.mode,
+            blocking_count(mode, &report.findings),
+            OUTPUT_DIR_REL,
+            MD_NAME,
+        );
+    }
+    Ok(())
+}
+
+// ─── Reconciliation ─────────────────────────────────────────────────────────
+
+fn reconcile(tracked: &[String], entries: &[Entry], today: &str) -> Findings {
+    // Build matchers and track which entries matched anything.
+    let mut entry_matched: Vec<bool> = vec![false; entries.len()];
+    let mut covered: BTreeSet<&str> = BTreeSet::new();
+
+    for path in tracked {
+        for (idx, entry) in entries.iter().enumerate() {
+            let matched = match &entry.selector {
+                Selector::Path(p) => p == path,
+                Selector::Pattern(pat) => glob_matches(pat, path),
+            };
+            if matched {
+                entry_matched[idx] = true;
+                covered.insert(path.as_str());
+            }
+        }
+    }
+
+    let unreceipted: Vec<String> = tracked
+        .iter()
+        .filter(|p| !covered.contains(p.as_str()))
+        .cloned()
+        .collect();
+
+    let missing_fields: Vec<MissingFields> = entries
+        .iter()
+        .filter_map(|e| {
+            let missing = missing_required_fields(&e.raw);
+            if missing.is_empty() {
+                None
+            } else {
+                Some(MissingFields {
+                    entry: e.label(),
+                    missing,
+                })
+            }
+        })
+        .collect();
+
+    let expired: Vec<ExpiredEntry> = entries
+        .iter()
+        .filter_map(|e| {
+            e.raw.expires.as_ref().and_then(|exp| {
+                if date_is_past(exp, today) {
+                    Some(ExpiredEntry {
+                        entry: e.label(),
+                        expires: exp.clone(),
+                        today: today.to_string(),
+                    })
+                } else {
+                    None
+                }
+            })
+        })
+        .collect();
+
+    let stale: Vec<StaleEntry> = entries
+        .iter()
+        .filter_map(|e| {
+            e.raw.review_after.as_ref().and_then(|rev| {
+                if date_is_past(rev, today) {
+                    Some(StaleEntry {
+                        entry: e.label(),
+                        review_after: rev.clone(),
+                        today: today.to_string(),
+                    })
+                } else {
+                    None
+                }
+            })
+        })
+        .collect();
+
+    let unused: Vec<String> = entries
+        .iter()
+        .zip(entry_matched.iter())
+        .filter_map(|(e, &m)| if m { None } else { Some(e.label()) })
+        .collect();
+
+    Findings {
+        unreceipted,
+        missing_fields,
+        expired,
+        stale,
+        unused,
+    }
+}
+
+fn missing_required_fields(raw: &RawEntry) -> Vec<String> {
+    let mut missing = Vec::new();
+    if raw.path.is_none() && raw.pattern.is_none() {
+        missing.push("path|pattern".to_string());
+    }
+    if raw.kind.is_none() {
+        missing.push("kind".to_string());
+    }
+    if raw.surface.is_none() {
+        missing.push("surface".to_string());
+    }
+    if raw.classification.is_none() {
+        missing.push("classification".to_string());
+    }
+    if raw.owner.is_none() {
+        missing.push("owner".to_string());
+    }
+    if raw.reason.is_none() {
+        missing.push("reason".to_string());
+    }
+    if raw.covered_by.is_none() {
+        missing.push("covered_by".to_string());
+    }
+    if raw.created.is_none() {
+        missing.push("created".to_string());
+    }
+    if raw.review_after.is_none() {
+        missing.push("review_after".to_string());
+    }
+    missing
+}
+
+fn glob_matches(pattern: &str, path: &str) -> bool {
+    match Glob::new(pattern) {
+        Ok(g) => g.compile_matcher().is_match(path),
+        Err(_) => false,
+    }
+}
+
+fn date_is_past(date: &str, today: &str) -> bool {
+    // ISO 8601 dates (YYYY-MM-DD) sort lexically, so plain string compare is
+    // correct as long as both sides are normalized. We accept anything chrono
+    // can parse to be defensive.
+    let parsed = NaiveDate::parse_from_str(date.trim(), "%Y-%m-%d").ok();
+    let today_parsed = NaiveDate::parse_from_str(today, "%Y-%m-%d").ok();
+    match (parsed, today_parsed) {
+        (Some(d), Some(t)) => d < t,
+        _ => date.trim() < today,
+    }
+}
+
+// ─── Mode semantics ─────────────────────────────────────────────────────────
+
+fn mode_str(mode: Mode) -> &'static str {
+    match mode {
+        Mode::Advisory => "advisory",
+        Mode::BlockingAllowlist => "blocking-allowlist",
+        Mode::BlockingStrict => "blocking-strict",
+    }
+}
+
+fn mode_fails(mode: Mode, f: &Findings) -> bool {
+    match mode {
+        Mode::Advisory => false,
+        Mode::BlockingAllowlist => {
+            !f.unreceipted.is_empty() || !f.missing_fields.is_empty() || !f.expired.is_empty()
+        }
+        Mode::BlockingStrict => {
+            !f.unreceipted.is_empty()
+                || !f.missing_fields.is_empty()
+                || !f.expired.is_empty()
+                || !f.unused.is_empty()
+                || !f.stale.is_empty()
+        }
+    }
+}
+
+fn blocking_count(mode: Mode, f: &Findings) -> usize {
+    let mut n = f.unreceipted.len() + f.missing_fields.len() + f.expired.len();
+    if matches!(mode, Mode::BlockingStrict) {
+        n += f.unused.len() + f.stale.len();
+    }
+    n
+}
+
+// ─── IO helpers ─────────────────────────────────────────────────────────────
+
+fn enumerate_non_rust(workspace_root: &Path) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(workspace_root)
+        .arg("ls-files")
+        .arg("-z")
+        .output()
+        .context("running `git ls-files -z`")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "`git ls-files -z` exited {}: {}",
+            output.status,
+            stderr.trim()
+        );
+    }
+    let mut paths: Vec<String> = output
+        .stdout
+        .split(|&b| b == 0)
+        .filter(|s| !s.is_empty())
+        .map(|bytes| String::from_utf8_lossy(bytes).into_owned())
+        .filter(|p| {
+            !Path::new(p)
+                .extension()
+                .and_then(|s| s.to_str())
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("rs"))
+        })
+        .collect();
+    paths.sort();
+    Ok(paths)
+}
+
+fn load_allowlist(workspace_root: &Path) -> Result<Vec<Entry>> {
+    let path = workspace_root.join(ALLOWLIST_REL);
+    let raw = fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    let doc: AllowlistDoc =
+        toml::from_str(&raw).with_context(|| format!("parsing TOML in {}", path.display()))?;
+
+    let mut entries = Vec::with_capacity(doc.file.len() + doc.glob.len());
+    for raw in doc.file {
+        let path = raw.path.clone().unwrap_or_default();
+        entries.push(Entry {
+            selector: Selector::Path(path),
+            raw,
+        });
+    }
+    for raw in doc.glob {
+        let pattern = raw.pattern.clone().unwrap_or_default();
+        entries.push(Entry {
+            selector: Selector::Pattern(pattern),
+            raw,
+        });
+    }
+    Ok(entries)
+}
+
+fn workspace_root() -> Result<PathBuf> {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+        .context("CARGO_MANIFEST_DIR not set; run via `cargo xtask`")?;
+    let xtask_dir = PathBuf::from(manifest_dir);
+    let root = xtask_dir
+        .parent()
+        .with_context(|| format!("xtask manifest dir has no parent: {}", xtask_dir.display()))?
+        .to_path_buf();
+    Ok(root)
+}
+
+fn today_iso() -> String {
+    chrono::Utc::now()
+        .date_naive()
+        .format("%Y-%m-%d")
+        .to_string()
+}
+
+fn write_report(workspace_root: &Path, report: &Report) -> Result<()> {
+    let out_dir = workspace_root.join(OUTPUT_DIR_REL);
+    fs::create_dir_all(&out_dir).with_context(|| format!("creating {}", out_dir.display()))?;
+    let json = serde_json::to_string_pretty(report).context("serializing report as JSON")?;
+    fs::write(out_dir.join(JSON_NAME), json).context("writing JSON report")?;
+    fs::write(out_dir.join(MD_NAME), render_markdown(report)).context("writing Markdown report")?;
+    Ok(())
+}
+
+fn render_markdown(r: &Report) -> String {
+    let mut out = String::new();
+    out.push_str("# File-Policy Report\n\n");
+    out.push_str(&format!(
+        "Generated by `{} --mode {}` on {}.\n\n",
+        r.tool, r.mode, r.today
+    ));
+
+    out.push_str("## Summary\n\n");
+    out.push_str(&format!(
+        "- Tracked non-Rust files: {}\n",
+        r.summary.tracked_non_rust
+    ));
+    out.push_str(&format!(
+        "- Allowlist entries: {}\n",
+        r.summary.allowlist_entries
+    ));
+    out.push_str(&format!("- Unreceipted files: {}\n", r.summary.unreceipted));
+    out.push_str(&format!(
+        "- Entries with missing required fields: {}\n",
+        r.summary.missing_fields
+    ));
+    out.push_str(&format!("- Expired entries: {}\n", r.summary.expired));
+    out.push_str(&format!("- Stale review entries: {}\n", r.summary.stale));
+    out.push_str(&format!("- Unused entries: {}\n\n", r.summary.unused));
+
+    section(&mut out, "Unreceipted files", &r.findings.unreceipted);
+    section(
+        &mut out,
+        "Entries with missing required fields",
+        &r.findings.missing_fields,
+    );
+    section(&mut out, "Expired entries", &r.findings.expired);
+    section(&mut out, "Stale review entries", &r.findings.stale);
+    section(&mut out, "Unused entries", &r.findings.unused);
+
+    out
+}
+
+fn section<T: Serialize>(out: &mut String, title: &str, items: &[T]) {
+    out.push_str(&format!("## {} ({})\n\n", title, items.len()));
+    if items.is_empty() {
+        out.push_str("_(none)_\n\n");
+    } else {
+        for item in items {
+            // Use JSON for structured items, plain bullets for strings.
+            let value = serde_json::to_value(item).unwrap_or_default();
+            match value {
+                serde_json::Value::String(s) => out.push_str(&format!("- `{}`\n", s)),
+                other => out.push_str(&format!("- `{}`\n", other)),
+            }
+        }
+        out.push('\n');
+    }
+}
+
+fn print_stdout_summary(r: &Report) {
+    println!(
+        "file-policy ({}): tracked={} entries={} unreceipted={} missing_fields={} expired={} stale={} unused={}",
+        r.mode,
+        r.summary.tracked_non_rust,
+        r.summary.allowlist_entries,
+        r.summary.unreceipted,
+        r.summary.missing_fields,
+        r.summary.expired,
+        r.summary.stale,
+        r.summary.unused,
+    );
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,8 +9,9 @@
 //! See `docs/policy/NON_RUST_ROLLOUT.md` for the full ladder.
 
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 
+mod check_file_policy;
 mod file_policy;
 
 #[derive(Parser, Debug)]
@@ -30,6 +31,10 @@ enum Command {
     /// Non-Rust file policy commands.
     #[command(subcommand, name = "non-rust")]
     NonRust(NonRustCommand),
+
+    /// Reconcile tracked non-Rust files against `policy/non-rust-allowlist.toml`.
+    #[command(name = "check-file-policy")]
+    CheckFilePolicy(CheckFilePolicyArgs),
 }
 
 #[derive(Subcommand, Debug)]
@@ -37,9 +42,15 @@ enum NonRustCommand {
     /// Inventory all tracked non-Rust files in the workspace.
     ///
     /// Emits a Markdown summary and a JSON payload to `target/policy/`.
-    /// The output is consumed by later policy checkers
-    /// (`cargo xtask check-file-policy`, landing in a follow-up PR).
+    /// The output is consumed by `check-file-policy`.
     Inventory,
+}
+
+#[derive(Args, Debug)]
+struct CheckFilePolicyArgs {
+    /// Reporting / enforcement mode.
+    #[arg(long, value_enum, default_value_t = check_file_policy::Mode::Advisory)]
+    mode: check_file_policy::Mode,
 }
 
 fn main() -> Result<()> {
@@ -48,6 +59,7 @@ fn main() -> Result<()> {
         Command::NonRust(cmd) => match cmd {
             NonRustCommand::Inventory => file_policy::inventory()?,
         },
+        Command::CheckFilePolicy(args) => check_file_policy::check(args.mode)?,
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fifth PR in the 12-PR file-policy rollout. **First real enforcement command.** Adds `cargo xtask check-file-policy --mode <mode>` which reconciles tracked non-Rust files against `policy/non-rust-allowlist.toml`.

## Issue

Closes #204. Depends on #202 (ledger scaffolds, merged), #212 (xtask scaffold, merged). Refines #180. Tracks #109.

## Behavior

Walks `git ls-files -z` minus `*.rs`, reconciles against `[[file]]` (exact path) and `[[glob]]` (globset pattern) entries. Reports five finding categories:

- **unreceipted files** — no allowlist entry matches
- **missing required fields** — entry without `path`|`pattern`, `kind`, `surface`, `classification`, `owner`, `reason`, `covered_by`, `created`, or `review_after`
- **expired entries** — `entry.expires < today` (when set)
- **stale review** — `entry.review_after < today`
- **unused entries** — allowlist entry matched no tracked file

## Modes

| Mode | Exit | Fails on |
|---|---|---|
| `advisory` (default) | always 0 | nothing |
| `blocking-allowlist` | 1 on any | unreceipted + missing fields + expired |
| `blocking-strict` | 1 on any | all five categories |

`blocking-strict` is wired but reserved until a dedicated stale/unused cleanup pass, per `docs/policy/NON_RUST_ROLLOUT.md`.

## Decisions

- **Added `toml`, `globset`, `chrono` (no defaults, `clock` only) as direct xtask deps.** `toml` is non-negotiable. `globset` handles `docs/**/*.md`-style patterns correctly. `chrono` for "today" — ISO 8601 dates would sort lexically but `NaiveDate` parse+compare is the defensive choice. `clock` feature is the only weight added.
- **Bail with issue count + pointer.** Failure exits via `bail!("...; see target/policy/file-policy-report.md")` so the artifact path is in the operator's terminal.

## Acceptance

- [x] `cargo check --workspace --locked` passes.
- [x] `cargo clippy -p xtask --all-targets --locked -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo xtask check-file-policy --mode advisory` exits 0 and reports:
      `tracked=1018 entries=24 unreceipted=945 missing_fields=0 expired=0 stale=0 unused=0`
- [x] `cargo xtask check-file-policy --mode blocking-allowlist` exits 1:
      `Error: check-file-policy: blocking-allowlist mode found 945 blocking issue(s); see target/policy/file-policy-report.md`
- [x] Both `target/policy/file-policy-report.md` and `.json` produced.

## Note on the 945-unreceipted count

Expected. Generated files (`**/*.snap`), workflow files, dependency-surface files, etc. live in their own ledgers (`generated-allowlist.toml`, `workflow-allowlist.toml`, `dependency-surface-allowlist.toml`). This checker is scoped to `non-rust-allowlist.toml` only. PRs 7 (#206) and 8 (#207) add the companion checkers; PR 9 (#208) aggregates into a unified `policy-report`. **Not a blocker for merging this PR** — advisory mode is the configured state, and the report is informational evidence for later PRs.

## Follow-ups

- PR 6 (#205) — `cargo xtask non-rust propose` writes draft receipts for the unreceipted files this PR surfaces.
- PR 7 (#206) — generated / executable / dependency-surface checks.
- PR 8 (#207) — workflow / process / network checks.
- PR 9 (#208) — unified `policy-report` consumes all four reports.