### PR TITLE
ci(policy): run doc-contracts advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
     # `blocking-strict` mode (fails on unused entries + stale review
     # dates) remains out of scope until a dedicated cleanup pass.
     #
+    # Source-of-truth document contracts run in advisory mode first. They
+    # produce target/policy/doc-contracts-report.* but do not gate merges yet.
+    #
     # The unified policy-report runs at the end and uploads
     # target/policy/ as a `policy-reports` artifact regardless of
     # pass/fail (`if: always()`). See docs/policy/NON_RUST_ROLLOUT.md.
@@ -113,6 +116,9 @@ jobs:
 
       - name: check-network-policy (blocking-allowlist)
         run: cargo xtask check-network-policy --mode blocking-allowlist
+
+      - name: check-doc-contracts (advisory)
+        run: cargo xtask check-doc-contracts --mode advisory
 
       - name: Unified policy report
         if: always()


### PR DESCRIPTION
Summary:
- add an advisory check-doc-contracts step to the CI Policy job
- keep doc contracts non-blocking while still uploading target/policy reports
- leave runtime behavior, release proof work, support tiers, and checker semantics unchanged

Validation:
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask policy-report
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo fmt --all -- --check
- cargo xtask check-workflow-surfaces --mode blocking-allowlist
- cargo xtask check-process-policy --mode blocking-allowlist
- cargo xtask check-network-policy --mode blocking-allowlist
- git diff --check