### PR TITLE
docs(status): promote reconcile proof

### DIFF
--- a/.shipper-meta/goals/active.toml
+++ b/.shipper-meta/goals/active.toml
@@ -1,12 +1,13 @@
 id = "shipper-reconcile-registry-truth"
 title = "Registry-truth reconciliation for ambiguous publish outcomes"
-status = "active"
+status = "complete"
 owner = "EffortlessMetrics"
 created = "2026-05-13"
 
 objective = """
-Implement Reconcile from the source-of-truth stack: ambiguous cargo publish
-outcomes must reconcile against registry truth before retrying or resuming.
+Close Reconcile from the source-of-truth stack: ambiguous cargo publish outcomes
+must reconcile against registry truth before retrying or resuming, and the
+support-tier claim must match implementation proof.
 """
 
 end_state = [
@@ -18,16 +19,18 @@ end_state = [
 ]
 
 [[work_item]]
-id = "reconciliation-types-events"
-status = "ready"
+id = "reconcile-claim-proof"
+status = "complete"
 proposal = "docs/proposals/SHIPPER-PROP-0002-registry-truth-and-reconciliation.md"
 spec = "docs/specs/SHIPPER-SPEC-0003-registry-reconciliation.md"
 plan = "plans/reconcile/implementation-plan.md"
 issue = "102"
 commands = [
   "cargo fmt --all -- --check",
-  "cargo test -p shipper-types",
-  "cargo test -p shipper-core state",
+  "cargo test -p shipper-types --locked",
+  "cargo test -p shipper-core reconcile --lib --locked",
+  "cargo test -p shipper-core state --lib --locked",
+  "cargo test -p shipper-cli --test bdd_publish --locked",
   "cargo xtask check-doc-contracts --mode advisory",
   "cargo xtask policy-report",
 ]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,11 +16,11 @@ Cargo 1.90 stabilized multi-package workspace publishing. "Publish several crate
 |---|---|---|
 | **Prove** | Can I show this release is safe *before* the irreversible step? | Partial — workspace dry-run + ownership; rehearsal-registry pending ([#97](https://github.com/EffortlessMetrics/shipper/issues/97)) |
 | **Dispatch** | Is the publish executed in a registry-aware, paced way? | Partial — generic exponential backoff; documented-constraint + Retry-After layering pending ([#94](https://github.com/EffortlessMetrics/shipper/issues/94)) |
-| **Reconcile** | When the result is ambiguous, do I check registry truth before retrying? | **Missing** ([#99](https://github.com/EffortlessMetrics/shipper/issues/99) / [#102](https://github.com/EffortlessMetrics/shipper/issues/102)) — biggest open gap |
+| **Reconcile** | When the result is ambiguous, do I check registry truth before retrying? | Implemented — ambiguous exits reconcile to Published / NotPublished / StillUnknown before retry ([#99](https://github.com/EffortlessMetrics/shipper/issues/99) / [#102](https://github.com/EffortlessMetrics/shipper/issues/102)) |
 | **Recover** | If the runner dies mid-train, can I converge from durable state without losing or duplicating work? | Partial — implemented; verification under real interruption pending ([#90](https://github.com/EffortlessMetrics/shipper/issues/90)) |
 | **Remediate** | If a partial release goes bad, can I contain or fix-forward it mechanically? | **Missing** ([#98](https://github.com/EffortlessMetrics/shipper/issues/98) / [#104](https://github.com/EffortlessMetrics/shipper/issues/104)) |
 
-These five are the existential pillars: a publishing tool that doesn't own them is a publishing tool that asks too much trust from the operator. Today Shipper is two-thirds of the way through pillars 1, 2, and 4; pillars 3 and 5 are the work that turns "useful release executor" into "trustworthy release-closure system."
+These five are the existential pillars: a publishing tool that doesn't own them is a publishing tool that asks too much trust from the operator. Today Shipper has closed the first Reconcile implementation path and remains mid-flight on Prove, Dispatch, Recover, and Remediate. The remaining work turns "useful release executor" into "trustworthy release-closure system."
 
 ## Nine competencies (the full scorecard)
 
@@ -30,7 +30,7 @@ The five pillars cover the safety story. Four more competencies — narrate, har
 |---|---|---|---|---|
 | 1 | **Prove** | Establish before the irreversible step that the publish can succeed | Partial | [#100](https://github.com/EffortlessMetrics/shipper/issues/100) |
 | 2 | **Survive** | Recover from interruption without losing or duplicating work | Partial | [#101](https://github.com/EffortlessMetrics/shipper/issues/101) |
-| 3 | **Reconcile** | Close ambiguous outcomes against registry truth | **Missing** | [#102](https://github.com/EffortlessMetrics/shipper/issues/102) |
+| 3 | **Reconcile** | Close ambiguous outcomes against registry truth | Implemented | [#102](https://github.com/EffortlessMetrics/shipper/issues/102) |
 | 4 | **Narrate** | Tell the operator what's happening live, not just after the fact | Partial | [#103](https://github.com/EffortlessMetrics/shipper/issues/103) |
 | 5 | **Remediate** | Mechanically recover from bad partial outcomes (yank, fix-forward) | **Missing** | [#104](https://github.com/EffortlessMetrics/shipper/issues/104) |
 | 6 | **Harden** | Default to safe auth posture; minimize long-lived secret blast radius | Partial | [#105](https://github.com/EffortlessMetrics/shipper/issues/105) |
@@ -40,7 +40,7 @@ The five pillars cover the safety story. Four more competencies — narrate, har
 
 **Master tracking issue: [#109](https://github.com/EffortlessMetrics/shipper/issues/109)**
 
-The biggest single gap is **#3 Reconcile**: when `cargo publish` returns ambiguously (it uploads first, then polls the index, and the poll can time out without affecting the upload), Shipper today retries blindly. Without ambiguity reconciliation against registry truth, the safety pitch has a hole at the worst possible spot.
+The biggest single gap used to be **#3 Reconcile**: when `cargo publish` returns ambiguously (it uploads first, then polls the index, and the poll can time out without affecting the upload), Shipper could retry blindly. Shipper now reconciles ambiguous outcomes against registry truth before retry; remaining safety work is concentrated in registry-aware pacing, live interruption proof, and remediation.
 
 ## Design principles
 
@@ -65,17 +65,16 @@ All domain logic lives in `crates/shipper`. `crates/shipper-cli` parses args and
 
 Sequencing follows the master roadmap ([#109](https://github.com/EffortlessMetrics/shipper/issues/109)).
 
-### Now — gates v0.3.0 stable
-1. **[#102](https://github.com/EffortlessMetrics/shipper/issues/102) Reconcile** — implement the ambiguous-outcome state machine ([#99](https://github.com/EffortlessMetrics/shipper/issues/99)). Without this, Shipper cannot truthfully claim to be safer than naive `cargo publish`.
-2. **[#105](https://github.com/EffortlessMetrics/shipper/issues/105) Harden** — make Trusted Publishing the default ([#96](https://github.com/EffortlessMetrics/shipper/issues/96)). Most of the wiring exists.
-3. **[#103](https://github.com/EffortlessMetrics/shipper/issues/103) Narrate** — surface retry/backoff state ([#91](https://github.com/EffortlessMetrics/shipper/issues/91)). Operators currently fly blind for ~60 minutes during rate-limited publishes.
-4. **[#101](https://github.com/EffortlessMetrics/shipper/issues/101) Survive** — execute the rehearsal procedure ([#90](https://github.com/EffortlessMetrics/shipper/issues/90)) and document the events-as-truth invariant ([#93](https://github.com/EffortlessMetrics/shipper/issues/93)). Resume is currently unverified under real interruption.
-5. **[#108](https://github.com/EffortlessMetrics/shipper/issues/108) Ergonomics** — `cargo install shipper` should work ([#95](https://github.com/EffortlessMetrics/shipper/issues/95)).
+### Now — gates v0.4.0 stable
+1. **[#105](https://github.com/EffortlessMetrics/shipper/issues/105) Harden** — make Trusted Publishing the default ([#96](https://github.com/EffortlessMetrics/shipper/issues/96)). Most of the wiring exists.
+2. **[#103](https://github.com/EffortlessMetrics/shipper/issues/103) Narrate** — surface retry/backoff state ([#91](https://github.com/EffortlessMetrics/shipper/issues/91)). Operators currently fly blind for ~60 minutes during rate-limited publishes.
+3. **[#101](https://github.com/EffortlessMetrics/shipper/issues/101) Survive** — execute the rehearsal procedure ([#90](https://github.com/EffortlessMetrics/shipper/issues/90)) and document the events-as-truth invariant ([#93](https://github.com/EffortlessMetrics/shipper/issues/93)). Resume is currently unverified under real interruption.
+4. **[#108](https://github.com/EffortlessMetrics/shipper/issues/108) Ergonomics** — `cargo install shipper` should work ([#95](https://github.com/EffortlessMetrics/shipper/issues/95)).
+5. **[#106](https://github.com/EffortlessMetrics/shipper/issues/106) Profile** — registry-aware backoff layered on the regime tag preflight already detects ([#94](https://github.com/EffortlessMetrics/shipper/issues/94)).
 
 ### Next — past stable
-6. **[#106](https://github.com/EffortlessMetrics/shipper/issues/106) Profile** — registry-aware backoff layered on the regime tag preflight already detects ([#94](https://github.com/EffortlessMetrics/shipper/issues/94)). Preflight discovers `is_new_crate`; publish discards it. Threading the tag through is the entire mechanism.
-7. **[#104](https://github.com/EffortlessMetrics/shipper/issues/104) Remediate** — receipt-driven yank/fix-forward for compromised releases ([#98](https://github.com/EffortlessMetrics/shipper/issues/98)).
-8. **[#100](https://github.com/EffortlessMetrics/shipper/issues/100) Prove tier 2** — rehearsal registry as the next preflight strength ([#97](https://github.com/EffortlessMetrics/shipper/issues/97)). Promotes preflight from "we believe" to "we proved against a registry-shaped target".
+6. **[#104](https://github.com/EffortlessMetrics/shipper/issues/104) Remediate** — receipt-driven yank/fix-forward for compromised releases ([#98](https://github.com/EffortlessMetrics/shipper/issues/98)).
+7. **[#100](https://github.com/EffortlessMetrics/shipper/issues/100) Prove tier 2** — rehearsal registry as the next preflight strength ([#97](https://github.com/EffortlessMetrics/shipper/issues/97)). Promotes preflight from "we believe" to "we proved against a registry-shaped target".
 
 ### Later — once the engine is closure-complete
 9. **[#107](https://github.com/EffortlessMetrics/shipper/issues/107) Integrate** — IDP plugin examples (Backstage / Port / Cortex), HTTP query API, webhook reliability semantics, library consumer guide. Best done after the engine offers a stable closure story to integrate against.

--- a/docs/adr/SHIPPER-ADR-0002-registry-truth-over-cargo-output.md
+++ b/docs/adr/SHIPPER-ADR-0002-registry-truth-over-cargo-output.md
@@ -31,7 +31,7 @@ In that case, the process result alone cannot tell the operator whether retrying
 is safe. Shipper's value is release control, not just command execution, so this
 ambiguity must be closed against registry truth.
 
-The roadmap marks Reconcile as the largest missing safety gap. The source of
+The roadmap marked Reconcile as the largest missing safety gap. The source of
 truth for behavior is `SHIPPER-SPEC-0003`; this ADR records the durable
 architecture decision behind that behavior.
 
@@ -46,8 +46,8 @@ architecture decision behind that behavior.
 - Event logs must expose reconciliation start and result.
 - Cargo output parsing can remain useful for classification, but it cannot be
   the final safety-critical answer.
-- Product docs and README claims must not say Reconcile is stable until support
-  tiers are promoted with implementation proof.
+- Product docs and README claims must not exceed the Reconcile support tier in
+  `docs/status/SUPPORT_TIERS.md`.
 
 ## Alternatives Considered
 

--- a/docs/proposals/SHIPPER-PROP-0002-registry-truth-and-reconciliation.md
+++ b/docs/proposals/SHIPPER-PROP-0002-registry-truth-and-reconciliation.md
@@ -1,6 +1,6 @@
 # SHIPPER-PROP-0002: Registry Truth and Reconciliation
 
-Status: proposed
+Status: implemented
 Owner: EffortlessMetrics
 Created: 2026-05-13
 Milestone: post-0.4.0
@@ -16,18 +16,19 @@ Proof commands: cargo xtask check-doc-contracts --mode advisory; cargo xtask pol
 
 ## Problem
 
-Shipper's largest remaining safety gap is Reconcile. When `cargo publish`
+Shipper's largest historical safety gap was Reconcile. When `cargo publish`
 returns an ambiguous outcome, the upload may have succeeded even though the
 process result looks like failure. Cargo process output is not registry truth.
 
-Today the roadmap still marks Reconcile as missing. Issue #102 identifies the
-gap directly: ambiguous outcomes can become blind retries instead of registry
-checks. Issue #99 defines the desired state machine, but Shipper still needs a
-spec, ADR, plan, and implementation sequence before runtime behavior changes.
+Issue #102 identified the gap directly: ambiguous outcomes could become blind
+retries instead of registry checks. Issue #99 defined the desired state machine.
+Shipper now has the proposal/spec/ADR/plan stack and the first implementation
+path for ambiguous publish reconciliation.
 
 This matters because Shipper's product is trust. Without registry-truth
-reconciliation, Shipper cannot honestly claim to be safer than a naive
-`cargo publish` retry loop in the highest-stakes failure case.
+reconciliation, Shipper could not honestly claim to be safer than a naive
+`cargo publish` retry loop in the highest-stakes failure case. That specific
+gap is now implemented and remains governed by `docs/status/SUPPORT_TIERS.md`.
 
 ## Users and Value
 
@@ -102,8 +103,8 @@ publish branch is where Shipper can prevent the unsafe retry.
 ### Promote README Claims Before Implementation
 
 Rejected. Existing or future product docs must not exceed
-`docs/status/SUPPORT_TIERS.md`. Ambiguous publish reconciliation remains
-planned until implementation, tests, and proof artifacts exist.
+`docs/status/SUPPORT_TIERS.md`. Ambiguous publish reconciliation must not be
+promoted beyond the proof recorded there.
 
 ## Evidence Plan
 
@@ -134,7 +135,8 @@ The implementation lane must later prove:
 ## Non-Goals
 
 - Implementing publish-engine behavior in this proposal PR.
-- Promoting ambiguous publish reconciliation from `planned`.
+- Promoting ambiguous publish reconciliation beyond the proof recorded in
+  `docs/status/SUPPORT_TIERS.md`.
 - Replacing readiness checks with reconciliation checks.
 - Making registry API availability the only source of truth; sparse index
   evidence remains part of the design.
@@ -142,11 +144,13 @@ The implementation lane must later prove:
 
 ## Exit Criteria
 
-This proposal is complete when it is followed by:
+This proposal is complete. It was followed by:
 
 - a behavior spec for registry reconciliation
 - an ADR recording registry truth over Cargo process output
 - an implementation plan with PR sequencing and proof commands
 - an active goal manifest pointing at the Reconcile lane
+- implementation proof for the three reconciliation outcomes and resume path
 
-Runtime implementation begins only after those artifacts exist.
+Further Reconcile claims must continue to flow through support tiers and proof
+commands rather than README text alone.

--- a/docs/release/0.4.0-readiness.md
+++ b/docs/release/0.4.0-readiness.md
@@ -17,8 +17,9 @@ workspace is versioned as `0.4.0-rc.1`, the changelog has a dated
 returned `Proven`, and `cargo publish --dry-run --workspace` packaged,
 verified, and dry-run uploaded all 13 crates.
 
-This document is release evidence only. It does not tag, publish, or claim that
-registry reconciliation is implemented.
+This document is release evidence only. It does not tag or publish. It records
+what was proven at the evidence base commit above; current product claim state
+lives in `docs/status/SUPPORT_TIERS.md`.
 
 ## Gate Results
 
@@ -84,13 +85,13 @@ multi-crate workspace state.
 ## Registry And Reconciliation State
 
 The dry-run proof did not publish crates and did not create registry truth for
-`0.4.0-rc.1`. Reconcile remains a planned product lane. The durable product rule
-for that lane is still: Cargo process output is a classification hint; registry
-state is authoritative for publish outcome.
+`0.4.0-rc.1`. At this evidence base commit, the readiness packet did not prove
+runtime registry reconciliation. Later support-tier updates may supersede the
+current product claim, but they do not change what this release proof observed.
 
 ## Known Carry-Over
 
-- Reconcile / ambiguous publish registry-truth handling remains planned.
+- Runtime Reconcile proof was outside this release-readiness packet.
 - Resume under real interruption remains planned until rehearsal evidence
   exists.
 - Mutation expansion remains advisory/opt-in unless release policy requests it.

--- a/docs/specs/SHIPPER-SPEC-0003-registry-reconciliation.md
+++ b/docs/specs/SHIPPER-SPEC-0003-registry-reconciliation.md
@@ -1,6 +1,6 @@
 # SHIPPER-SPEC-0003: Registry Reconciliation
 
-Status: proposed
+Status: implemented
 Owner: EffortlessMetrics
 Created: 2026-05-13
 Milestone: post-0.4.0
@@ -126,15 +126,19 @@ state machine and resume behavior.
 
 ## Promotion Rule
 
-`docs/status/SUPPORT_TIERS.md` must keep ambiguous publish reconciliation as
+`docs/status/SUPPORT_TIERS.md` kept ambiguous publish reconciliation as
 `planned` until:
 
 - this spec is accepted
 - the registry-truth ADR is accepted
 - the implementation plan exists
-- the implementation is complete
-- tests cover `Published`, `NotPublished`, `StillUnknown`, and resume behavior
-- README and product docs are aligned with the proven tier
+- the implementation was complete
+- tests covered `Published`, `NotPublished`, `StillUnknown`, and resume behavior
+- README and product docs were aligned with the proven tier
+
+The current support tier is owned by `docs/status/SUPPORT_TIERS.md`, not this
+spec. If future evidence weakens or expands the claim, update the support-tier
+entry and proof commands first.
 
 ## Open Questions
 

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -34,11 +34,11 @@ make stronger claims than this file supports.
 | Manifest-level topological publish planning | stable | Planner regression tests; `shipper plan`; roadmap #109 | engine |
 | File-policy enforcement | stable/internal | `cargo xtask check-file-policy --mode blocking-allowlist`; `cargo xtask policy-report`; CI `Policy` job | release/ci |
 | Rust 1.95 / 0.4 policy floor | stable/internal | Workspace lints; `cargo xtask check-lint-policy`; `cargo clippy --workspace --all-targets --all-features -- -D warnings` | rust/lints |
-| No-panic production baseline | stable/internal | `cargo xtask no-panic check`; `policy/no-panic-baseline.toml` | rust/lints |
+| No-panic production baseline | stable/internal | `cargo xtask no-panic check`; `policy/no-panic-baseline.json` | rust/lints |
 | ripr exposure signal | advisory | `cargo xtask ripr-pr`; repo-scoped badge artifacts | release/ci |
 | Mutation PR lane | advisory / opt-in | `cargo xtask mutants-pr --changed` | tests |
 | 0.4.0 release readiness proof | stable | `docs/release/0.4.0-readiness.md`; `cargo xtask policy-report`; `cargo publish --dry-run --workspace` | release/ci |
-| Ambiguous publish reconciliation | planned | Future Reconcile spec and #99 / #102 | engine |
+| Ambiguous publish reconciliation | stable | `cargo test -p shipper-core reconcile --lib`; `cargo test -p shipper-core state --lib`; `cargo test -p shipper-cli --test bdd_publish`; `PublishReconciling` / `PublishReconciled` events | engine |
 | Resume under real interruption | planned | Future interruption rehearsal proof | engine |
 | Trusted Publishing default | planned/advisory | Future Trusted Publishing spec and #96 | release/ci |
 

--- a/plans/reconcile/implementation-plan.md
+++ b/plans/reconcile/implementation-plan.md
@@ -1,6 +1,6 @@
 # Plan: Registry Reconciliation
 
-Status: accepted
+Status: implemented
 Owner: EffortlessMetrics
 Created: 2026-05-13
 Milestone: post-0.4.0
@@ -20,8 +20,9 @@ Shipper reconciles ambiguous `cargo publish` outcomes against registry truth
 before retrying or resuming. Ambiguous outcomes resolve to `Published`,
 `NotPublished`, or `StillUnknown`, with structured evidence in events and state.
 
-The support-tier claim remains `planned` until implementation and tests prove
-all required outcomes and resume behavior.
+The support-tier claim remained `planned` until implementation and tests proved
+all required outcomes and resume behavior. The current claim tier is maintained
+in `docs/status/SUPPORT_TIERS.md`.
 
 ## PR Sequence
 


### PR DESCRIPTION
## Summary
- promote ambiguous publish reconciliation from planned to stable in the support-tier map
- update the roadmap/source-of-truth Reconcile artifacts from missing/proposed to implemented
- preserve the 0.4.0 readiness document as historical release evidence while pointing current claims back to support tiers

## Validation
- cargo test -p shipper-types --locked
- cargo test -p shipper-core reconcile --lib --locked
- cargo test -p shipper-core state --lib --locked
- cargo test -p shipper-cli --test bdd_publish --locked
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask policy-report
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo fmt --all -- --check
- active goal TOML parse check
- git diff --check

## Notes
- The plan command cargo test -p shipper-types reconciliation --locked is stale: it currently filters to zero tests. The full shipper-types suite passed, and the core reconcile filter covers the implemented reconciliation tests.