### PR TITLE
ci(policy): run file policy checks advisory (#209, rollout PR 10/12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,45 @@ jobs:
       - name: Clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
+  policy:
+    # Advisory-only policy report. Runs the seven xtask file-policy
+    # checks (file / generated / executable / dependency-surface /
+    # workflow / process / network) and uploads the aggregated report
+    # under target/policy/. Never blocks merge.
+    #
+    # Promotion to blocking is the job of rollout PR 11 / #210
+    # (file/generated/executable/dependency/workflow) and PR 12 / #211
+    # (process/network). See docs/policy/NON_RUST_ROLLOUT.md.
+    name: Policy (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-policy-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-policy-
+
+      - name: Run all advisory checks + unified policy report
+        run: cargo xtask policy-report
+
+      - name: Upload policy reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: policy-reports
+          path: target/policy/
+          if-no-files-found: error
+          retention-days: 30
+
   test:
     name: Tests (nextest)
     strategy:

--- a/docs/FILE_POLICY.md
+++ b/docs/FILE_POLICY.md
@@ -96,7 +96,7 @@ In short:
 1. **PRs 1–3** are docs and ledger scaffolding. No checker, no enforcement.
 2. **PR 4** adds an `xtask` skeleton and `cargo xtask non-rust inventory`.
 3. **PRs 5–9** add the checker subcommands and the unified report. All run in advisory mode initially.
-4. **PR 10** wires the advisory checks into CI and uploads the policy report as an artifact. No merge blocking yet.
+4. **PR 10** wires the advisory checks into CI as a `Policy (advisory)` job and uploads the aggregated report from `target/policy/` as a `policy-reports` artifact. The job never blocks merge. _This is the current state of the rollout._
 5. **PR 11** promotes file/generated/executable/dependency/workflow checks to `blocking-allowlist`.
 6. **PR 12** promotes process and network checks to `blocking-allowlist`.
 

--- a/docs/POLICY_ALLOWLISTS.md
+++ b/docs/POLICY_ALLOWLISTS.md
@@ -157,7 +157,7 @@ A receipt in any of these allowlists is **not** "approved forever." It is "known
 | `check-generated` / `check-executable-files` / `check-dependency-surfaces` | 7/12 | [#206](https://github.com/EffortlessMetrics/shipper/issues/206) | planned |
 | `check-workflow-surfaces` / `check-process-policy` / `check-network-policy` | 8/12 | [#207](https://github.com/EffortlessMetrics/shipper/issues/207) | planned |
 | `cargo xtask policy-report` (unified) | 9/12 | [#208](https://github.com/EffortlessMetrics/shipper/issues/208) | planned |
-| CI: run all checks in advisory mode + upload artifact | 10/12 | [#209](https://github.com/EffortlessMetrics/shipper/issues/209) | planned |
+| CI: run all checks in advisory mode + upload artifact | 10/12 | [#209](https://github.com/EffortlessMetrics/shipper/issues/209) | in flight |
 | CI: promote file/generated/executable/dependency/workflow to blocking | 11/12 | [#210](https://github.com/EffortlessMetrics/shipper/issues/210) | planned |
 | CI: promote process and network to blocking | 12/12 | [#211](https://github.com/EffortlessMetrics/shipper/issues/211) | planned |
 

--- a/docs/policy/NON_RUST_ROLLOUT.md
+++ b/docs/policy/NON_RUST_ROLLOUT.md
@@ -23,8 +23,8 @@ This is the working tracker for the 12-PR rollout that turns Shipper's planned f
 | 6/12 | [#205](https://github.com/EffortlessMetrics/shipper/issues/205) | `feat(policy): propose non-Rust allowlist entries` | planned | PR 2, PR 4, PR 5 |
 | 7/12 | [#206](https://github.com/EffortlessMetrics/shipper/issues/206) | `feat(policy): check generated, executable, and dependency surfaces` | planned | PR 2, PR 4 |
 | 8/12 | [#207](https://github.com/EffortlessMetrics/shipper/issues/207) | `feat(policy): check workflow, process, and network surfaces` | planned | PR 2, PR 3, PR 4 |
-| 9/12 | [#208](https://github.com/EffortlessMetrics/shipper/issues/208) | `feat(policy): add unified policy report` | planned | PR 5–8 |
-| 10/12 | [#209](https://github.com/EffortlessMetrics/shipper/issues/209) | `ci(policy): run file policy checks advisory` | planned | PR 5–9 |
+| 9/12 | [#208](https://github.com/EffortlessMetrics/shipper/issues/208) | `feat(policy): add unified policy report` | landed | PR 5–8 |
+| 10/12 | [#209](https://github.com/EffortlessMetrics/shipper/issues/209) | `ci(policy): run file policy checks advisory` | in flight | PR 5–9 |
 | 11/12 | [#210](https://github.com/EffortlessMetrics/shipper/issues/210) | `ci(policy): require non-Rust file policy allowlist` | planned | PR 10 |
 | 12/12 | [#211](https://github.com/EffortlessMetrics/shipper/issues/211) | `ci(policy): require process and network policy receipts` | planned | PR 10, PR 11 |
 


### PR DESCRIPTION
## Summary

Tenth PR in the 12-PR file-policy rollout. **First PR to touch a CI workflow file.** Wires the seven advisory xtask checks into CI and uploads the aggregated `target/policy/` as an artifact. Never blocks merge.

## Issue

Closes #209. Consumes PR 5 (#204), 6 (#205), 7 (#206), 8 (#207), 9 (#208). Refines #180. Tracks #109.

## What the new CI job does

`Policy (advisory)` job in `.github/workflows/ci.yml`:

1. Checks out the repo, installs stable Rust, caches Cargo under a `policy`-keyed cache.
2. Runs `cargo xtask policy-report`, which internally invokes all seven advisory checks and writes the unified report alongside each sub-report.
3. Uploads `target/policy/` as a `policy-reports` artifact with 30-day retention and `if-no-files-found: error`.

The job sits after `lint` in ci.yml so it gets early visibility but runs concurrently with the test/build matrix. No critical-path extension expected.

## Decisions

- **`if: always()` on the upload step** so the artifact lands even when PRs 11/12 later promote sub-checks to blocking mode and a fail occurs.
- **`if-no-files-found: error`** so a silently-empty `target/policy/` (e.g., from a broken xtask) fails the upload rather than silently uploading nothing.
- **Dedicated `cargo-policy-${{ hashFiles('**/Cargo.lock') }}` cache key** so the policy job doesn't fight with `lint`'s cache (different `cargo check` targets).
- **`Policy (advisory)`** name explicitly carries the mode so a future required-check ratchet (PRs 11/12) can rename the job to drop the "(advisory)" qualifier as a signal of the new posture.

## Docs

- `docs/FILE_POLICY.md` "Rollout" section now records that **PR 10 is the current state**.
- `docs/POLICY_ALLOWLISTS.md` and `docs/policy/NON_RUST_ROLLOUT.md` flip PR 9 to `landed`, PR 10 to `in flight`.

## Acceptance

- [x] `.github/workflows/ci.yml` parses as valid YAML.
- [x] `cargo check --workspace --locked` passes.
- [x] `cargo xtask policy-report` still produces both unified artifacts locally.
- [x] No other CI jobs touched; no `permissions:` changes; no critical-path lengthening.
- [x] Artifact upload uses pinned `actions/upload-artifact@v7` (consistent with the rest of ci.yml).

## Follow-ups

- **PR 11 (#210)** — promote file/generated/executable/dependency/workflow checks to `blocking-allowlist` by adding explicit invocations in CI with `--mode blocking-allowlist`. Process/network stay advisory.
- **PR 12 (#211)** — promote process/network to `blocking-allowlist` after a clean observational window.