### PR TITLE
fix(profile): honor retry-after retry floors

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ Cargo 1.90 stabilized multi-package workspace publishing. "Publish several crate
 | Pillar | Question it answers | Status |
 |---|---|---|
 | **Prove** | Can I show this release is safe *before* the irreversible step? | Partial — workspace dry-run + ownership; rehearsal-registry pending ([#97](https://github.com/EffortlessMetrics/shipper/issues/97)) |
-| **Dispatch** | Is the publish executed in a registry-aware, paced way? | Partial — crates.io first-publish backoff is regime-aware; Retry-After, duration estimates, and alternative registry profiles pending ([#94](https://github.com/EffortlessMetrics/shipper/issues/94) / [#106](https://github.com/EffortlessMetrics/shipper/issues/106)) |
+| **Dispatch** | Is the publish executed in a registry-aware, paced way? | Partial — crates.io first-publish backoff and `Retry-After` retry floors exist; duration estimates and alternative registry profiles pending ([#94](https://github.com/EffortlessMetrics/shipper/issues/94) / [#106](https://github.com/EffortlessMetrics/shipper/issues/106)) |
 | **Reconcile** | When the result is ambiguous, do I check registry truth before retrying? | Implemented — ambiguous exits reconcile to Published / NotPublished / StillUnknown before retry ([#99](https://github.com/EffortlessMetrics/shipper/issues/99) / [#102](https://github.com/EffortlessMetrics/shipper/issues/102)) |
 | **Recover** | If the runner dies mid-train, can I converge from durable state without losing or duplicating work? | Partial — implemented; verification under real interruption pending ([#90](https://github.com/EffortlessMetrics/shipper/issues/90)) |
 | **Remediate** | If a partial release goes bad, can I contain or fix-forward it mechanically? | **Missing** ([#98](https://github.com/EffortlessMetrics/shipper/issues/98) / [#104](https://github.com/EffortlessMetrics/shipper/issues/104)) |
@@ -70,7 +70,7 @@ Sequencing follows the master roadmap ([#109](https://github.com/EffortlessMetri
 2. **[#103](https://github.com/EffortlessMetrics/shipper/issues/103) Narrate** — surface retry/backoff state ([#91](https://github.com/EffortlessMetrics/shipper/issues/91)). Operators currently fly blind for ~60 minutes during rate-limited publishes.
 3. **[#101](https://github.com/EffortlessMetrics/shipper/issues/101) Survive** — execute the rehearsal procedure ([#90](https://github.com/EffortlessMetrics/shipper/issues/90)) and document the events-as-truth invariant ([#93](https://github.com/EffortlessMetrics/shipper/issues/93)). Resume is currently unverified under real interruption.
 4. **[#108](https://github.com/EffortlessMetrics/shipper/issues/108) Ergonomics** — `cargo install shipper` should work ([#95](https://github.com/EffortlessMetrics/shipper/issues/95)).
-5. **[#106](https://github.com/EffortlessMetrics/shipper/issues/106) Profile** — registry-aware backoff now has a crates.io `RegistryProfile` surface; next work is Retry-After parsing and preflight duration estimates.
+5. **[#106](https://github.com/EffortlessMetrics/shipper/issues/106) Profile** — registry-aware backoff now has a crates.io `RegistryProfile` surface and honors `Retry-After`; next work is preflight duration estimates and alternative registry profiles.
 
 ### Next — past stable
 6. **[#104](https://github.com/EffortlessMetrics/shipper/issues/104) Remediate** — receipt-driven yank/fix-forward for compromised releases ([#98](https://github.com/EffortlessMetrics/shipper/issues/98)).

--- a/crates/shipper-cli/tests/bdd_error_handling.rs
+++ b/crates/shipper-cli/tests/bdd_error_handling.rs
@@ -378,8 +378,10 @@ mod rate_limiting {
         let fake_cargo = create_fake_cargo_with_stderr(&bin_dir);
         let (new_path, real_cargo) = prepend_fake_bin(&bin_dir);
 
-        // Enough registry responses for version checks + post-attempt checks
-        let registry = spawn_registry(vec![404], 20);
+        // Preflight sees the crate as existing (version absent, crate present)
+        // so this retry-focused test does not take the crates.io first-publish
+        // 10-minute backoff floor.
+        let registry = spawn_registry(vec![404, 404, 200, 404, 404], 20);
 
         let output = shipper_cmd()
             .arg("--manifest-path")
@@ -406,7 +408,12 @@ mod rate_limiting {
             .expect("run");
 
         // Should fail (all retries exhausted)
-        assert!(!output.status.success());
+        assert!(
+            !output.status.success(),
+            "expected publish to fail after retry exhaustion; stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
 
         let stderr = String::from_utf8_lossy(&output.stderr);
         // The engine should mention retry/attempt or the transient classification

--- a/crates/shipper-core/src/engine/mod.rs
+++ b/crates/shipper-core/src/engine/mod.rs
@@ -966,6 +966,7 @@ pub fn run_publish(
                         break;
                     }
 
+                    let failure_output = format!("{}\n{}", out.stderr_tail, out.stdout_tail);
                     let (class, msg) = classify_cargo_failure(&out.stderr_tail, &out.stdout_tail);
                     last_err = Some((class.clone(), msg.clone()));
 
@@ -997,14 +998,15 @@ pub fn run_publish(
                             ));
                         }
                         ErrorClass::Retryable | ErrorClass::Ambiguous => {
-                            let is_new_crate =
-                                if crate::runtime::execution::looks_like_rate_limit(&msg) {
-                                    *is_new_crate_cached.get_or_insert_with(|| {
-                                        reg.check_new_crate(&p.name).unwrap_or(false)
-                                    })
-                                } else {
-                                    false
-                                };
+                            let is_new_crate = if crate::runtime::execution::looks_like_rate_limit(
+                                &failure_output,
+                            ) {
+                                *is_new_crate_cached.get_or_insert_with(|| {
+                                    reg.check_new_crate(&p.name).unwrap_or(false)
+                                })
+                            } else {
+                                false
+                            };
                             let delay = registry_aware_backoff(
                                 opts.base_delay,
                                 opts.max_delay,
@@ -1012,7 +1014,7 @@ pub fn run_publish(
                                 opts.retry_strategy,
                                 opts.retry_jitter,
                                 is_new_crate,
-                                &msg,
+                                &failure_output,
                             );
                             emit_retry_backoff_event(
                                 &mut event_log,

--- a/crates/shipper-core/src/engine/parallel/publish.rs
+++ b/crates/shipper-core/src/engine/parallel/publish.rs
@@ -435,6 +435,7 @@ pub(super) fn publish_package(
                     break;
                 }
 
+                let failure_output = format!("{}\n{}", out.stderr_tail, out.stdout_tail);
                 let (class, msg) = classify_cargo_failure(&out.stderr_tail, &out.stdout_tail);
                 last_err = Some((class.clone(), msg.clone()));
 
@@ -605,13 +606,14 @@ pub(super) fn publish_package(
                         // Only query crate_exists when the error looks like
                         // a rate limit (saves a registry round-trip for
                         // generic network/transient failures).
-                        let is_new_crate = if crate::runtime::execution::looks_like_rate_limit(&msg)
-                        {
-                            *is_new_crate_cached
-                                .get_or_insert_with(|| !reg.crate_exists(&p.name).unwrap_or(true))
-                        } else {
-                            false
-                        };
+                        let is_new_crate =
+                            if crate::runtime::execution::looks_like_rate_limit(&failure_output) {
+                                *is_new_crate_cached.get_or_insert_with(|| {
+                                    !reg.crate_exists(&p.name).unwrap_or(true)
+                                })
+                            } else {
+                                false
+                            };
                         let delay = registry_aware_backoff(
                             opts.base_delay,
                             opts.max_delay,
@@ -619,7 +621,7 @@ pub(super) fn publish_package(
                             opts.retry_strategy,
                             opts.retry_jitter,
                             is_new_crate,
-                            &msg,
+                            &failure_output,
                         );
                         emit_retry_backoff(
                             event_log,

--- a/crates/shipper-core/src/runtime/execution/mod.rs
+++ b/crates/shipper-core/src/runtime/execution/mod.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 
 use shipper_retry::{RetryStrategyConfig, RetryStrategyType, calculate_delay};
 use shipper_types::{ErrorClass, ExecutionState, PackageState, PublishRegime};
@@ -203,6 +203,47 @@ pub fn looks_like_rate_limit(message: &str) -> bool {
         || m.contains("too many requests")
 }
 
+/// Parse a `Retry-After` header value from cargo/registry output.
+///
+/// Cargo exposes registry failures through human-facing stderr/stdout rather
+/// than a structured HTTP response. When that text contains a `Retry-After`
+/// header, this returns the registry's requested wait as a duration.
+pub fn retry_after_delay(message: &str) -> Option<Duration> {
+    retry_after_delay_at(message, Utc::now())
+}
+
+fn retry_after_delay_at(message: &str, now: DateTime<Utc>) -> Option<Duration> {
+    message.lines().find_map(|line| {
+        let line = line
+            .trim_start()
+            .trim_start_matches(['<', '>'])
+            .trim_start();
+        let (name, value) = line.split_once(':')?;
+        if !name.trim().eq_ignore_ascii_case("retry-after") {
+            return None;
+        }
+
+        parse_retry_after_value(value.trim(), now)
+    })
+}
+
+fn parse_retry_after_value(value: &str, now: DateTime<Utc>) -> Option<Duration> {
+    let value = value.trim_matches('"').trim_matches('\'').trim();
+    if value.is_empty() {
+        return None;
+    }
+
+    if value.bytes().all(|b| b.is_ascii_digit()) {
+        return value.parse::<u64>().ok().map(Duration::from_secs);
+    }
+
+    let target = DateTime::parse_from_rfc2822(value)
+        .ok()?
+        .with_timezone(&Utc);
+    let delta = target.signed_duration_since(now);
+    delta.to_std().ok().or(Some(Duration::ZERO))
+}
+
 /// Registry-aware backoff. Layered on top of the generic [`backoff_delay`]:
 /// if we're publishing a brand-new crate and the retry is caused by a
 /// rate-limit signal, floor the delay at [`CRATES_IO_NEW_CRATE_WINDOW`]
@@ -254,9 +295,13 @@ pub fn registry_profile_aware_backoff(
     error_message: &str,
 ) -> Duration {
     let generic = backoff_delay(base, max, attempt, strategy, jitter);
-    profile
-        .retry_floor_for(regime, error_message)
-        .map_or(generic, |floor| generic.max(floor))
+    [
+        profile.retry_floor_for(regime, error_message),
+        retry_after_delay(error_message),
+    ]
+    .into_iter()
+    .flatten()
+    .fold(generic, Duration::max)
 }
 
 /// Update a package state inside an in-memory execution state.
@@ -345,6 +390,82 @@ mod tests {
             RegistryProfile::crates_io(),
             PublishRegime::FirstPublish,
             "HTTP 429 Too Many Requests",
+        );
+
+        assert_eq!(d, CRATES_IO_NEW_CRATE_WINDOW);
+    }
+
+    #[test]
+    fn retry_after_delay_parses_delta_seconds() {
+        assert_eq!(
+            retry_after_delay("HTTP 429\r\nRetry-After: 90\r\n"),
+            Some(Duration::from_secs(90))
+        );
+        assert_eq!(
+            retry_after_delay("< retry-after: \"120\""),
+            Some(Duration::from_secs(120))
+        );
+    }
+
+    #[test]
+    fn retry_after_delay_parses_http_date() {
+        let now = DateTime::parse_from_rfc2822("Wed, 21 Oct 2015 07:27:00 GMT")
+            .expect("valid rfc2822")
+            .with_timezone(&Utc);
+
+        assert_eq!(
+            retry_after_delay_at("Retry-After: Wed, 21 Oct 2015 07:28:00 GMT", now),
+            Some(Duration::from_secs(60))
+        );
+    }
+
+    #[test]
+    fn retry_after_delay_past_http_date_is_zero() {
+        let now = DateTime::parse_from_rfc2822("Wed, 21 Oct 2015 07:29:00 GMT")
+            .expect("valid rfc2822")
+            .with_timezone(&Utc);
+
+        assert_eq!(
+            retry_after_delay_at("Retry-After: Wed, 21 Oct 2015 07:28:00 GMT", now),
+            Some(Duration::ZERO)
+        );
+    }
+
+    #[test]
+    fn retry_after_delay_ignores_invalid_headers() {
+        assert_eq!(retry_after_delay("Retry-After:"), None);
+        assert_eq!(retry_after_delay("X-Retry-After: 60"), None);
+        assert_eq!(retry_after_delay("retry-after: not a date"), None);
+        assert_eq!(retry_after_delay("HTTP 429 Too Many Requests"), None);
+    }
+
+    #[test]
+    fn registry_profile_aware_backoff_honors_retry_after_floor() {
+        let d = registry_profile_aware_backoff(
+            Duration::from_secs(10),
+            Duration::from_secs(120),
+            1,
+            RetryStrategyType::Exponential,
+            0.0,
+            RegistryProfile::unknown(),
+            PublishRegime::Update,
+            "HTTP 429 Too Many Requests\nRetry-After: 75",
+        );
+
+        assert_eq!(d, Duration::from_secs(75));
+    }
+
+    #[test]
+    fn registry_profile_aware_backoff_uses_larger_floor() {
+        let d = registry_profile_aware_backoff(
+            Duration::from_secs(10),
+            Duration::from_secs(120),
+            1,
+            RetryStrategyType::Exponential,
+            0.0,
+            RegistryProfile::crates_io(),
+            PublishRegime::FirstPublish,
+            "HTTP 429 Too Many Requests\nRetry-After: 30",
         );
 
         assert_eq!(d, CRATES_IO_NEW_CRATE_WINDOW);

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -40,6 +40,7 @@ make stronger claims than this file supports.
 | 0.4.0 release readiness proof | stable | `docs/release/0.4.0-readiness.md`; `cargo xtask policy-report`; `cargo publish --dry-run --workspace` | release/ci |
 | Ambiguous publish reconciliation | stable | `cargo test -p shipper-core reconcile --lib`; `cargo test -p shipper-core state --lib`; `cargo test -p shipper-cli --test bdd_publish`; `PublishReconciling` / `PublishReconciled` events | engine |
 | crates.io first-publish backoff profile | stable | `cargo test -p shipper-core runtime::execution --lib`; `cargo test -p shipper-core publish --lib`; `RegistryProfile::crates_io()` | engine |
+| Retry-After retry floor | stable | `cargo test -p shipper-core retry_after --lib`; `cargo test -p shipper-core publish --lib`; raw cargo stderr/stdout retry signal path | engine |
 | Resume under real interruption | planned | Future interruption rehearsal proof | engine |
 | Trusted Publishing default | planned/advisory | Future Trusted Publishing spec and #96 | release/ci |
 


### PR DESCRIPTION
## Summary
- parse Retry-After retry floors from raw cargo/registry output, including delta seconds and HTTP-date values
- pass raw cargo stdout/stderr to rate-limit backoff decisions instead of the classifier's generic summary
- update roadmap and support tiers to reflect the precise Dispatch/Profile claim now proven

## Validation
- cargo fmt --all -- --check
- cargo test -p shipper-core retry_after --lib --locked
- cargo test -p shipper-core registry_profile_aware_backoff --lib --locked
- cargo test -p shipper-core runtime::execution --lib --locked
- cargo test -p shipper-core publish --lib --locked
- cargo clippy -p shipper-core --all-targets --locked -- -D warnings
- cargo xtask policy-report
- cargo xtask check-file-policy --mode blocking-allowlist
- git diff --check