### PR TITLE
chore(release): bump workspace to 0.4.0-rc.1 (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0-rc.1] - 2026-05-12
+
+This is the first release candidate of the **0.4.0** line. The line bumps MSRV from 1.92 to 1.95 (and therefore takes a minor-version step per semver), threads the Rust 1.95 lint floor and Clippy ratchets through the workspace, lands an exact no-panic baseline + check + release CI gate, adopts the external `ripr` static-exposure tool as an advisory PR lane, sets up policy receipts for every non-Rust surface, and stabilises a long-standing macOS test flake. See the per-area entries below for citations.
+
 ### Changed
 
 - **MSRV raised from 1.92 to 1.95.** `[workspace.package] rust-version` updated to `"1.95"`. `rust-toolchain.toml` pins the toolchain to `1.95.0` (minimal profile + rustfmt + clippy). `clippy.toml` sets `msrv = "1.95"`, cognitive-complexity threshold 40, too-many-arguments threshold 8. All CI MSRV references (ci.yml, coverage.yml, release.yml) updated. Documentation and badge updated accordingly.
@@ -37,24 +41,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **First no-panic burn-down: three indexing sites in `shipper-core`** ([#190](https://github.com/EffortlessMetrics/shipper/issues/190)). Refactored three safe-by-construction indexing operations to their idiomatic Rust equivalents, removing them from the no-panic baseline: `is_valid_package_name` in `ops/cargo/mod.rs` (replaced the `name.is_empty()` + `chars: Vec<char>` + `chars[0]` dance with `chars.next()` returning `Option<char>`); `normalize_version` in `runtime/environment/mod.rs` (replaced `.collect::<Vec<_>>()` + `.len() >= 2` + `[1]` with `.nth(1)`); `chunk_by_max_concurrent` in `plan/chunking/mod.rs` (replaced the manual index/while loop with `slice::chunks(batch_size)`). All three were already provably safe — the panic surface was statically unreachable — but the new forms make that obvious and remove the entries from `policy/no-panic-baseline.json`. Baseline: 28 → 25 entries, 59 → 55 production sites, `index` family 7 → 3. `cargo xtask no-panic check` correctly reported `resolved=3` against the prior baseline, validating the check loop end-to-end. The issue's chosen target (`shipper-duration`) had zero production debt — all 53 sites flagged in the issue body were in test code, already excluded from the baseline — so the burn-down moved into `shipper-core` where the real debt lives.
 
-### Planned — Rust 1.95 / 0.4.0 Quality Rollout
+### Carry-over to follow
 
-The next release line is **0.4.0** (minor bump because MSRV increases). The rollout is tracked in [`docs/ci/rust-1.95-rollout.md`](docs/ci/rust-1.95-rollout.md) and proceeds through fifteen PRs:
+These items are planned for the 0.4.0 line but did not land in rc.1:
 
-- Raise MSRV from Rust 1.92 to Rust 1.95.
-- Pin toolchain via `rust-toolchain.toml`.
-- Add `xtask` Rust-native policy runner.
-- Add Clippy lint ledger (`policy/clippy-lints.toml`) and checker.
-- Activate Rust 1.95 compiler lint floor (`unsafe_op_in_unsafe_fn`, `unused_must_use`, `const_item_interior_mutations`, et al.).
-- Activate Rust 1.95 Clippy ratchets (`manual_checked_ops`, `manual_take`, `unnecessary_trailing_comma`, `disallowed_fields`, et al.). `duration_suboptimal_units` deferred; `manual_pop_if` from the original plan turned out not to be a real clippy lint.
-- Add exact no-panic no-new-debt baseline and checker.
-- Add non-Rust file policy allowlists for workflows, generated files, executables, dependency surfaces.
-- Add advisory `ripr` PR-time exposure lane.
-- Add scoped CI lane policy and targeted mutation routing.
-- Apply Rust 1.95 API cleanup in publish and receipt paths.
-- First Clippy / no-panic debt burndown.
-- Version alignment to `0.4.0-rc.1` / `v0.4.0`.
-- Release dry-run proof.
+- Mutation-workflow crate-list expansion to the full trust-critical surface (today the weekly job only covers `shipper-duration` / `shipper-types` / `shipper-config`).
+- `duration_suboptimal_units` clippy lint activation (204-site cleanup; deferred from #191).
+- `engine/parallel/` `.lock().unwrap()` Mutex-poisoning posture (~35 sites; tracked in the no-panic baseline).
+- CI lane routing changes documented as deferred in [`docs/ci/test-evidence-lanes.md`](docs/ci/test-evidence-lanes.md#routing-changes-deferred-to-follow-up-prs).
+- Final release dry-run proof against the actual tag-push pipeline.
 
 ## [0.3.0-rc.2] - 2026-04-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2303,7 +2303,7 @@ dependencies = [
 
 [[package]]
 name = "shipper"
-version = "0.3.0-rc.2"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2323,7 +2323,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-cargo-failure"
-version = "0.3.0-rc.2"
+version = "0.4.0-rc.1"
 dependencies = [
  "insta",
  "proptest",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-cli"
-version = "0.3.0-rc.2"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-config"
-version = "0.3.0-rc.2"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "insta",
@@ -2378,7 +2378,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-core"
-version = "0.3.0-rc.2"
+version = "0.4.0-rc.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2422,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-duration"
-version = "0.3.0-rc.2"
+version = "0.4.0-rc.1"
 dependencies = [
  "humantime",
  "insta",
@@ -2434,7 +2434,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-encrypt"
-version = "0.3.0-rc.2"
+version = "0.4.0-rc.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-output-sanitizer"
-version = "0.3.0-rc.2"
+version = "0.4.0-rc.1"
 dependencies = [
  "insta",
  "proptest",
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-registry"
-version = "0.3.0-rc.2"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2477,7 +2477,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-retry"
-version = "0.3.0-rc.2"
+version = "0.4.0-rc.1"
 dependencies = [
  "humantime-serde",
  "insta",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-sparse-index"
-version = "0.3.0-rc.2"
+version = "0.4.0-rc.1"
 dependencies = [
  "insta",
  "proptest",
@@ -2498,7 +2498,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-types"
-version = "0.3.0-rc.2"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "shipper-webhook"
-version = "0.3.0-rc.2"
+version = "0.4.0-rc.1"
 dependencies = [
  "anyhow",
  "hmac 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = ["fuzz"]
 resolver = "3"
 
 [workspace.package]
-version = "0.3.0-rc.2"
+version = "0.4.0-rc.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.95"
@@ -61,19 +61,19 @@ disallowed_fields = "deny"
 
 [workspace.dependencies]
 # Intra-workspace crates (path + version for publish-readiness).
-shipper = { path = "crates/shipper", version = "0.3.0-rc.2" }
-shipper-core = { path = "crates/shipper-core", version = "0.3.0-rc.2" }
-shipper-cli = { path = "crates/shipper-cli", version = "0.3.0-rc.2" }
-shipper-config = { path = "crates/shipper-config", version = "0.3.0-rc.2" }
-shipper-types = { path = "crates/shipper-types", version = "0.3.0-rc.2" }
-shipper-duration = { path = "crates/shipper-duration", version = "0.3.0-rc.2" }
-shipper-retry = { path = "crates/shipper-retry", version = "0.3.0-rc.2" }
-shipper-encrypt = { path = "crates/shipper-encrypt", version = "0.3.0-rc.2" }
-shipper-webhook = { path = "crates/shipper-webhook", version = "0.3.0-rc.2" }
-shipper-registry = { path = "crates/shipper-registry", version = "0.3.0-rc.2" }
-shipper-sparse-index = { path = "crates/shipper-sparse-index", version = "0.3.0-rc.2" }
-shipper-cargo-failure = { path = "crates/shipper-cargo-failure", version = "0.3.0-rc.2" }
-shipper-output-sanitizer = { path = "crates/shipper-output-sanitizer", version = "0.3.0-rc.2" }
+shipper = { path = "crates/shipper", version = "0.4.0-rc.1" }
+shipper-core = { path = "crates/shipper-core", version = "0.4.0-rc.1" }
+shipper-cli = { path = "crates/shipper-cli", version = "0.4.0-rc.1" }
+shipper-config = { path = "crates/shipper-config", version = "0.4.0-rc.1" }
+shipper-types = { path = "crates/shipper-types", version = "0.4.0-rc.1" }
+shipper-duration = { path = "crates/shipper-duration", version = "0.4.0-rc.1" }
+shipper-retry = { path = "crates/shipper-retry", version = "0.4.0-rc.1" }
+shipper-encrypt = { path = "crates/shipper-encrypt", version = "0.4.0-rc.1" }
+shipper-webhook = { path = "crates/shipper-webhook", version = "0.4.0-rc.1" }
+shipper-registry = { path = "crates/shipper-registry", version = "0.4.0-rc.1" }
+shipper-sparse-index = { path = "crates/shipper-sparse-index", version = "0.4.0-rc.1" }
+shipper-cargo-failure = { path = "crates/shipper-cargo-failure", version = "0.4.0-rc.1" }
+shipper-output-sanitizer = { path = "crates/shipper-output-sanitizer", version = "0.4.0-rc.1" }
 
 # External crates.
 serde = { version = "1.0.228", features = ["derive"] }


### PR DESCRIPTION
## Summary

First release candidate of the 0.4.0 line. Mechanical version bump driven by the MSRV move from 1.92 to 1.95 (#198) — MSRV is part of the semver promise for a library/tool, so a non-additive change requires a minor-version step.

## What changed

- `Cargo.toml` `[workspace.package].version` — `0.3.0-rc.2` → `0.4.0-rc.1`
- `Cargo.toml` `[workspace.dependencies]` pins — all 13 intra-workspace crates bumped to `0.4.0-rc.1`
- `Cargo.lock` regenerated via `cargo build --workspace`
- `CHANGELOG.md`:
  - Contents of `[Unreleased]` graduate to `[0.4.0-rc.1] - 2026-05-12` with a one-paragraph release summary citing the major threads.
  - New empty `[Unreleased]` header above the 0.4.0-rc.1 block.
  - "Planned — Rust 1.95 / 0.4.0 Quality Rollout" forward-looking section replaced by a short "Carry-over to follow" enumerating deferred work.

## Carry-over to follow (deferred from rc.1)

- Mutation-workflow crate-list expansion to the full trust-critical surface.
- `duration_suboptimal_units` Clippy lint activation (204-site cleanup).
- `engine/parallel/` `.lock().unwrap()` Mutex-poisoning posture (~35 sites in the no-panic baseline).
- CI lane routing changes documented in `docs/ci/test-evidence-lanes.md`.
- Final release dry-run proof against the actual tag-push pipeline (#195).

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo xtask check-file-policy --mode blocking-allowlist` — `unreceipted=0`
- [ ] CI green (full nextest matrix)

Refs #109 (master tracking) and #192.