### PR TITLE
docs(release): add 0.4.0-rc.1 readiness proof

### DIFF
--- a/.shipper-meta/goals/active.toml
+++ b/.shipper-meta/goals/active.toml
@@ -19,14 +19,21 @@ end_state = [
 ]
 
 [[work_item]]
-id = "doc-contract-checker"
-status = "ready"
+id = "release-readiness-proof"
+status = "in_review"
 proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
-spec = "docs/specs/SHIPPER-SPEC-0001-source-of-truth-stack.md"
-plan = "plans/0.4.0/source-of-truth-stack.md"
-issue = "109"
+spec = "docs/specs/SHIPPER-SPEC-0002-release-readiness-proof.md"
+plan = "plans/0.4.0/release-readiness-proof.md"
+issue = "195"
 commands = [
-  "cargo xtask check-file-policy --mode blocking-allowlist",
-  "cargo xtask policy-report",
   "cargo fmt --all -- --check",
+  "cargo clippy --workspace --all-targets --all-features -- -D warnings",
+  "cargo test --workspace --all-features",
+  "cargo test --workspace --doc",
+  "cargo check --workspace",
+  "cargo audit",
+  "cargo doc --workspace --no-deps --document-private-items",
+  "cargo test -p shipper-cli --test bdd_publish",
+  "cargo xtask check-doc-contracts --mode advisory",
+  "cargo xtask policy-report",
 ]

--- a/docs/release/0.4.0-readiness.md
+++ b/docs/release/0.4.0-readiness.md
@@ -1,0 +1,111 @@
+# Shipper 0.4.0-rc.1 Readiness
+
+Version: 0.4.0-rc.1
+Evidence date: 2026-05-13
+Evidence base commit: d72f58b251b12d93ba3e3b8e7bd0d636d7c8264d
+Plan ID: 5d63c5b0725a59a01c1fa1406220808f5a7b1a166c0ddf76d3ba97d13e6feeb5
+Linked spec: docs/specs/SHIPPER-SPEC-0002-release-readiness-proof.md
+Linked plan: plans/0.4.0/release-readiness-proof.md
+Linked issue: #195
+Status: ready for review; do not tag or publish from this document alone
+
+## Readiness Summary
+
+Shipper 0.4.0-rc.1 has a passing local release-readiness evidence packet. The
+workspace is versioned as `0.4.0-rc.1`, the changelog has a dated
+`0.4.0-rc.1` entry, the Shipper plan includes 13 publishable crates, preflight
+returned `Proven`, and `cargo publish --dry-run --workspace` packaged,
+verified, and dry-run uploaded all 13 crates.
+
+This document is release evidence only. It does not tag, publish, or claim that
+registry reconciliation is implemented.
+
+## Gate Results
+
+| Gate | Status | Evidence |
+|---|---:|---|
+| Version check | pass | Root workspace and publishable workspace dependency pins read `0.4.0-rc.1`; changelog has `## [0.4.0-rc.1] - 2026-05-12`. |
+| `cargo run -p shipper -- plan` | pass | Plan ID `5d63c5b0725a59a01c1fa1406220808f5a7b1a166c0ddf76d3ba97d13e6feeb5`; 13 publishable crates; `xtask@0.0.0` skipped as `publish = false`. |
+| `shipper preflight --preflight-only --format json --state-dir target/release-proof-state-copied` | pass | `finishability = "proven"`; token detected; all 13 packages `dry_run_passed = true`; sidecar under `target/release-proof-state-copied/preflight_workspace_verify.txt`. |
+| `cargo fmt --all -- --check` | pass | Exit 0. |
+| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | pass | Exit 0; RTK summary: no issues found. |
+| `cargo test --workspace --all-features` | pass | Exit 0 on rerun with longer timeout; 4,266 passed, 36 ignored. |
+| `cargo test --workspace --doc` | pass | Exit 0; 19 passed, 36 ignored. |
+| `cargo check --workspace` | pass | Exit 0. |
+| `cargo audit` | pass | Exit 0; 385 dependencies scanned. |
+| `cargo doc --workspace --no-deps --document-private-items` | pass | Exit 0; docs generated under `target/doc/`. |
+| `cargo test -p shipper-cli --test bdd_publish` | pass | Exit 0; 26 passed. |
+| `cargo xtask check-doc-contracts --mode advisory` | pass | `documents=6`, `active_goal=true`, `findings=0`, `blocking=0`. |
+| `cargo xtask policy-report` | pass | 9 policy areas, 9 headline rows; doc-contracts included. |
+| `cargo xtask check-file-policy --mode blocking-allowlist` | pass | 204 tracked files, 41 entries, 0 unreceipted, 0 missing fields, 0 expired. |
+| `cargo xtask no-panic check` | pass | 25 baseline entries, 25 current entries, no new/resolved/count drift. |
+| `cargo xtask check-lint-policy` | pass | MSRV aligned across Rust policy surfaces at 1.95. |
+| `cargo xtask ripr-pr` | advisory | Completed. Top recommendation: add boundary discriminator coverage for `crates/shipper-cli/src/lib.rs::run`; details in `target/ripr/pilot/pilot-summary.md`. |
+| Mutation evidence | not requested | Mutation lane remains advisory/opt-in for this readiness packet. |
+
+The first local `cargo test --workspace --all-features` invocation hit the
+command timeout after 904 seconds and left child test processes running. The
+stale Shipper proof processes were stopped, and the same command passed on a
+longer rerun.
+
+## Publish Dry-Run Evidence
+
+The authoritative release dry-run command was:
+
+```bash
+cargo publish --dry-run --workspace
+```
+
+It exited 0 and dry-run uploaded all 13 publishable crates. Cargo's isolated
+`cargo publish --dry-run -p <crate>` shape was also tested for the tier-1 leaf
+crates. Those seven package-level dry-runs passed. The first downstream
+package-level dry-run, `shipper-types`, failed before verification because Cargo
+resolved `shipper-duration = ^0.4.0-rc.1` against crates.io, where that rc.1
+dependency is not published yet. `--no-verify` fails the same way. The
+workspace dry-run is therefore the Cargo-supported proof for the unpublished
+multi-crate workspace state.
+
+| Order | Crate | Version | Workspace dry-run | Isolated `-p` note |
+|---:|---|---|---:|---|
+| 1 | shipper-cargo-failure | 0.4.0-rc.1 | pass | pass |
+| 2 | shipper-duration | 0.4.0-rc.1 | pass | pass |
+| 3 | shipper-encrypt | 0.4.0-rc.1 | pass | pass |
+| 4 | shipper-output-sanitizer | 0.4.0-rc.1 | pass | pass |
+| 5 | shipper-retry | 0.4.0-rc.1 | pass | pass |
+| 6 | shipper-sparse-index | 0.4.0-rc.1 | pass | pass |
+| 7 | shipper-webhook | 0.4.0-rc.1 | pass | pass |
+| 8 | shipper-types | 0.4.0-rc.1 | pass | blocked before verify: unpublished `shipper-duration 0.4.0-rc.1` dependency absent from crates.io index |
+| 9 | shipper-config | 0.4.0-rc.1 | pass | not rerun after the downstream `-p` registry-resolution block |
+| 10 | shipper-registry | 0.4.0-rc.1 | pass | not rerun after the downstream `-p` registry-resolution block |
+| 11 | shipper-core | 0.4.0-rc.1 | pass | not rerun after the downstream `-p` registry-resolution block |
+| 12 | shipper-cli | 0.4.0-rc.1 | pass | not rerun after the downstream `-p` registry-resolution block |
+| 13 | shipper | 0.4.0-rc.1 | pass | not rerun after the downstream `-p` registry-resolution block |
+
+## Registry And Reconciliation State
+
+The dry-run proof did not publish crates and did not create registry truth for
+`0.4.0-rc.1`. Reconcile remains a planned product lane. The durable product rule
+for that lane is still: Cargo process output is a classification hint; registry
+state is authoritative for publish outcome.
+
+## Known Carry-Over
+
+- Reconcile / ambiguous publish registry-truth handling remains planned.
+- Resume under real interruption remains planned until rehearsal evidence
+  exists.
+- Mutation expansion remains advisory/opt-in unless release policy requests it.
+- The `duration_suboptimal_units` cleanup remains carry-over from the 0.4.0
+  quality lane.
+- The engine/parallel mutex posture remains carry-over.
+- CI lane routing cleanup remains carry-over outside this readiness artifact.
+
+## Sign-Off
+
+- Version matches the 0.4.0-rc.1 release candidate.
+- Changelog has a dated 0.4.0-rc.1 block.
+- Source-of-truth spec and plan exist for this readiness proof.
+- Local release gates passed.
+- Shipper preflight returned `Proven`.
+- Workspace publish dry-run proved all 13 publishable crates without uploading.
+- No tag was created.
+- No crate was published.

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -37,7 +37,7 @@ make stronger claims than this file supports.
 | No-panic production baseline | stable/internal | `cargo xtask no-panic check`; `policy/no-panic-baseline.toml` | rust/lints |
 | ripr exposure signal | advisory | `cargo xtask ripr-pr`; repo-scoped badge artifacts | release/ci |
 | Mutation PR lane | advisory / opt-in | `cargo xtask mutants-pr --changed` | tests |
