### PR TITLE
feat(profile): estimate preflight registry pacing

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ Cargo 1.90 stabilized multi-package workspace publishing. "Publish several crate
 | Pillar | Question it answers | Status |
 |---|---|---|
 | **Prove** | Can I show this release is safe *before* the irreversible step? | Partial — workspace dry-run + ownership; rehearsal-registry pending ([#97](https://github.com/EffortlessMetrics/shipper/issues/97)) |
-| **Dispatch** | Is the publish executed in a registry-aware, paced way? | Partial — crates.io first-publish backoff and `Retry-After` retry floors exist; duration estimates and alternative registry profiles pending ([#94](https://github.com/EffortlessMetrics/shipper/issues/94) / [#106](https://github.com/EffortlessMetrics/shipper/issues/106)) |
+| **Dispatch** | Is the publish executed in a registry-aware, paced way? | Partial — crates.io first-publish backoff, `Retry-After` retry floors, and preflight registry-pacing estimates exist; alternative registry profiles pending ([#94](https://github.com/EffortlessMetrics/shipper/issues/94) / [#106](https://github.com/EffortlessMetrics/shipper/issues/106)) |
 | **Reconcile** | When the result is ambiguous, do I check registry truth before retrying? | Implemented — ambiguous exits reconcile to Published / NotPublished / StillUnknown before retry ([#99](https://github.com/EffortlessMetrics/shipper/issues/99) / [#102](https://github.com/EffortlessMetrics/shipper/issues/102)) |
 | **Recover** | If the runner dies mid-train, can I converge from durable state without losing or duplicating work? | Partial — implemented; verification under real interruption pending ([#90](https://github.com/EffortlessMetrics/shipper/issues/90)) |
 | **Remediate** | If a partial release goes bad, can I contain or fix-forward it mechanically? | **Missing** ([#98](https://github.com/EffortlessMetrics/shipper/issues/98) / [#104](https://github.com/EffortlessMetrics/shipper/issues/104)) |
@@ -70,7 +70,7 @@ Sequencing follows the master roadmap ([#109](https://github.com/EffortlessMetri
 2. **[#103](https://github.com/EffortlessMetrics/shipper/issues/103) Narrate** — surface retry/backoff state ([#91](https://github.com/EffortlessMetrics/shipper/issues/91)). Operators currently fly blind for ~60 minutes during rate-limited publishes.
 3. **[#101](https://github.com/EffortlessMetrics/shipper/issues/101) Survive** — execute the rehearsal procedure ([#90](https://github.com/EffortlessMetrics/shipper/issues/90)) and document the events-as-truth invariant ([#93](https://github.com/EffortlessMetrics/shipper/issues/93)). Resume is currently unverified under real interruption.
 4. **[#108](https://github.com/EffortlessMetrics/shipper/issues/108) Ergonomics** — `cargo install shipper` should work ([#95](https://github.com/EffortlessMetrics/shipper/issues/95)).
-5. **[#106](https://github.com/EffortlessMetrics/shipper/issues/106) Profile** — registry-aware backoff now has a crates.io `RegistryProfile` surface and honors `Retry-After`; next work is preflight duration estimates and alternative registry profiles.
+5. **[#106](https://github.com/EffortlessMetrics/shipper/issues/106) Profile** — registry-aware backoff now has a crates.io `RegistryProfile` surface, honors `Retry-After`, and reports minimum preflight registry pacing; next work is alternative registry profiles.
 
 ### Next — past stable
 6. **[#104](https://github.com/EffortlessMetrics/shipper/issues/104) Remediate** — receipt-driven yank/fix-forward for compromised releases ([#98](https://github.com/EffortlessMetrics/shipper/issues/98)).

--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -1731,6 +1731,16 @@ fn print_preflight(rep: &PreflightReport, format: &str) {
             println!("  New crates: {}", new_crates);
             println!("  Ownership verified: {}", ownership_verified);
             println!("  Dry-run passed: {}", dry_run_passed);
+            if let Some(estimate) = &rep.estimated_publish_duration {
+                println!(
+                    "  Estimated registry pacing: at least {}",
+                    humantime::format_duration(estimate.minimum_registry_pacing)
+                );
+                println!(
+                    "    profile={} first_publish={} updates={}",
+                    estimate.registry_profile, estimate.first_publish_count, estimate.update_count
+                );
+            }
             println!();
 
             // What to do next guidance

--- a/crates/shipper-cli/tests/cli_e2e.rs
+++ b/crates/shipper-cli/tests/cli_e2e.rs
@@ -415,6 +415,8 @@ Summary:
   New crates: 1
   Ownership verified: 0
   Dry-run passed: 1
+  Estimated registry pacing: at least 0s
+    profile=crates-io first_publish=1 updates=0
 
 What to do next:
 -----------------
@@ -1146,6 +1148,19 @@ fn preflight_command_json_output_structure() {
     assert!(json.get("finishability").is_some());
     assert!(json.get("packages").is_some());
     assert!(json.get("timestamp").is_some());
+    assert_eq!(
+        json.pointer("/estimated_publish_duration/registry_profile"),
+        Some(&serde_json::Value::String("crates-io".to_string()))
+    );
+    assert_eq!(
+        json.pointer("/estimated_publish_duration/first_publish_count")
+            .and_then(serde_json::Value::as_u64),
+        Some(1)
+    );
+    assert!(
+        json.pointer("/estimated_publish_duration/minimum_registry_pacing")
+            .is_some()
+    );
 
     // Verify packages array structure
     let packages = json.get("packages").unwrap().as_array().unwrap();

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__preflight_allow_dirty.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__preflight_allow_dirty.snap
@@ -26,6 +26,8 @@ Summary:
   New crates: 1
   Ownership verified: 0
   Dry-run passed: 1
+  Estimated registry pacing: at least 0s
+    profile=crates-io first_publish=1 updates=0
 
 What to do next:
 -----------------

--- a/crates/shipper-core/src/engine/mod.rs
+++ b/crates/shipper-core/src/engine/mod.rs
@@ -16,8 +16,8 @@ use crate::runtime::environment;
 #[cfg(test)]
 use crate::runtime::execution::short_state;
 use crate::runtime::execution::{
-    backoff_delay, classify_cargo_failure, pkg_key, registry_aware_backoff, resolve_state_dir,
-    update_state,
+    RegistryProfile, backoff_delay, classify_cargo_failure, pkg_key, registry_aware_backoff,
+    resolve_state_dir, update_state,
 };
 use crate::state::events;
 use crate::state::execution_state as state;
@@ -25,8 +25,9 @@ use crate::state::execution_state as state;
 use crate::types::ExecutionResult;
 use crate::types::{
     AttemptEvidence, ErrorClass, EventType, ExecutionState, Finishability, PackageProgress,
-    PackageReceipt, PackageState, PreflightPackage, PreflightReport, PublishEvent, PublishRegime,
-    ReadinessEvidence, Receipt, ReconciliationOutcome, Registry, RuntimeOptions,
+    PackageReceipt, PackageState, PreflightDurationEstimate, PreflightPackage, PreflightReport,
+    PublishEvent, PublishRegime, ReadinessEvidence, Receipt, ReconciliationOutcome, Registry,
+    RuntimeOptions,
 };
 use crate::webhook::{self, WebhookEvent};
 
@@ -486,18 +487,51 @@ pub fn run_preflight_in_place_with_options(
     });
     flush_events(&event_log, &events_path)?;
 
+    let estimated_publish_duration = estimate_preflight_duration(&ws.plan.registry.name, &packages);
+
     Ok(PreflightReport {
         plan_id: ws.plan.plan_id.clone(),
         token_detected,
         finishability,
         packages,
         timestamp: Utc::now(),
+        estimated_publish_duration,
         dry_run_output: if opts.verify_mode == VerifyMode::Workspace {
             Some(workspace_dry_run_output)
         } else {
             None
         },
     })
+}
+
+fn estimate_preflight_duration(
+    registry_name: &str,
+    packages: &[PreflightPackage],
+) -> Option<PreflightDurationEstimate> {
+    let profile = RegistryProfile::for_registry_name(registry_name);
+    let first_publish_refill = profile.first_publish_refill?;
+    let first_publish_burst = profile.first_publish_burst.unwrap_or(0) as usize;
+    let first_publish_count = packages.iter().filter(|p| p.is_new_crate).count();
+    let update_count = packages.len().saturating_sub(first_publish_count);
+    let paced_publishes = first_publish_count.saturating_sub(first_publish_burst);
+    let minimum_registry_pacing = multiply_duration(first_publish_refill, paced_publishes);
+
+    Some(PreflightDurationEstimate {
+        registry_profile: profile.name.to_string(),
+        first_publish_count,
+        update_count,
+        minimum_registry_pacing,
+        notes: vec![
+            "Estimate includes documented registry pacing only.".to_string(),
+            "It excludes build time, upload time, readiness polling, retries, and human pauses."
+                .to_string(),
+        ],
+    })
+}
+
+fn multiply_duration(duration: Duration, count: usize) -> Duration {
+    let count = u32::try_from(count).unwrap_or(u32::MAX);
+    duration.checked_mul(count).unwrap_or(Duration::MAX)
 }
 
 /// Enforce the rehearsal hard gate (#97 PR 3).
@@ -3624,6 +3658,47 @@ mod tests {
 
     // Preflight-specific tests
 
+    fn preflight_pkg(name: &str, is_new_crate: bool) -> PreflightPackage {
+        PreflightPackage {
+            name: name.to_string(),
+            version: "0.1.0".to_string(),
+            already_published: false,
+            is_new_crate,
+            auth_type: Some(AuthType::Token),
+            ownership_verified: true,
+            dry_run_passed: true,
+            dry_run_output: None,
+        }
+    }
+
+    #[test]
+    fn estimate_preflight_duration_accounts_for_crates_io_first_publish_burst() {
+        let packages: Vec<_> = (0..6)
+            .map(|i| preflight_pkg(&format!("crate-{i}"), true))
+            .collect();
+
+        let estimate = estimate_preflight_duration("crates-io", &packages)
+            .expect("crates.io profile should estimate");
+
+        assert_eq!(estimate.registry_profile, "crates-io");
+        assert_eq!(estimate.first_publish_count, 6);
+        assert_eq!(estimate.update_count, 0);
+        assert_eq!(estimate.minimum_registry_pacing, Duration::from_secs(600));
+        assert!(
+            estimate
+                .notes
+                .iter()
+                .any(|note| note.contains("documented registry pacing"))
+        );
+    }
+
+    #[test]
+    fn estimate_preflight_duration_is_none_for_unknown_registry() {
+        let packages = vec![preflight_pkg("demo", true)];
+
+        assert!(estimate_preflight_duration("private", &packages).is_none());
+    }
+
     #[test]
     fn preflight_report_serializes_correctly() {
         let report = PreflightReport {
@@ -3641,6 +3716,7 @@ mod tests {
                 dry_run_output: None,
             }],
             timestamp: Utc::now(),
+            estimated_publish_duration: None,
             dry_run_output: None,
         };
 
@@ -3669,6 +3745,7 @@ mod tests {
                 dry_run_output: None,
             }],
             timestamp: Utc::now(),
+            estimated_publish_duration: None,
             dry_run_output: None,
         };
 
@@ -3692,6 +3769,7 @@ mod tests {
                 dry_run_output: None,
             }],
             timestamp: Utc::now(),
+            estimated_publish_duration: None,
             dry_run_output: None,
         };
 
@@ -3715,6 +3793,7 @@ mod tests {
                 dry_run_output: None,
             }],
             timestamp: Utc::now(),
+            estimated_publish_duration: None,
             dry_run_output: None,
         };
 

--- a/crates/shipper-types/src/lib.rs
+++ b/crates/shipper-types/src/lib.rs
@@ -1827,8 +1827,35 @@ pub struct PreflightReport {
     pub finishability: Finishability,
     pub packages: Vec<PreflightPackage>,
     pub timestamp: DateTime<Utc>,
+    /// Minimum registry pacing estimate derived from package regimes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estimated_publish_duration: Option<PreflightDurationEstimate>,
     /// Detailed output from workspace-level dry-run verification
     pub dry_run_output: Option<String>,
+}
+
+/// Registry pacing estimate derived during preflight.
+///
+/// This is deliberately a lower-bound pacing estimate, not a full wall-clock
+/// release prediction. It excludes build time, upload time, readiness polling,
+/// network failures, human pauses, and retry jitter.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PreflightDurationEstimate {
+    /// Registry profile that produced the estimate.
+    pub registry_profile: String,
+    /// Packages that appear to be first publishes for this registry.
+    pub first_publish_count: usize,
+    /// Packages that appear to be version updates for this registry.
+    pub update_count: usize,
+    /// Minimum registry-imposed pacing time expected before all publishes can
+    /// be accepted.
+    #[serde(
+        deserialize_with = "deserialize_duration",
+        serialize_with = "serialize_duration"
+    )]
+    pub minimum_registry_pacing: Duration,
+    /// Human/agent-readable caveats for what this estimate excludes.
+    pub notes: Vec<String>,
 }
 
 /// Preflight status for a single package.
@@ -3230,6 +3257,7 @@ mod tests {
                     },
                 ],
                 timestamp: fixed_time(),
+                estimated_publish_duration: None,
                 dry_run_output: Some("workspace dry-run passed".to_string()),
             };
             insta::assert_yaml_snapshot!(report);
@@ -3883,6 +3911,7 @@ mod tests {
                     dry_run_output: Some("error: could not compile".to_string()),
                 }],
                 timestamp: fixed_time(),
+                estimated_publish_duration: None,
                 dry_run_output: Some("workspace dry-run failed".to_string()),
             };
             insta::assert_yaml_snapshot!(report);
@@ -3930,6 +3959,7 @@ mod tests {
                     finishability,
                     packages: packages.clone(),
                     timestamp: Utc::now(),
+                    estimated_publish_duration: None,
                     dry_run_output: Some("workspace dry-run output".to_string()),
                 };
 

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -41,6 +41,7 @@ make stronger claims than this file supports.
 | Ambiguous publish reconciliation | stable | `cargo test -p shipper-core reconcile --lib`; `cargo test -p shipper-core state --lib`; `cargo test -p shipper-cli --test bdd_publish`; `PublishReconciling` / `PublishReconciled` events | engine |
 | crates.io first-publish backoff profile | stable | `cargo test -p shipper-core runtime::execution --lib`; `cargo test -p shipper-core publish --lib`; `RegistryProfile::crates_io()` | engine |
 | Retry-After retry floor | stable | `cargo test -p shipper-core retry_after --lib`; `cargo test -p shipper-core publish --lib`; raw cargo stderr/stdout retry signal path | engine |
+| Preflight registry pacing estimate | stable | `cargo test -p shipper-core estimate_preflight_duration --lib`; `cargo test -p shipper-cli preflight`; `estimated_publish_duration` JSON field | engine/cli |
 | Resume under real interruption | planned | Future interruption rehearsal proof | engine |
 | Trusted Publishing default | planned/advisory | Future Trusted Publishing spec and #96 | release/ci |
 


### PR DESCRIPTION
## Summary
- add structured preflight registry pacing estimates as estimated_publish_duration
- compute crates.io minimum first-publish pacing from the RegistryProfile burst/refill model
- surface the estimate in human preflight output, JSON output, roadmap, and support tiers

## Validation
- cargo fmt --all -- --check
- cargo test -p shipper-core estimate_preflight_duration --lib --locked
- cargo test -p shipper-core preflight --lib --locked
- cargo test -p shipper-types --locked
- cargo test -p shipper-cli preflight --locked
- cargo clippy -p shipper-core --all-targets --locked -- -D warnings
- cargo clippy -p shipper-cli --all-targets --locked -- -D warnings
- cargo clippy -p shipper-types --all-targets --locked -- -D warnings
- cargo xtask policy-report
- cargo xtask check-file-policy --mode blocking-allowlist
- git diff --check