### PR TITLE
docs(adr): prefer registry truth over cargo output

### DIFF
--- a/docs/adr/SHIPPER-ADR-0002-registry-truth-over-cargo-output.md
+++ b/docs/adr/SHIPPER-ADR-0002-registry-truth-over-cargo-output.md
@@ -1,0 +1,79 @@
+# SHIPPER-ADR-0002: Registry Truth Over Cargo Output
+
+Status: accepted
+Owner: EffortlessMetrics
+Created: 2026-05-13
+Milestone: post-0.4.0
+Linked proposal: docs/proposals/SHIPPER-PROP-0002-registry-truth-and-reconciliation.md
+Linked specs: docs/specs/SHIPPER-SPEC-0003-registry-reconciliation.md
+Linked ADRs: docs/adr/SHIPPER-ADR-0001-claims-become-checkable-state.md
+Linked plan:
+Linked issues: #99, #102, #109
+Linked PRs:
+Support-tier impact: docs/status/SUPPORT_TIERS.md
+Policy impact: policy ledgers remain authoritative for exceptions and receipts
+Proof commands: cargo xtask check-doc-contracts --mode advisory; cargo xtask policy-report; cargo fmt --all -- --check
+
+## Decision
+
+For ambiguous publish outcomes, Shipper treats Cargo stdout, stderr, and exit
+code as classification hints. Registry state is authoritative for publish
+outcome.
+
+The engine must not blind-retry an ambiguous `cargo publish` result. It must
+first reconcile against bounded registry evidence and resolve to `Published`,
+`NotPublished`, or `StillUnknown`.
+
+## Context
+
+Cargo can return an error after an upload may already have reached the registry.
+In that case, the process result alone cannot tell the operator whether retrying
+is safe. Shipper's value is release control, not just command execution, so this
+ambiguity must be closed against registry truth.
+
+The roadmap marks Reconcile as the largest missing safety gap. The source of
+truth for behavior is `SHIPPER-SPEC-0003`; this ADR records the durable
+architecture decision behind that behavior.
+
+## Consequences
+
+- Ambiguous publish handling must query sparse-index and/or registry API
+  evidence before retrying.
+- `Published` reconciliation marks the package complete and prevents re-upload.
+- `NotPublished` reconciliation allows retry policy to continue.
+- `StillUnknown` reconciliation stops for operator action.
+- Resume must honor persisted reconciliation outcomes.
+- Event logs must expose reconciliation start and result.
+- Cargo output parsing can remain useful for classification, but it cannot be
+  the final safety-critical answer.
+- Product docs and README claims must not say Reconcile is stable until support
+  tiers are promoted with implementation proof.
+
+## Alternatives Considered
+
+### Trust Cargo Exit Status
+
+Rejected. Exit status cannot distinguish "upload failed" from "upload succeeded
+but the post-upload process failed" in ambiguous cases.
+
+### Parse Human-Readable Cargo Output As Truth
+
+Rejected. Cargo output is not a stable registry-state API. It can classify
+failure shape but cannot prove publication outcome.
+
+### Retry First, Reconcile Later
+
+Rejected. Retrying before registry evidence can create duplicate-upload pressure
+and obscures the actual outcome.
+
+### Treat Local State As Truth On Resume
+
+Rejected. Local state is a projection. When publish outcome is ambiguous,
+registry reconciliation must either produce truth or leave an explicit
+`StillUnknown` operator stop.
+
+## Follow-Up Specs And Plans
+
+- `docs/specs/SHIPPER-SPEC-0003-registry-reconciliation.md`
+- future `plans/reconcile/implementation-plan.md`
+- future `.shipper-meta/goals/active.toml` update for Reconcile execution


### PR DESCRIPTION
Summary:
- add SHIPPER-ADR-0002 for the Reconcile lane
- record the durable decision that Cargo output is a classification hint and registry state is authoritative
- keep runtime behavior and support tiers unchanged

Validation:
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask policy-report
- cargo fmt --all -- --check
- cargo xtask check-file-policy --mode blocking-allowlist
- git diff --cached --check

Non-goals:
- no runtime publish-engine behavior change
- no support-tier promotion
- no Reconcile implementation