### PR TITLE
feat(harden): activate Clippy 1.94/1.95 ratchets (#191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`shipper` crate:** the `shipper-cli` dependency is now behind a default `cli` feature. `cargo install shipper` and the `shipper` binary still work unchanged (the feature is on by default). Library consumers that only want the curated `shipper-core` re-export can opt out with `shipper = { version = "...", default-features = false }`, which drops the `clap` graph. `shipper-core` remains the canonical lean embedding surface.
 
+- **Clippy 1.94/1.95 ratchets activated** ([#191](https://github.com/EffortlessMetrics/shipper/issues/191)). Eight lints moved from `[[planned]]` to `[[active]]` in `policy/clippy-lints.toml` and added to `[workspace.lints.clippy]`: `same_length_and_capacity` (deny), `manual_ilog2`, `decimal_bitwise_operands`, `needless_type_cast`, `manual_checked_ops`, `manual_take`, `unnecessary_trailing_comma`, `disallowed_fields` (deny). All eight had zero workspace fallout at activation. `duration_suboptimal_units` (1.95) stays in `[[planned]]` with measured fallout of 204 sites across 20 files, pending a focused cleanup PR. `manual_pop_if` was listed in the original #191 plan but is not a real clippy lint — `[workspace.lints.rust] unknown_lints = "deny"` rejected it via E0602; the omission is recorded in the ledger.
+
 ### Planned — Rust 1.95 / 0.4.0 Quality Rollout
 
 The next release line is **0.4.0** (minor bump because MSRV increases). The rollout is tracked in [`docs/ci/rust-1.95-rollout.md`](docs/ci/rust-1.95-rollout.md) and proceeds through fifteen PRs:
@@ -22,7 +24,7 @@ The next release line is **0.4.0** (minor bump because MSRV increases). The roll
 - Add `xtask` Rust-native policy runner.
 - Add Clippy lint ledger (`policy/clippy-lints.toml`) and checker.
 - Activate Rust 1.95 compiler lint floor (`unsafe_op_in_unsafe_fn`, `unused_must_use`, `const_item_interior_mutations`, et al.).
-- Activate Rust 1.95 Clippy ratchets (`manual_checked_ops`, `manual_take`, `manual_pop_if`, `duration_suboptimal_units`, et al.).
+- Activate Rust 1.95 Clippy ratchets (`manual_checked_ops`, `manual_take`, `unnecessary_trailing_comma`, `disallowed_fields`, et al.). `duration_suboptimal_units` deferred; `manual_pop_if` from the original plan turned out not to be a real clippy lint.
 - Add exact no-panic no-new-debt baseline and checker.
 - Add non-Rust file policy allowlists for workflows, generated files, executables, dependency surfaces.
 - Add advisory `ripr` PR-time exposure lane.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,26 @@ unsafe_op_in_unsafe_fn = "deny"
 unused_must_use = "deny"
 unexpected_cfgs = "warn"
 const_item_mutation = "deny"
+# Surface clippy's `unknown_lints` warnings as errors — same posture #198 took
+# for rustc lints. Catches fabricated names before they go live.
+unknown_lints = "deny"
+
+[workspace.lints.clippy]
+# Clippy 1.94/1.95 ratchet activation (#191). Names were verified via clippy
+# round-trip with `unknown_lints = "deny"` in [workspace.lints.rust], which
+# rejected one fabricated name from the original #191 plan
+# (`clippy::manual_pop_if`). Fallout per real lint was measured against the
+# workspace at activation time; the eight here had zero fallout. The
+# remaining planned lint (`duration_suboptimal_units`) has 204 sites and
+# stays in [[planned]] until a focused cleanup PR lands.
+same_length_and_capacity = "deny"
+manual_ilog2 = "warn"
+decimal_bitwise_operands = "warn"
+needless_type_cast = "warn"
+manual_checked_ops = "warn"
+manual_take = "warn"
+unnecessary_trailing_comma = "warn"
+disallowed_fields = "deny"
 
 [workspace.dependencies]
 # Intra-workspace crates (path + version for publish-readiness).

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -52,64 +52,82 @@ class = "panic"
 reason = "Unimplemented execution paths are not allowed"
 since = "0.0.0"
 
-# ─── Planned lints (MSRV-gated) ─────────────────────────────────────────────
+# ─── 1.94/1.95 ratchet activations (#191) ───────────────────────────────────
+#
+# Moved from [[planned]] to [[active]] after the activation PR (#191)
+# verified each name via clippy round-trip and measured zero fallout
+# across the workspace. `since = "1.95"` records the MSRV at activation
+# time (the lints themselves stabilised at their `min_msrv` from the
+# previous planned entries).
 
-[[planned]]
+[[active]]
 name = "clippy::same_length_and_capacity"
 level = "deny"
-min_msrv = "1.94"
+class = "correctness"
 reason = "Catch raw-parts reconstruction mistakes"
+since = "1.95"
 
-[[planned]]
+[[active]]
 name = "clippy::manual_ilog2"
 level = "warn"
-min_msrv = "1.94"
+class = "style"
 reason = "Prefer standard integer log helper"
+since = "1.95"
 
-[[planned]]
+[[active]]
 name = "clippy::decimal_bitwise_operands"
 level = "warn"
-min_msrv = "1.94"
+class = "correctness"
 reason = "Make bit masks visually inspectable"
+since = "1.95"
 
-[[planned]]
+[[active]]
 name = "clippy::needless_type_cast"
 level = "warn"
-min_msrv = "1.94"
+class = "style"
 reason = "Avoid stale numeric type drift"
+since = "1.95"
 
-[[planned]]
+[[active]]
 name = "clippy::manual_checked_ops"
 level = "warn"
-min_msrv = "1.95"
+class = "correctness"
 reason = "Prefer checked arithmetic over manual guards"
+since = "1.95"
 
-[[planned]]
+[[active]]
 name = "clippy::manual_take"
 level = "warn"
-min_msrv = "1.95"
+class = "style"
 reason = "Use standard ownership helper"
+since = "1.95"
 
-[[planned]]
-name = "clippy::manual_pop_if"
+[[active]]
+name = "clippy::unnecessary_trailing_comma"
 level = "warn"
-min_msrv = "1.95"
-reason = "Use predicate-and-pop collection APIs"
+class = "style"
+reason = "Keep format macro calls clean"
+since = "1.95"
+
+[[active]]
+name = "clippy::disallowed_fields"
+level = "deny"
+class = "boundary"
+reason = "Ban direct field access across protected seams (pending seam configuration; see docs/CLIPPY_POLICY.md)"
+since = "1.95"
+
+# ─── Planned lints (MSRV-gated) ─────────────────────────────────────────────
 
 [[planned]]
 name = "clippy::duration_suboptimal_units"
 level = "warn"
 min_msrv = "1.95"
-reason = "Make durations legible"
+reason = "Make durations legible. Activation deferred from #191: 204 fallout sites across 20 files (config/runtime/retry/types/lock APIs that accept user-supplied millisecond values); needs a focused cleanup PR rather than a debt entry."
 
-[[planned]]
-name = "clippy::unnecessary_trailing_comma"
-level = "warn"
-min_msrv = "1.95"
-reason = "Keep format macro calls clean"
-
-[[planned]]
-name = "clippy::disallowed_fields"
-level = "deny"
-min_msrv = "1.95"
-reason = "Ban direct field access across protected seams (pending seam configuration; see docs/CLIPPY_POLICY.md)"
+# ─── Fabricated names rejected by the activation audit ──────────────────────
+#
+# `clippy::manual_pop_if` was listed in #191's original plan but is not a
+# real clippy lint in 1.95 — clippy emits E0602 (unknown lint) when it is
+# referenced. Recorded here so future readers can see that the omission
+# was intentional, not an oversight. Same pattern as the rustc fabrications
+# recorded in [workspace.lints.rust] in Cargo.toml (#198).


### PR DESCRIPTION
## Summary

- Activates the 1.94/1.95 Clippy ratchets planned in #191. Eight lints move from `[[planned]]` to `[[active]]` in `policy/clippy-lints.toml` and become live in `[workspace.lints.clippy]`: `same_length_and_capacity` (deny), `manual_ilog2`, `decimal_bitwise_operands`, `needless_type_cast`, `manual_checked_ops`, `manual_take`, `unnecessary_trailing_comma`, `disallowed_fields` (deny).
- All eight measured **zero workspace fallout** at activation. `cargo clippy --workspace --all-targets -- -D warnings` is clean.
- `duration_suboptimal_units` stays `[[planned]]` with a measured-fallout note (204 sites across 20 files, mostly config/runtime/retry/types/lock APIs that accept user-supplied millisecond values). A focused cleanup PR will revisit; an unconditional warn would create permanent noise across stable APIs.
- `manual_pop_if` from the original #191 plan turned out not to be a real clippy lint in 1.95. Added `unknown_lints = \"deny\"` to `[workspace.lints.rust]` (same posture #198 took to catch fabricated rustc lints) and it rejected the name via E0602. The fabrication is recorded in the ledger so future readers can see the omission was intentional.

## Lint-policy state after this PR

\`\`\`
cargo xtask check-lint-policy
msrv aligned across all three: 1.95
check-lint-policy: workspace.lints.clippy=8 active_in_ledger=12 planned_in_ledger=1
\`\`\`

(`active_in_ledger=12` = 4 pre-existing + 8 newly activated. `planned_in_ledger=1` = `duration_suboptimal_units`.)

## Why activate eight and defer one

The general rollout posture is *no surprise enforcement* — an active lint shouldn't be the first thing the repo learns about its own fallout. For the eight zero-fallout lints, activation is a free ratchet. For `duration_suboptimal_units`, the 204 hits cluster in config/types APIs where `Duration::from_millis(timeout_ms)` is the natural ergonomics and a literal-to-larger-unit rewrite would obscure rather than clarify some sites; that warrants a per-site judgment pass, not a blanket warn.

## Test plan

- [x] `cargo xtask check-lint-policy` — MSRV aligned, workspace.lints.clippy ↔ ledger coverage clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (exit 0)
- [x] `cargo build --workspace --all-targets` — clean (no `unknown_lints` regressions from the new rust-side deny)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo xtask policy-report` — all 7 advisory areas clean
- [x] `cargo xtask check-clippy-exceptions` — 0 expired, 0 schema errors (16 informational bare-allow sites pre-existing; tracked separately)
- [ ] CI green (full nextest matrix, MSRV check, security audit, docs, builds)

Closes #191 partially (eight of nine planned 1.94/1.95 ratchets activate here; `duration_suboptimal_units` carries over to a focused cleanup PR).