### PR TITLE
docs: add source-of-truth templates

### DIFF
--- a/.shipper-meta/goals/TEMPLATE.toml
+++ b/.shipper-meta/goals/TEMPLATE.toml
@@ -1,0 +1,19 @@
+id = "shipper-goal-id"
+title = ""
+status = "active"
+owner = ""
+created = "YYYY-MM-DD"
+
+objective = """
+"""
+
+end_state = []
+
+[[work_item]]
+id = ""
+status = "ready"
+proposal = ""
+spec = ""
+plan = ""
+issue = ""
+commands = []

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,25 @@
+# SHIPPER-ADR-0000: Title
+
+Status:
+Owner:
+Created:
+Milestone:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+Proof commands:
+
+## Decision
+
+## Context
+
+## Consequences
+
+## Alternatives Considered
+
+## Follow-Up Specs And Plans

--- a/docs/proposals/TEMPLATE.md
+++ b/docs/proposals/TEMPLATE.md
@@ -1,0 +1,33 @@
+# SHIPPER-PROP-0000: Title
+
+Status:
+Owner:
+Created:
+Milestone:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+Proof commands:
+
+## Problem
+
+## Users and Value
+
+## Success Criteria
+
+## Proposed Shape
+
+## Alternatives Considered
+
+## Evidence Plan
+
+## Risks
+
+## Non-Goals
+
+## Exit Criteria

--- a/docs/specs/TEMPLATE.md
+++ b/docs/specs/TEMPLATE.md
@@ -1,0 +1,35 @@
+# SHIPPER-SPEC-0000: Title
+
+Status:
+Owner:
+Created:
+Milestone:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+Proof commands:
+
+## Problem
+
+## Behavior Contract
+
+## Non-Goals
+
+## Required Evidence
+
+## Acceptance Examples
+
+## Test Mapping
+
+## Implementation Mapping
+
+## CI Proof
+
+## Promotion Rule
+
+## Open Questions

--- a/plans/TEMPLATE.md
+++ b/plans/TEMPLATE.md
@@ -1,0 +1,37 @@
+# Plan: Title
+
+Status:
+Owner:
+Created:
+Milestone:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+Proof commands:
+
+## End State
+
+## PR Sequence
+
+### PR 1 - Title
+
+Linked spec:
+Blocks:
+Blocked by:
+
+#### Goal
+
+#### Production Delta
+
+#### Non-Goals
+
+#### Acceptance
+
+#### Proof Commands
+
+#### Rollback

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -348,6 +348,17 @@ covered_by = ["manual review", "cargo xtask check-file-policy"]
 created = "2026-05-13"
 review_after = "2026-08-13"
 
+[[glob]]
+pattern = ".shipper-meta/goals/*.toml"
+kind = "agent_goal_manifest"
+surface = "tooling"
+classification = "config"
+owner = "agent-maintainers"
+reason = "Machine-readable active goal manifests and templates for Codex/Droid execution state. Kept outside `.shipper/` so runtime state remains separate from repo-management state."
+covered_by = ["manual review", "future: cargo xtask check-doc-contracts"]
+created = "2026-05-13"
+review_after = "2026-08-13"
+
 [[file]]
 path = ".github/CODEOWNERS"
 kind = "github_codeowners"


### PR DESCRIPTION
## Summary
- add small templates for Shipper proposals, specs, ADRs, and implementation plans
- add `.shipper-meta/goals/TEMPLATE.toml` for future active goal manifests
- receipt `.shipper-meta/goals/*.toml` in the non-Rust file policy ledger

## Scope boundary
This is PR 2 only: templates plus the required TOML receipt. It intentionally does not add support tiers, concrete proposal/spec/ADR artifacts, active goals, doc-contract checker code, CI changes, or #195 release proof work.

## Validation
- `python -c "import pathlib,tomllib; tomllib.loads(pathlib.Path('.shipper-meta/goals/TEMPLATE.toml').read_text()); print('goal template TOML parses')"`
- `cargo fmt --all -- --check`
- `cargo xtask check-file-policy --mode blocking-allowlist`
- `cargo xtask policy-report`