-| 0.4.0 release readiness proof | planned until #195 | `docs/release/0.4.0-readiness.md` | release/ci |
+| 0.4.0 release readiness proof | stable | `docs/release/0.4.0-readiness.md`; `cargo xtask policy-report`; `cargo publish --dry-run --workspace` | release/ci |
 | Ambiguous publish reconciliation | planned | Future Reconcile spec and #99 / #102 | engine |
 | Resume under real interruption | planned | Future interruption rehearsal proof | engine |
 | Trusted Publishing default | planned/advisory | Future Trusted Publishing spec and #96 | release/ci |


### PR DESCRIPTION
Summary:
- add docs/release/0.4.0-readiness.md for the 0.4.0-rc.1 evidence packet
- promote only the release-readiness support-tier entry now that the proof artifact exists
- update the active goal manifest to point at the #195 release-readiness work item

Evidence:
- cargo run -p shipper -- plan
- copied-binary shipper preflight --preflight-only --format json --state-dir target/release-proof-state-copied => finishability proven
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features => 4266 passed, 36 ignored
- cargo test --workspace --doc => 19 passed, 36 ignored
- cargo check --workspace
- cargo audit
- cargo doc --workspace --no-deps --document-private-items
- cargo test -p shipper-cli --test bdd_publish => 26 passed
- cargo publish --dry-run --workspace => all 13 crates packaged, verified, and dry-run uploaded
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask policy-report
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask no-panic check
- cargo xtask check-lint-policy
- cargo xtask ripr-pr

Notes:
- No tag was created and no crate was published.
- Isolated cargo publish --dry-run -p passed for tier-1 leaf crates. The first downstream isolated dry-run, shipper-types, is blocked before verification because unpublished rc.1 dependencies are absent from the crates.io index; cargo publish --dry-run --workspace is the successful Cargo-supported proof for this unpublished multi-crate workspace state.

Closes #195