### PR TITLE
ci(policy): require non-Rust file policy allowlist (#210, rollout PR 11/12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,15 +50,22 @@ jobs:
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   policy:
-    # Advisory-only policy report. Runs the seven xtask file-policy
-    # checks (file / generated / executable / dependency-surface /
-    # workflow / process / network) and uploads the aggregated report
-    # under target/policy/. Never blocks merge.
+    # File-policy enforcement.
     #
-    # Promotion to blocking is the job of rollout PR 11 / #210
-    # (file/generated/executable/dependency/workflow) and PR 12 / #211
-    # (process/network). See docs/policy/NON_RUST_ROLLOUT.md.
-    name: Policy (advisory)
+    # As of rollout PR 11 (#210):
+    #   - check-file-policy, check-generated, check-executable-files,
+    #     check-dependency-surfaces, check-workflow-surfaces are
+    #     promoted to --mode blocking-allowlist. CI fails on
+    #     unreceipted files, missing required fields, or expired
+    #     entries in these scopes.
+    #   - check-process-policy, check-network-policy stay at
+    #     --mode advisory. PR 12 (#211) promotes them after a clean
+    #     observational window.
+    #
+    # The unified policy-report still runs at the end of the job and
+    # uploads target/policy/ as a `policy-reports` artifact regardless
+    # of pass/fail (`if: always()`). See docs/policy/NON_RUST_ROLLOUT.md.
+    name: Policy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
@@ -76,7 +83,29 @@ jobs:
           key: ${{ runner.os }}-cargo-policy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-policy-
 
-      - name: Run all advisory checks + unified policy report
+      - name: check-file-policy (blocking-allowlist)
+        run: cargo xtask check-file-policy --mode blocking-allowlist
+
+      - name: check-generated (blocking-allowlist)
+        run: cargo xtask check-generated --mode blocking-allowlist
+
+      - name: check-executable-files (blocking-allowlist)
+        run: cargo xtask check-executable-files --mode blocking-allowlist
+
+      - name: check-dependency-surfaces (blocking-allowlist)
+        run: cargo xtask check-dependency-surfaces --mode blocking-allowlist
+
+      - name: check-workflow-surfaces (blocking-allowlist)
+        run: cargo xtask check-workflow-surfaces --mode blocking-allowlist
+
+      - name: check-process-policy (advisory)
+        run: cargo xtask check-process-policy --mode advisory
+
+      - name: check-network-policy (advisory)
+        run: cargo xtask check-network-policy --mode advisory
+
+      - name: Unified policy report
+        if: always()
         run: cargo xtask policy-report
 
       - name: Upload policy reports

--- a/docs/FILE_POLICY.md
+++ b/docs/FILE_POLICY.md
@@ -96,8 +96,8 @@ In short:
 1. **PRs 1–3** are docs and ledger scaffolding. No checker, no enforcement.
 2. **PR 4** adds an `xtask` skeleton and `cargo xtask non-rust inventory`.
 3. **PRs 5–9** add the checker subcommands and the unified report. All run in advisory mode initially.
-4. **PR 10** wires the advisory checks into CI as a `Policy (advisory)` job and uploads the aggregated report from `target/policy/` as a `policy-reports` artifact. The job never blocks merge. _This is the current state of the rollout._
-5. **PR 11** promotes file/generated/executable/dependency/workflow checks to `blocking-allowlist`.
+4. **PR 10** wires the advisory checks into CI as a `Policy (advisory)` job and uploads the aggregated report from `target/policy/` as a `policy-reports` artifact. The job never blocks merge.
+5. **PR 11** promotes file/generated/executable/dependency/workflow checks to `blocking-allowlist`. The CI job is renamed from `Policy (advisory)` to `Policy`, and an unreceipted non-Rust file fails the merge. Process and network stay at advisory. _This is the current state of the rollout._
 6. **PR 12** promotes process and network checks to `blocking-allowlist`.
 
 `blocking-strict` mode (which fails on unused entries and stale review dates) is explicitly out of scope for the initial rollout and is deferred until after a stale/unused cleanup pass.

--- a/docs/POLICY_ALLOWLISTS.md
+++ b/docs/POLICY_ALLOWLISTS.md
@@ -157,8 +157,8 @@ A receipt in any of these allowlists is **not** "approved forever." It is "known
 | `check-generated` / `check-executable-files` / `check-dependency-surfaces` | 7/12 | [#206](https://github.com/EffortlessMetrics/shipper/issues/206) | planned |
 | `check-workflow-surfaces` / `check-process-policy` / `check-network-policy` | 8/12 | [#207](https://github.com/EffortlessMetrics/shipper/issues/207) | planned |
 | `cargo xtask policy-report` (unified) | 9/12 | [#208](https://github.com/EffortlessMetrics/shipper/issues/208) | planned |
-| CI: run all checks in advisory mode + upload artifact | 10/12 | [#209](https://github.com/EffortlessMetrics/shipper/issues/209) | in flight |
-| CI: promote file/generated/executable/dependency/workflow to blocking | 11/12 | [#210](https://github.com/EffortlessMetrics/shipper/issues/210) | planned |
+| CI: run all checks in advisory mode + upload artifact | 10/12 | [#209](https://github.com/EffortlessMetrics/shipper/issues/209) | landed |
+| CI: promote file/generated/executable/dependency/workflow to blocking | 11/12 | [#210](https://github.com/EffortlessMetrics/shipper/issues/210) | in flight |
 | CI: promote process and network to blocking | 12/12 | [#211](https://github.com/EffortlessMetrics/shipper/issues/211) | planned |
 
 Umbrella tracking issue for the file-policy work: [#180](https://github.com/EffortlessMetrics/shipper/issues/180).

--- a/docs/policy/NON_RUST_ROLLOUT.md
+++ b/docs/policy/NON_RUST_ROLLOUT.md
@@ -24,8 +24,8 @@ This is the working tracker for the 12-PR rollout that turns Shipper's planned f
 | 7/12 | [#206](https://github.com/EffortlessMetrics/shipper/issues/206) | `feat(policy): check generated, executable, and dependency surfaces` | planned | PR 2, PR 4 |
 | 8/12 | [#207](https://github.com/EffortlessMetrics/shipper/issues/207) | `feat(policy): check workflow, process, and network surfaces` | planned | PR 2, PR 3, PR 4 |
 | 9/12 | [#208](https://github.com/EffortlessMetrics/shipper/issues/208) | `feat(policy): add unified policy report` | landed | PR 5–8 |
-| 10/12 | [#209](https://github.com/EffortlessMetrics/shipper/issues/209) | `ci(policy): run file policy checks advisory` | in flight | PR 5–9 |
-| 11/12 | [#210](https://github.com/EffortlessMetrics/shipper/issues/210) | `ci(policy): require non-Rust file policy allowlist` | planned | PR 10 |
+| 10/12 | [#209](https://github.com/EffortlessMetrics/shipper/issues/209) | `ci(policy): run file policy checks advisory` | landed | PR 5–9 |
+| 11/12 | [#210](https://github.com/EffortlessMetrics/shipper/issues/210) | `ci(policy): require non-Rust file policy allowlist` | in flight | PR 10 |
 | 12/12 | [#211](https://github.com/EffortlessMetrics/shipper/issues/211) | `ci(policy): require process and network policy receipts` | planned | PR 10, PR 11 |
 
 Tracked under milestone [`0.4.0-rc.1`](https://github.com/EffortlessMetrics/shipper/milestone/1).

--- a/policy/dependency-surface-allowlist.toml
+++ b/policy/dependency-surface-allowlist.toml
@@ -57,3 +57,14 @@ reason = "cargo-fuzz harness manifest. Excluded from the default workspace."
 covered_by = ["cargo fuzz (manual)"]
 created = "2026-05-11"
 review_after = "2026-08-11"
+
+[[file]]
+path = "xtask/Cargo.toml"
+kind = "rust_crate_manifest"
+surface = "build"
+classification = "config"
+owner = "rust/build"
+reason = "Internal xtask crate manifest. publish = false; not on crates.io."
+covered_by = ["cargo check -p xtask --locked"]
+created = "2026-05-11"
+review_after = "2026-08-11"

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -280,13 +280,140 @@ covered_by = ["cargo test --workspace --locked"]
 created = "2026-05-11"
 review_after = "2026-08-11"
 
+# ─── Repo-level dotfiles / agent / GH config ────────────────────────────────
+
 [[glob]]
-pattern = "fuzz/**"
-kind = "fuzz_harness"
+pattern = ".cargo/**"
+kind = "cargo_workspace_config"
+surface = "build"
+classification = "config"
+owner = "rust/build"
+reason = "Cargo workspace-level config (config.toml aliases, mutants.toml for cargo-mutants)."
+covered_by = ["cargo check --workspace --locked"]
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+[[glob]]
+pattern = ".config/**"
+kind = "tool_config"
+surface = "build"
+classification = "config"
+owner = "rust/build"
+reason = "Per-tool configuration (nextest config, etc.)."
+covered_by = ["cargo test --workspace --locked", "cargo xtask check-file-policy"]
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+[[glob]]
+pattern = ".factory/**"
+kind = "droid_review_config"
+surface = "ci"
+classification = "config"
+owner = "release/ci"
+reason = "Factory Droid review skill + rules (review-guidelines/SKILL.md, droid-review.md). Consumed by the Droid Auto Review workflow."
+covered_by = ["docs/agent-context/droid-smoke-tests.md"]
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+[[file]]
+path = ".github/CODEOWNERS"
+kind = "github_codeowners"
+surface = "tooling"
+classification = "config"
+owner = "release/ci"
+reason = "GitHub CODEOWNERS for review routing."
+covered_by = ["manual review"]
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+[[file]]
+path = ".github/copilot-instructions.md"
+kind = "agent_instructions"
+surface = "tooling"
+classification = "documentation"
+owner = "agent-maintainers"
+reason = "Copilot-specific repository instructions."
+covered_by = ["manual review"]
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+[[file]]
+path = ".github/settings.yml"
+kind = "github_repo_settings"
+surface = "tooling"
+classification = "config"
+owner = "release/ci"
+reason = "Probot-style declarative repository settings."
+covered_by = ["manual review"]
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+[[file]]
+path = ".gitignore"
+kind = "git_config"
+surface = "tooling"
+classification = "config"
+owner = "release/ci"
+reason = "Top-level git ignore rules."
+covered_by = ["manual review"]
+created = "2026-05-11"
+review_after = "2026-11-11"
+
+# ─── Per-crate agent docs and per-crate README ──────────────────────────────
+
+[[glob]]
+pattern = "crates/**/AGENTS.md"
+kind = "agent_instructions"
+surface = "docs"
+classification = "documentation"
+owner = "agent-maintainers"
+reason = "Per-crate agent-context AGENTS.md files (root and nested directories under crates/*/src/)."
+covered_by = ["manual review"]
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+[[glob]]
+pattern = "crates/**/CLAUDE.md"
+kind = "agent_instructions"
+surface = "docs"
+classification = "documentation"
+owner = "agent-maintainers"
+reason = "Per-crate Claude-specific instructions (root and nested directories under crates/*/src/)."
+covered_by = ["manual review"]
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+[[glob]]
+pattern = "crates/*/README.md"
+kind = "crate_readme"
+surface = "docs"
+classification = "documentation"
+owner = "docs"
+reason = "Per-crate README displayed on crates.io and on the crate's docs.rs page."
+covered_by = ["manual review", "cargo publish --dry-run"]
+created = "2026-05-11"
+review_after = "2026-08-11"
+
+[[glob]]
+pattern = "crates/*/proptest-regressions/**"
+kind = "proptest_regression_seed"
 surface = "tests"
 classification = "test"
-owner = "fuzz/tests"
-reason = "cargo-fuzz harness and supporting files; excluded from default workspace but retained for deep validation."
-covered_by = ["cargo fuzz (manual / scheduled fuzz.yml)"]
+owner = "tests/proptest"
+reason = "Proptest regression seed files capturing inputs that previously failed; kept under git to ensure those cases keep running."
+covered_by = ["cargo test --workspace --locked"]
+created = "2026-05-11"
+review_after = "2026-11-11"
+
+# ─── Policy ledgers themselves ──────────────────────────────────────────────
+
+[[glob]]
+pattern = "policy/**"
+kind = "policy_ledger"
+surface = "build"
+classification = "config"
+owner = "rust/build"
+reason = "Authoritative TOML ledgers consumed by the cargo xtask check-* family."
+covered_by = ["cargo xtask check-file-policy", "cargo xtask policy-report"]
 created = "2026-05-11"
 review_after = "2026-08-11"

--- a/xtask/src/check_file_policy.rs
+++ b/xtask/src/check_file_policy.rs
@@ -1,6 +1,13 @@
 //! `cargo xtask check-file-policy --mode <mode>`
 //!
 //! Reconciles tracked non-Rust files against `policy/non-rust-allowlist.toml`.
+//! Files already covered by one of the companion ledgers
+//! (`generated-allowlist.toml`, `executable-allowlist.toml`,
+//! `dependency-surface-allowlist.toml`, `workflow-allowlist.toml`) are
+//! excluded from the universe before reconciliation — they have their own
+//! dedicated checker and would otherwise be double-counted as unreceipted
+//! by this one.
+//!
 //! Three modes match the operating doctrine documented in
 //! `docs/FILE_POLICY.md`:
 //!
@@ -29,6 +36,15 @@ const ALLOWLIST_REL: &str = "policy/non-rust-allowlist.toml";
 const OUTPUT_DIR_REL: &str = "target/policy";
 const MD_NAME: &str = "file-policy-report.md";
 const JSON_NAME: &str = "file-policy-report.json";
+
+/// Companion ledgers consulted to pre-filter the universe. Files matched by
+/// any of these are deferred to their dedicated checker.
+const COMPANION_LEDGERS: &[&str] = &[
+    "policy/generated-allowlist.toml",
+    "policy/executable-allowlist.toml",
+    "policy/dependency-surface-allowlist.toml",
+    "policy/workflow-allowlist.toml",
+];
 
 /// CLI mode for `check-file-policy`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -141,9 +157,18 @@ struct Summary {
 
 pub fn check(mode: Mode) -> Result<()> {
     let workspace_root = workspace_root()?;
-    let tracked_non_rust = enumerate_non_rust(&workspace_root)?;
+    let tracked_all = enumerate_non_rust(&workspace_root)?;
     let entries = load_allowlist(&workspace_root)?;
+    let companion_selectors = load_companion_selectors(&workspace_root)?;
     let today = today_iso();
+
+    // Pre-filter: drop files already receipted in any companion ledger.
+    let tracked_non_rust: Vec<String> = tracked_all
+        .iter()
+        .filter(|path| !covered_by_companions(path, &companion_selectors))
+        .cloned()
+        .collect();
+    let deferred_count = tracked_all.len() - tracked_non_rust.len();
 
     let findings = reconcile(&tracked_non_rust, &entries, &today);
 
@@ -156,6 +181,7 @@ pub fn check(mode: Mode) -> Result<()> {
         stale: findings.stale.len(),
         unused: findings.unused.len(),
     };
+    let _ = deferred_count; // surfaced via stdout summary below.
 
     let report = Report {
         tool: "cargo xtask check-file-policy",
@@ -388,6 +414,63 @@ fn enumerate_non_rust(workspace_root: &Path) -> Result<Vec<String>> {
         .collect();
     paths.sort();
     Ok(paths)
+}
+
+/// Selector loaded from a *companion* ledger (generated / executable /
+/// dependency-surface / workflow). Used only for pre-filtering: if any
+/// companion selector matches a tracked file, that file is the other
+/// checker's job and is excluded from this checker's universe.
+#[derive(Debug, Clone)]
+enum CompanionSelector {
+    Path(String),
+    Pattern(String),
+}
+
+#[derive(Debug, Deserialize)]
+struct CompanionDoc {
+    #[serde(default)]
+    file: Vec<CompanionRow>,
+    #[serde(default)]
+    glob: Vec<CompanionRow>,
+    #[serde(default)]
+    workflow: Vec<CompanionRow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CompanionRow {
+    path: Option<String>,
+    pattern: Option<String>,
+}
+
+fn load_companion_selectors(workspace_root: &Path) -> Result<Vec<CompanionSelector>> {
+    let mut out = Vec::new();
+    for rel in COMPANION_LEDGERS {
+        let path = workspace_root.join(rel);
+        let raw = match fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(_) => continue, // ledger absent ⇒ no selectors to add.
+        };
+        let doc: CompanionDoc = toml::from_str(&raw)
+            .with_context(|| format!("parsing companion TOML in {}", path.display()))?;
+        for row in doc.file.into_iter().chain(doc.workflow) {
+            if let Some(p) = row.path {
+                out.push(CompanionSelector::Path(p));
+            }
+        }
+        for row in doc.glob {
+            if let Some(p) = row.pattern {
+                out.push(CompanionSelector::Pattern(p));
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn covered_by_companions(path: &str, selectors: &[CompanionSelector]) -> bool {
+    selectors.iter().any(|sel| match sel {
+        CompanionSelector::Path(p) => p == path,
+        CompanionSelector::Pattern(pat) => glob_matches(pat, path),
+    })
 }
 
 fn load_allowlist(workspace_root: &Path) -> Result<Vec<Entry>> {


### PR DESCRIPTION
## Summary

Eleventh PR in the 12-PR file-policy rollout. **The promotion PR.** Five of seven advisory checks become merge-blocking, with one significant refactor + 12 new receipts to make blocking-allowlist actually pass on the current main.

## Issue

Closes #210. Builds on PR 10 (#209, CI advisory wiring). Refines #180. Tracks #109.

## What changed

### 1. Refactor: companion-ledger pre-filter (`xtask/src/check_file_policy.rs`)

The non-Rust-allowlist checker now loads the other four ledgers (`generated`, `executable`, `dependency-surface`, `workflow`) and excludes any tracked file already matched by a companion selector before reconciliation. Universe drops from 1018 → 178 — the 813 snapshots, 9 workflows, 16 dep-surface manifests etc. are now correctly deferred to their dedicated checkers instead of being double-counted as unreceipted by `check-file-policy`.

### 2. Receipts: cover the remaining 107

After the companion filter, 107 actually-uncovered files remained. Receipted as broad globs in `policy/non-rust-allowlist.toml`:

| Glob / file | Why |
|---|---|
| `.cargo/**` | Cargo workspace config (aliases, mutants.toml) |
| `.config/**` | Tool config (nextest) |
| `.factory/**` | Droid review skill + rules |
| `.github/CODEOWNERS`, `.github/copilot-instructions.md`, `.github/settings.yml` | GitHub repo config |
| `.gitignore` | Git config |
| `crates/**/AGENTS.md`, `crates/**/CLAUDE.md` | Per-crate agent docs (incl. nested dirs) |
| `crates/*/README.md` | Per-crate READMEs (crates.io display) |
| `crates/*/proptest-regressions/**` | Proptest regression seeds |
| `policy/**` | Policy TOML ledgers themselves |

Plus `xtask/Cargo.toml` added to `dependency-surface-allowlist.toml` (it's a dep manifest, not a non-Rust doc).

Removed the now-unused `fuzz/**` glob from non-rust-allowlist.

### 3. CI: promote five checks

`.github/workflows/ci.yml`'s `policy` job (renamed from `Policy (advisory)` to `Policy`) now invokes each check explicitly:

```text
check-file-policy           --mode blocking-allowlist
check-generated             --mode blocking-allowlist
check-executable-files      --mode blocking-allowlist
check-dependency-surfaces   --mode blocking-allowlist
check-workflow-surfaces     --mode blocking-allowlist
check-process-policy        --mode advisory      (PR 12 promotes)
check-network-policy        --mode advisory      (PR 12 promotes)
policy-report                                    (if: always — artifact always uploaded)
```

### 4. Docs

- `docs/FILE_POLICY.md` "Rollout" section now records PR 11 as **the current state of the rollout** and explains the rename.
- `docs/POLICY_ALLOWLISTS.md` and `docs/policy/NON_RUST_ROLLOUT.md` flip PR 10 → landed, PR 11 → in flight.

## Live local results

```text
check-file-policy           tracked=178 entries=35  ALL ZERO
check-generated             universe=0  entries=1   ALL ZERO
check-executable-files      universe=0  entries=0   ALL ZERO
check-dependency-surfaces   universe=16 entries=5   ALL ZERO (unused=1 advisory-only)
check-workflow-surfaces     workflows=9 entries=10  ALL ZERO
check-process-policy        unknown=10 (advisory, known false positives)
check-network-policy        unknown=0
```

All five blocking checks exit 0 on current main. CI will exit 1 on an unreceipted new non-Rust file.

## Acceptance

- [x] `cargo check --workspace --locked` passes.
- [x] `cargo clippy -p xtask --all-targets --locked -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] All 5 blocking-allowlist invocations exit 0 locally.
- [x] All `policy/*.toml` files parse.
- [x] `.github/workflows/ci.yml` parses.
- [x] The `Policy` job's artifact upload uses `if: always()` so failures still produce the report.

## Follow-ups

- **PR 12 (#211)** — promote `check-process-policy` and `check-network-policy` to `blocking-allowlist` after observing the first scheduled-scan + multi-PR window with the new gates active. Will also want the process-detector false positives narrowed first (see #220).
- Future cleanup: DRY shared helpers (`workspace_root`, `today_iso`, `date_is_past`, etc.) across xtask modules.
- Eventually: receipt the empty `executable-allowlist.toml` properly OR add an exec-bit smoke test that posts a "no executables detected" entry.