### PR TITLE
feat(harden): Rust 1.95 rustc lint floor in workspace.lints.rust (#198)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,18 @@ license = "MIT OR Apache-2.0"
 rust-version = "1.95"
 
 [workspace.lints.rust]
+# Rust 1.95 compiler-side lint floor. Zero current fallout per the audit in
+# #198. Sources of truth: docs/CLIPPY_POLICY.md and policy/clippy-lints.toml.
+#
+# Issue #198 listed two lint names that turned out not to be real rustc lints
+# in 1.95 (`function_casts_as_integer` and `unused_visibilities`). They are
+# omitted here. `const_item_interior_mutations` from the issue maps to the
+# real `const_item_mutation`.
 unsafe_code = "forbid"
+unsafe_op_in_unsafe_fn = "deny"
+unused_must_use = "deny"
+unexpected_cfgs = "warn"
+const_item_mutation = "deny"
 
 [workspace.dependencies]
 # Intra-workspace crates (path + version for publish-readiness).


### PR DESCRIPTION
## Summary

Adds five 1.95-stable compiler-side lints to `[workspace.lints.rust]`. Codebase is clean against all of them — single-commit activation, no fallout.

## Issue

Closes #198. Builds on #171 (MSRV 1.95 bump). Refines #109 (Harden pillar).

## Activated

```toml
[workspace.lints.rust]
unsafe_code              = "forbid"   # preserved from prior state
unsafe_op_in_unsafe_fn   = "deny"
unused_must_use          = "deny"
unexpected_cfgs          = "warn"
const_item_mutation      = "deny"
```

## Lint-name correction (important)

Issue #198 listed seven lints; **two had names that are not real rustc lints in 1.95**:

| Issue body | Status |
|---|---|
| `function_casts_as_integer` | ❌ Not a real lint. Omitted. |
| `unused_visibilities` | ❌ Not a real lint. Omitted. |
| `const_item_interior_mutations` | ❌ Near-miss → real name `const_item_mutation`. Used the real one. |

The Haiku planning agent that filed #198 inferred lint names by pattern rather than against the rustc lint catalog. The five remaining lints are verified — `cargo check` with `-D <lint>` rejects unknown lint names via E0602, and all five compile cleanly here.

## Acceptance

- [x] `cargo check --workspace --all-targets --all-features --locked` passes.
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] Single-commit activation per the issue's "zero fallout" verdict.

**Note**: `cargo test --workspace` produced one flake in `ops::git::cleanliness::tests::ensure_git_clean_new_phrasing` (a pre-existing race that passes in isolation). Not introduced by this PR — the only change here is to `Cargo.toml`, no Rust code modified.

## Follow-ups

- **PR for #191** — Clippy 1.94/1.95 ratchet activation. Turns the 10 `[[planned]]` entries in `policy/clippy-lints.toml` (landed in #225) into live `[workspace.lints.clippy]` entries with measured fallout into `clippy-debt.toml`.
- Convert bare `#[allow(clippy::...)]` to `#[expect(..., reason = "...")]` — 10 occurrences surfaced by #225's `check-clippy-exceptions`.
- The flaky git-cleanliness test is worth a separate small PR to fix (likely a `SHIPPER_GIT_BIN` env var leak between parallel tests).