### PR TITLE
chore(policy): sync no-panic baseline after plan split

### DIFF
--- a/policy/no-panic-baseline.json
+++ b/policy/no-panic-baseline.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "1.0",
   "generated_by": "cargo xtask no-panic baseline (#187)",
-  "generated_on": "2026-05-12",
+  "generated_on": "2026-05-14",
   "note": "Machine-generated. Run `cargo xtask no-panic baseline` to regenerate. See docs/NO_PANIC_POLICY.md for semantics.",
   "counts": {
     "total_call_sites": 55,
     "total_entries": 25,
-    "files_scanned": 50,
-    "files_with_findings": 25,
+    "files_scanned": 63,
+    "files_with_findings": 27,
     "by_family": {
       "expect": 4,
       "index": 3,
@@ -22,7 +22,7 @@
       "selector_callee": "unwrap",
       "snippet": ".verify_ownership(&p.name, token.as_deref().unwrap())",
       "count": 1,
-      "first_line": 422
+      "first_line": 428
     },
     {
       "path": "crates/shipper-core/src/engine/mod.rs",
@@ -31,7 +31,7 @@
       "selector_callee": "unwrap",
       "snippet": "reg.list_owners(&p.name, token.as_deref().unwrap())?;",
       "count": 1,
-      "first_line": 417
+      "first_line": 423
     },
     {
       "path": "crates/shipper-core/src/engine/parallel/mod.rs",
@@ -40,7 +40,7 @@
       "selector_callee": "unwrap",
       "snippet": "let st_guard = st_arc.lock().unwrap();",
       "count": 2,
-      "first_line": 293
+      "first_line": 295
     },
     {
       "path": "crates/shipper-core/src/engine/parallel/mod.rs",
@@ -49,7 +49,7 @@
       "selector_callee": "unwrap",
       "snippet": "let updated_st = st_arc.lock().unwrap();",
       "count": 1,
-      "first_line": 370
+      "first_line": 372
     },
     {
       "path": "crates/shipper-core/src/engine/parallel/mod.rs",
@@ -58,7 +58,7 @@
       "selector_callee": "unwrap",
       "snippet": "self.errors.lock().unwrap().push(msg.to_string());",
       "count": 1,
-      "first_line": 137
+      "first_line": 139
     },
     {
       "path": "crates/shipper-core/src/engine/parallel/mod.rs",
@@ -67,7 +67,7 @@
       "selector_callee": "unwrap",
       "snippet": "self.infos.lock().unwrap().push(msg.to_string());",
       "count": 1,
-      "first_line": 129
+      "first_line": 131
     },
     {
       "path": "crates/shipper-core/src/engine/parallel/mod.rs",
@@ -76,7 +76,7 @@
       "selector_callee": "unwrap",
       "snippet": "self.retry_waits.lock().unwrap().drain(..).collect()",
       "count": 1,
-      "first_line": 177
+      "first_line": 179
     },
     {
       "path": "crates/shipper-core/src/engine/parallel/mod.rs",
@@ -85,7 +85,7 @@
       "selector_callee": "unwrap",
       "snippet": "self.retry_waits.lock().unwrap().push_back(RetryWaitNotice {",
       "count": 1,
-      "first_line": 151
+      "first_line": 153
     },
     {
       "path": "crates/shipper-core/src/engine/parallel/mod.rs",
@@ -94,7 +94,7 @@
       "selector_callee": "unwrap",
       "snippet": "self.warns.lock().unwrap().push(msg.to_string());",
       "count": 1,
-      "first_line": 133
+      "first_line": 135
     },
     {
       "path": "crates/shipper-core/src/engine/parallel/mod.rs",
@@ -103,7 +103,7 @@
       "selector_callee": "unwrap",
       "snippet": "std::mem::take(&mut *self.errors.lock().unwrap())",
       "count": 1,
-      "first_line": 173
+      "first_line": 175
     },
     {
       "path": "crates/shipper-core/src/engine/parallel/mod.rs",
@@ -112,7 +112,7 @@
       "selector_callee": "unwrap",
       "snippet": "std::mem::take(&mut *self.infos.lock().unwrap())",
       "count": 1,
-      "first_line": 165
+      "first_line": 167
     },
     {
       "path": "crates/shipper-core/src/engine/parallel/mod.rs",
@@ -121,7 +121,7 @@
       "selector_callee": "unwrap",
       "snippet": "std::mem::take(&mut *self.warns.lock().unwrap())",
       "count": 1,
-      "first_line": 169
+      "first_line": 171
     },
     {
       "path": "crates/shipper-core/src/engine/parallel/publish.rs",
@@ -169,49 +169,49 @@
       "first_line": 188
     },
     {
-      "path": "crates/shipper-core/src/plan/mod.rs",
-      "family": "expect",
-      "selector_kind": "method_call",
-      "selector_callee": "expect",
-      "snippet": "let d = indegree",
-      "count": 1,
-      "first_line": 326
-    },
-    {
-      "path": "crates/shipper-core/src/plan/mod.rs",
-      "family": "expect",
-      "selector_kind": "method_call",
-      "selector_callee": "expect",
-      "snippet": "let dep_id = dep_ids",
-      "count": 1,
-      "first_line": 199
-    },
-    {
-      "path": "crates/shipper-core/src/plan/mod.rs",
+      "path": "crates/shipper-core/src/plan/assembly.rs",
       "family": "expect",
       "selector_kind": "method_call",
       "selector_callee": "expect",
       "snippet": "let pkg = pkg_map.get(id).expect(\"pkg exists\");",
       "count": 2,
-      "first_line": 224
+      "first_line": 14
     },
     {
-      "path": "crates/shipper-core/src/plan/mod.rs",
+      "path": "crates/shipper-core/src/plan/graph.rs",
+      "family": "expect",
+      "selector_kind": "method_call",
+      "selector_callee": "expect",
+      "snippet": "let d = indegree",
+      "count": 1,
+      "first_line": 159
+    },
+    {
+      "path": "crates/shipper-core/src/plan/graph.rs",
+      "family": "expect",
+      "selector_kind": "method_call",
+      "selector_callee": "expect",
+      "snippet": "let dep_id = dep_ids",
+      "count": 1,
+      "first_line": 101
+    },
+    {
+      "path": "crates/shipper-core/src/plan/graph.rs",
       "family": "unwrap",
       "selector_kind": "method_call",
       "selector_callee": "unwrap",
       "snippet": "let name = pkg_map.get(dep).unwrap().name.to_string();",
       "count": 1,
-      "first_line": 331
+      "first_line": 164
     },
     {
-      "path": "crates/shipper-core/src/plan/mod.rs",
+      "path": "crates/shipper-core/src/plan/graph.rs",
       "family": "unwrap",
       "selector_kind": "method_call",
       "selector_callee": "unwrap",
       "snippet": "ready.remove(&(pkg_map.get(&id).unwrap().name.to_string(), id.clone()));",
       "count": 1,
-      "first_line": 318
+      "first_line": 151
     },
     {
       "path": "crates/shipper-core/src/state/execution_state/mod.rs",


### PR DESCRIPTION
## Summary
- regenerate policy/no-panic-baseline.json after the plan and publish SRP splits moved existing panic-family call sites
- keep the baseline count stable at 25 entries / 55 production call sites
- clear the advisory no-panic drift surfaced by cargo xtask policy-report

## Validation
- cargo xtask no-panic check --mode blocking
- cargo xtask policy-report
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo fmt --all -- --check
- git diff --check