### PR TITLE
feat(policy): Clippy lint ledgers + check-lint-policy / check-clippy-exceptions (#179)

### DIFF
--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,27 @@
+# Clippy debt ledger.
+#
+# Temporary accepted violations of an active Clippy lint. Every entry has
+# an owner and an expires date. When `expires` passes, the entry must be
+# renewed or the underlying suppression removed.
+#
+# This file ships empty in PR for #179. The workspace is currently
+# Clippy-clean, so no debt exists. Real entries arrive only when PR 7
+# (#191) activates new lints with measured fallout, or when a future PR
+# accepts a specific time-bound exception.
+#
+# See docs/CLIPPY_POLICY.md and policy/clippy-lints.toml.
+
+schema_version = "1.0"
+policy = "clippy-debt"
+owner = "rust/lints"
+status = "active"
+
+# Entries take this shape:
+#
+# [[debt]]
+# lint = "clippy::needless_pass_by_value"
+# path = "crates/shipper-core/src/plan/mod.rs"
+# count = 3
+# owner = "rust/lints"
+# reason = "Refactor planned in API cleanup PR (#184)."
+# expires = "2026-08-11"

--- a/policy/clippy-exceptions.toml
+++ b/policy/clippy-exceptions.toml
@@ -1,0 +1,29 @@
+# Clippy exception ledger.
+#
+# Intentional suppressions with business justification. Every entry has
+# an owner, a reason, and an expires date (used to force annual review).
+# `check-clippy-exceptions` fails if any entry is past its expires.
+#
+# This file ships empty. Real entries are added intentionally when a
+# specific suppression is judged durable.
+#
+# Suppressions in code must use `#[expect(clippy::lint_name, reason = "...")]`,
+# not bare `#[allow(clippy::...)]`. The check-clippy-exceptions command
+# runs a shallow scan to surface bare-allow occurrences as informational
+# findings.
+#
+# See docs/CLIPPY_POLICY.md, policy/clippy-lints.toml, policy/clippy-debt.toml.
+
+schema_version = "1.0"
+policy = "clippy-exceptions"
+owner = "rust/lints"
+status = "active"
+
+# Entries take this shape:
+#
+# [[exception]]
+# lint = "clippy::needless_pass_by_value"
+# path = "crates/shipper-core/src/engine/publish.rs:142"
+# owner = "rust/lints"
+# reason = "Hot-path function taking owned value by deliberate API contract."
+# expires = "2027-05-12"

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,115 @@
+# Clippy lint ledger.
+#
+# Authoritative record of active and planned Clippy lints for the shipper
+# workspace. Mirrors the tables in docs/CLIPPY_POLICY.md.
+#
+# `msrv` here must equal the MSRV set in clippy.toml and
+# `[workspace.package] rust-version` in Cargo.toml. The `cargo xtask
+# check-lint-policy` command verifies all three agree.
+#
+# `[[active]]` entries are the lints that are (or will be, at lint-activation
+# time) live in `[workspace.lints.clippy]`. The check-lint-policy command
+# verifies every member of `[workspace.lints.clippy]` has a ledger entry
+# here. Reverse direction is NOT enforced — entries here may be
+# aspirational until the activation PR lands (see PR 7 / #191).
+#
+# `[[planned]]` entries activate once MSRV reaches `min_msrv`. Activation
+# itself is a separate PR after measurement; see docs/CLIPPY_POLICY.md.
+
+schema_version = "1.0"
+policy = "clippy-lints"
+owner = "rust/lints"
+status = "active"
+msrv = "1.95"
+
+# ─── Active lints ───────────────────────────────────────────────────────────
+
+[[active]]
+name = "rust::unsafe_code"
+level = "forbid"
+class = "unsafe-memory"
+reason = "shipper has no unsafe code"
+since = "1.92"
+
+[[active]]
+name = "clippy::dbg_macro"
+level = "deny"
+class = "hygiene"
+reason = "Debug macros are not a reviewable diagnostics path"
+since = "0.0.0"
+
+[[active]]
+name = "clippy::todo"
+level = "deny"
+class = "panic"
+reason = "TODO execution paths are not allowed"
+since = "0.0.0"
+
+[[active]]
+name = "clippy::unimplemented"
+level = "deny"
+class = "panic"
+reason = "Unimplemented execution paths are not allowed"
+since = "0.0.0"
+
+# ─── Planned lints (MSRV-gated) ─────────────────────────────────────────────
+
+[[planned]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+min_msrv = "1.94"
+reason = "Catch raw-parts reconstruction mistakes"
+
+[[planned]]
+name = "clippy::manual_ilog2"
+level = "warn"
+min_msrv = "1.94"
+reason = "Prefer standard integer log helper"
+
+[[planned]]
+name = "clippy::decimal_bitwise_operands"
+level = "warn"
+min_msrv = "1.94"
+reason = "Make bit masks visually inspectable"
+
+[[planned]]
+name = "clippy::needless_type_cast"
+level = "warn"
+min_msrv = "1.94"
+reason = "Avoid stale numeric type drift"
+
+[[planned]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+min_msrv = "1.95"
+reason = "Prefer checked arithmetic over manual guards"
+
+[[planned]]
+name = "clippy::manual_take"
+level = "warn"
+min_msrv = "1.95"
+reason = "Use standard ownership helper"
+
+[[planned]]
+name = "clippy::manual_pop_if"
+level = "warn"
+min_msrv = "1.95"
+reason = "Use predicate-and-pop collection APIs"
+
+[[planned]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+min_msrv = "1.95"
+reason = "Make durations legible"
+
+[[planned]]
+name = "clippy::unnecessary_trailing_comma"
+level = "warn"
+min_msrv = "1.95"
+reason = "Keep format macro calls clean"
+
+[[planned]]
+name = "clippy::disallowed_fields"
+level = "deny"
+min_msrv = "1.95"
+reason = "Ban direct field access across protected seams (pending seam configuration; see docs/CLIPPY_POLICY.md)"

--- a/xtask/src/clippy_checks.rs
+++ b/xtask/src/clippy_checks.rs
@@ -1,0 +1,319 @@
+//! `cargo xtask check-lint-policy` + `cargo xtask check-clippy-exceptions`.
+//!
+//! Two checkers for the Clippy ledger surface added in PR for #179:
+//!
+//! - **`check-lint-policy`** validates that MSRV agrees across
+//!   `Cargo.toml` `[workspace.package] rust-version`, `clippy.toml`
+//!   `msrv`, and `policy/clippy-lints.toml` `msrv`, and that every lint
+//!   in `[workspace.lints.clippy]` has a ledger entry. Reverse direction
+//!   (ledger entries not in `[workspace.lints.clippy]`) is intentionally
+//!   not enforced — `[[active]]` entries may be aspirational until PR 7
+//!   activates them.
+//!
+//! - **`check-clippy-exceptions`** validates the schema of every
+//!   `policy/clippy-exceptions.toml` entry (lint, path, owner, reason,
+//!   expires), fails on expired entries, and runs a shallow regex scan
+//!   for bare `#[allow(clippy::...)]` attributes — reported as
+//!   *informational* findings only in this PR (PR for #179 is ledger
+//!   only). Code-ledger correspondence enforcement is a future PR.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use chrono::NaiveDate;
+use regex::Regex;
+use serde::Deserialize;
+
+const CARGO_TOML: &str = "Cargo.toml";
+const CLIPPY_TOML: &str = "clippy.toml";
+const LINTS_LEDGER: &str = "policy/clippy-lints.toml";
+const EXCEPTIONS_LEDGER: &str = "policy/clippy-exceptions.toml";
+
+// ─── check-lint-policy ──────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct CargoToml {
+    #[serde(default)]
+    workspace: Option<Workspace>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Workspace {
+    #[serde(default)]
+    package: Option<WorkspacePackage>,
+    #[serde(default)]
+    lints: Option<Lints>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkspacePackage {
+    #[serde(rename = "rust-version")]
+    rust_version: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct Lints {
+    #[serde(default)]
+    clippy: BTreeMap<String, toml::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClippyTomlConfig {
+    msrv: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LintsLedger {
+    msrv: Option<String>,
+    #[serde(default)]
+    active: Vec<ActiveLint>,
+    #[serde(default)]
+    planned: Vec<PlannedLint>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ActiveLint {
+    name: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PlannedLint {
+    name: String,
+    #[allow(dead_code)]
+    min_msrv: Option<String>,
+}
+
+pub fn check_lint_policy() -> Result<()> {
+    let workspace_root = workspace_root()?;
+
+    // Read MSRV from three sources.
+    let cargo: CargoToml = read_toml(&workspace_root.join(CARGO_TOML))?;
+    let cargo_msrv = cargo
+        .workspace
+        .as_ref()
+        .and_then(|w| w.package.as_ref())
+        .and_then(|p| p.rust_version.clone());
+
+    let clippy: ClippyTomlConfig = read_toml(&workspace_root.join(CLIPPY_TOML))?;
+    let clippy_msrv = clippy.msrv.clone();
+
+    let ledger: LintsLedger = read_toml(&workspace_root.join(LINTS_LEDGER))?;
+    let ledger_msrv = ledger.msrv.clone();
+
+    let mut errors: Vec<String> = Vec::new();
+
+    match (&cargo_msrv, &clippy_msrv, &ledger_msrv) {
+        (Some(c), Some(cl), Some(l)) if c == cl && cl == l => {
+            println!("msrv aligned across all three: {c}");
+        }
+        _ => {
+            errors.push(format!(
+                "MSRV disagreement: Cargo.toml workspace.package.rust-version={:?}, \
+                 clippy.toml msrv={:?}, {} msrv={:?}",
+                cargo_msrv, clippy_msrv, LINTS_LEDGER, ledger_msrv
+            ));
+        }
+    }
+
+    // Cross-check: every `[workspace.lints.clippy]` entry has a ledger entry.
+    let workspace_lints: BTreeSet<String> = cargo
+        .workspace
+        .as_ref()
+        .and_then(|w| w.lints.as_ref())
+        .map(|l| {
+            l.clippy
+                .keys()
+                .map(|k| format!("clippy::{k}"))
+                .collect::<BTreeSet<_>>()
+        })
+        .unwrap_or_default();
+
+    let ledger_names: BTreeSet<String> = ledger
+        .active
+        .iter()
+        .map(|a| a.name.clone())
+        .chain(ledger.planned.iter().map(|p| p.name.clone()))
+        .collect();
+
+    let workspace_lint_count = workspace_lints.len();
+    for lint in &workspace_lints {
+        if !ledger_names.contains(lint) {
+            errors.push(format!(
+                "lint `{lint}` is in [workspace.lints.clippy] but has no ledger entry in {LINTS_LEDGER}"
+            ));
+        }
+    }
+
+    println!(
+        "check-lint-policy: workspace.lints.clippy={} active_in_ledger={} planned_in_ledger={}",
+        workspace_lint_count,
+        ledger.active.len(),
+        ledger.planned.len(),
+    );
+
+    if !errors.is_empty() {
+        for e in &errors {
+            eprintln!("error: {e}");
+        }
+        bail!("check-lint-policy: {} error(s)", errors.len());
+    }
+    Ok(())
+}
+
+// ─── check-clippy-exceptions ────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct ExceptionsLedger {
+    #[serde(default)]
+    exception: Vec<RawException>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawException {
+    lint: Option<String>,
+    path: Option<String>,
+    owner: Option<String>,
+    reason: Option<String>,
+    expires: Option<String>,
+}
+
+pub fn check_clippy_exceptions() -> Result<()> {
+    let workspace_root = workspace_root()?;
+    let today = today_iso();
+
+    let ledger: ExceptionsLedger = read_toml(&workspace_root.join(EXCEPTIONS_LEDGER))?;
+
+    let mut errors: Vec<String> = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
+
+    // Schema + expiry validation.
+    for (idx, e) in ledger.exception.iter().enumerate() {
+        let label = e
+            .lint
+            .clone()
+            .unwrap_or_else(|| format!("entry {}", idx + 1));
+        for (field, present) in [
+            ("lint", e.lint.is_some()),
+            ("path", e.path.is_some()),
+            ("owner", e.owner.is_some()),
+            ("reason", e.reason.is_some()),
+            ("expires", e.expires.is_some()),
+        ] {
+            if !present {
+                errors.push(format!(
+                    "exception {label} missing required field `{field}`"
+                ));
+            }
+        }
+        if let Some(exp) = &e.expires
+            && date_is_past(exp, &today)
+        {
+            errors.push(format!(
+                "exception {label} expired: expires={exp} today={today}"
+            ));
+        }
+    }
+
+    // Shallow scan for bare `#[allow(clippy::...)]`. Informational only.
+    let bare_allows = shallow_bare_allow_scan(&workspace_root)?;
+    for occ in &bare_allows {
+        warnings.push(format!(
+            "bare `#[allow(clippy::...)]` at {} — prefer `#[expect(clippy::..., reason = \"...\")]` (informational; not failing in PR 5)",
+            occ
+        ));
+    }
+
+    println!(
+        "check-clippy-exceptions: entries={} expired=0 schema_errors={} bare_allow_informational={}",
+        ledger.exception.len(),
+        errors.len(),
+        bare_allows.len(),
+    );
+    for w in &warnings {
+        println!("note: {w}");
+    }
+
+    if !errors.is_empty() {
+        for e in &errors {
+            eprintln!("error: {e}");
+        }
+        bail!("check-clippy-exceptions: {} error(s)", errors.len());
+    }
+    Ok(())
+}
+
+fn shallow_bare_allow_scan(workspace_root: &Path) -> Result<Vec<String>> {
+    let re = Regex::new(r"#\s*\[\s*allow\s*\(\s*clippy::[A-Za-z0-9_]+")
+        .context("compiling bare-allow regex")?;
+
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(workspace_root)
+        .arg("ls-files")
+        .arg("-z")
+        .arg("*.rs")
+        .output()
+        .context("running `git ls-files -z *.rs`")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "`git ls-files -z *.rs` exited {}: {}",
+            output.status,
+            stderr.trim()
+        );
+    }
+
+    let mut hits: Vec<String> = Vec::new();
+    for entry in output.stdout.split(|&b| b == 0).filter(|s| !s.is_empty()) {
+        let rel = String::from_utf8_lossy(entry).into_owned();
+        let abs = workspace_root.join(&rel);
+        let content = match fs::read_to_string(&abs) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        for (lineno, line) in content.lines().enumerate() {
+            if re.is_match(line) {
+                hits.push(format!("{}:{}", rel, lineno + 1));
+            }
+        }
+    }
+    hits.sort();
+    Ok(hits)
+}
+
+// ─── Shared helpers ─────────────────────────────────────────────────────────
+
+fn read_toml<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    toml::from_str(&raw).with_context(|| format!("parsing TOML in {}", path.display()))
+}
+
+fn workspace_root() -> Result<PathBuf> {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+        .context("CARGO_MANIFEST_DIR not set; run via `cargo xtask`")?;
+    let xtask_dir = PathBuf::from(manifest_dir);
+    let root = xtask_dir
+        .parent()
+        .with_context(|| format!("xtask manifest dir has no parent: {}", xtask_dir.display()))?
+        .to_path_buf();
+    Ok(root)
+}
+
+fn today_iso() -> String {
+    chrono::Utc::now()
+        .date_naive()
+        .format("%Y-%m-%d")
+        .to_string()
+}
+
+fn date_is_past(date: &str, today: &str) -> bool {
+    let parsed = NaiveDate::parse_from_str(date.trim(), "%Y-%m-%d").ok();
+    let today_parsed = NaiveDate::parse_from_str(today, "%Y-%m-%d").ok();
+    match (parsed, today_parsed) {
+        (Some(d), Some(t)) => d < t,
+        _ => date.trim() < today,
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -13,6 +13,7 @@ use clap::{Args, Parser, Subcommand};
 
 mod check_file_policy;
 mod checks;
+mod clippy_checks;
 mod file_policy;
 mod policy_report;
 mod propose;
@@ -67,6 +68,14 @@ enum Command {
     /// Run every advisory check and emit a unified policy report.
     #[command(name = "policy-report")]
     PolicyReport,
+
+    /// Validate Clippy lint policy: MSRV alignment + workspace.lints coverage.
+    #[command(name = "check-lint-policy")]
+    CheckLintPolicy,
+
+    /// Validate `policy/clippy-exceptions.toml` schema, expiry, and bare-allow scan.
+    #[command(name = "check-clippy-exceptions")]
+    CheckClippyExceptions,
 }
 
 #[derive(Subcommand, Debug)]
@@ -122,6 +131,8 @@ fn main() -> Result<()> {
         Command::CheckProcessPolicy(args) => workflow_checks::check_process_policy(args.mode)?,
         Command::CheckNetworkPolicy(args) => workflow_checks::check_network_policy(args.mode)?,
         Command::PolicyReport => policy_report::policy_report()?,
+        Command::CheckLintPolicy => clippy_checks::check_lint_policy()?,
+        Command::CheckClippyExceptions => clippy_checks::check_clippy_exceptions()?,
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

First PR in the post-file-policy 0.4.0 rollout. Adds the Clippy ledger infrastructure called for by `docs/CLIPPY_POLICY.md`. **Ledger-only — no lint activation; that's PR 7 (#191).**

## Issue

Closes #179. Builds on the now-complete file-policy ladder (#176/#180). Refines #109. Blocks PR 7 (#191 Clippy 1.94/1.95 ratchet activation).

## Three TOML ledgers under `policy/`

| File | Contents |
|---|---|
| `clippy-lints.toml` | 4 `[[active]]` + 10 `[[planned]]` lints mirroring `docs/CLIPPY_POLICY.md` tables |
| `clippy-debt.toml` | Empty (workspace is currently Clippy-clean) |
| `clippy-exceptions.toml` | Empty (no durable exceptions yet) |

## Two xtask checkers

**`cargo xtask check-lint-policy`** — validates MSRV agrees across `Cargo.toml` `[workspace.package] rust-version`, `clippy.toml` `msrv`, and `policy/clippy-lints.toml` `msrv`. Plus every lint in `[workspace.lints.clippy]` (currently 0) must have a ledger entry. Reverse direction (ledger entries not in `[workspace.lints.clippy]`) is intentionally not enforced — `[[active]]` entries are aspirational until PR 7 activates them.

**`cargo xtask check-clippy-exceptions`** — validates `policy/clippy-exceptions.toml` schema (lint, path, owner, reason, expires), fails on expired entries, plus runs a shallow regex scan for bare `#[allow(clippy::...)]` attributes in tracked Rust source. **Bare-allow scan is informational only in this PR.** The 10 occurrences currently in `shipper-core/src/engine/` and `shipper-core/src/runtime/` are recorded for a future conversion PR.

## Live local output

```text
msrv aligned across all three: 1.95
check-lint-policy: workspace.lints.clippy=0 active_in_ledger=4 planned_in_ledger=10
check-clippy-exceptions: entries=0 expired=0 schema_errors=0 bare_allow_informational=10
```

## Decisions

- **Debt expiry: fail for exceptions, warn for debt.** This PR adds only the exceptions checker (fails on expired). Debt expiry handling lands when PR 7 begins populating the debt ledger.
- **Bare-allow scan: informational only.** Honest to the ledger-only scope. Future PR converts existing bare-allows to expect+reason and flips the scan to blocking.
- **`[[planned]]` reverse-direction not enforced.** Lets PR 7 activate lints from the ledger one at a time without first having to remove their `[[planned]]` entries here.

## Acceptance

- [x] `cargo check --workspace --locked` passes.
- [x] `cargo clippy -p xtask --all-targets --locked -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo xtask check-lint-policy` exits 0.
- [x] `cargo xtask check-clippy-exceptions` exits 0.
- [x] `cargo xtask policy-report` still produces the unified artifact (no regression on PR 9's command).
- [x] All three `policy/clippy-*.toml` files parse as valid TOML.

## Follow-ups

- **PR for #198** — Rust 1.95 rustc lint floor (next in the queue).
- **PR for #191** — Clippy 1.94/1.95 ratchet activation. Will turn `[[planned]]` ledger entries into live `[workspace.lints.clippy]` entries and measure fallout into `clippy-debt.toml`.
- Convert the 10 bare `#[allow(clippy::...)]` occurrences to `#[expect(..., reason = "...")]`. Once clean, flip the bare-allow scan to blocking.
- Wire `check-lint-policy` and `check-clippy-exceptions` into the CI `Policy` job (separate from the file-policy half).