### PR TITLE
ci(packaging): smoke-test shipper install facade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,38 @@ jobs:
           path: target/nextest/ci/junit.xml
           retention-days: 14
 
+  install-smoke:
+    name: Install Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-install-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-install-
+
+      - name: Install shipper facade crate
+        run: |
+          cargo install --path crates/shipper --locked --root "$RUNNER_TEMP/shipper-install"
+          echo "$RUNNER_TEMP/shipper-install/bin" >> "$GITHUB_PATH"
+
+      - name: Verify installed shipper
+        run: |
+          shipper --version
+          shipper --help
+          shipper doctor --help
+          shipper plan --help
+          shipper preflight --help
+
   crypto-proptests-heavy:
     name: Crypto Proptests (full strength, ubuntu)
     # Deep crypto proving lane. The PR matrix above runs proptests with

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
   # The dogfood publish train.
   #
   # Execution order:
-  #   1.  Build shipper (release profile) and install it to PATH.
+  #   1.  Install shipper from the supported facade crate and verify it.
   #   2.  `shipper plan`  — persist plan to .shipper/, also dump JSON to
   #       .shipper/plan.json for artifact review.
   #   3.  Upload .shipper/ as an artifact BEFORE preflight runs (belt-and-
@@ -234,13 +234,14 @@ jobs:
           key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-publish-
 
-      # --- Step 1: build and install shipper ----------------------------
-      - name: Build shipper (release)
-        run: cargo build --release -p shipper
-
-      - name: Install shipper to PATH
+      # --- Step 1: install shipper from the supported facade crate ---------
+      - name: Install shipper facade crate
         run: |
-          sudo install -m 0755 target/release/shipper /usr/local/bin/shipper
+          cargo install --path crates/shipper --locked --root "$RUNNER_TEMP/shipper-install"
+          echo "$RUNNER_TEMP/shipper-install/bin" >> "$GITHUB_PATH"
+
+      - name: Verify installed shipper
+        run: |
           shipper --version
 
       # --- Step 2: plan -----------------------------------------------------
@@ -472,12 +473,13 @@ jobs:
           key: ${{ runner.os }}-cargo-rehearse-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-rehearse-
 
-      - name: Build shipper (release)
-        run: cargo build --release -p shipper
-
-      - name: Install shipper to PATH
+      - name: Install shipper facade crate
         run: |
-          sudo install -m 0755 target/release/shipper /usr/local/bin/shipper
+          cargo install --path crates/shipper --locked --root "$RUNNER_TEMP/shipper-install"
+          echo "$RUNNER_TEMP/shipper-install/bin" >> "$GITHUB_PATH"
+
+      - name: Verify installed shipper
+        run: |
           shipper --version
 
       - name: shipper plan (verbose)
@@ -566,12 +568,13 @@ jobs:
           key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-publish-
 
-      - name: Build shipper (release)
-        run: cargo build --release -p shipper
-
-      - name: Install shipper to PATH
+      - name: Install shipper facade crate
         run: |
-          sudo install -m 0755 target/release/shipper /usr/local/bin/shipper
+          cargo install --path crates/shipper --locked --root "$RUNNER_TEMP/shipper-install"
+          echo "$RUNNER_TEMP/shipper-install/bin" >> "$GITHUB_PATH"
+
+      - name: Verify installed shipper
+        run: |
           shipper --version
 
       - name: Download prior .shipper/ state

--- a/README.md
+++ b/README.md
@@ -18,10 +18,25 @@ Publishing a multi-crate Rust workspace is easy to start and hard to trust. Ship
 - Reconciles ambiguous `cargo publish` outcomes against registry truth instead of blind-retrying.
 - Records events, state, and receipts for post-run auditing and remediation.
 
-## Try it
+## Install
+
+Shipper's supported install handle is the product facade crate:
 
 ```bash
 cargo install shipper --locked
+shipper --version
+```
+
+For local checkout validation before a release, use the same facade crate:
+
+```bash
+cargo install --path crates/shipper --locked
+shipper --help
+```
+
+## Try it
+
+```bash
 shipper plan        # preview the publish order
 shipper preflight   # check readiness
 shipper publish     # execute the plan
@@ -34,7 +49,7 @@ Shipper does not decide version numbers, generate changelogs, tag releases, or c
 
 ## Where to go next
 
-- **Learn** → [docs/tutorials](docs/tutorials) (first publish, recovery walkthrough)
+- **Learn** → [docs/tutorials](docs/tutorials) (five-minute confidence path, first publish, recovery walkthrough)
 - **Do** → [docs/how-to](docs/how-to) (CI integration, stalled-run triage, remediation)
 - **Look up** → [docs/reference](docs/reference) (CLI, state files, `.shipper.toml`)
 - **Understand** → [docs/explanation](docs/explanation) (why Shipper, `not_proven`, invariants)

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Organized by reader purpose ([Diátaxis](https://diataxis.fr/)). Pick the column
 Step-by-step learning paths. Start here if you've never used Shipper before.
 
 - [First publish — from a toy workspace](tutorials/first-publish.md)
+- [Getting to release confidence in five minutes](tutorials/getting-started-5-minutes.md)
 - [Recover from an interrupted release](tutorials/recover-from-interruption.md)
 
 ## How-to guides

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -32,6 +32,7 @@ make stronger claims than this file supports.
 | Claim | Tier | Proof / Source | Owner |
 |---|---|---|---|
 | Facade / CLI / core crate boundary | stable/internal | `docs/architecture.md`; `cargo xtask package-surface`; `crates/shipper/Cargo.toml`; `crates/shipper-cli/Cargo.toml`; `crates/shipper-core/Cargo.toml` | architecture |
+| `cargo install shipper` install facade | stable | `cargo install --path crates/shipper --locked`; CI `Install Smoke` job; `shipper --version`; `shipper --help`; `shipper doctor --help`; `shipper plan --help`; `shipper preflight --help` | packaging/ux |
 | Manifest-level topological publish planning | stable | Planner regression tests; `shipper plan`; roadmap #109 | engine |
 | File-policy enforcement | stable/internal | `cargo xtask check-file-policy --mode blocking-allowlist`; `cargo xtask policy-report`; CI `Policy` job | release/ci |
 | Rust 1.95 / 0.4 policy floor | stable/internal | Workspace lints; `cargo xtask check-lint-policy`; `cargo clippy --workspace --all-targets --all-features -- -D warnings` | rust/lints |

--- a/docs/tutorials/first-publish.md
+++ b/docs/tutorials/first-publish.md
@@ -25,7 +25,9 @@ In this tutorial you will publish a two-crate workspace to crates.io using Shipp
 cargo install shipper --locked
 ```
 
-> The binary is named `shipper`; the published crate is `shipper-cli`. [Issue #95](https://github.com/EffortlessMetrics/shipper/issues/95) tracks making `cargo install shipper` work.
+> The binary is named `shipper`; the supported install package is the `shipper`
+> facade crate. `shipper-cli` remains available for embedders that need the
+> exact CLI adapter surface.
 
 Confirm:
 

--- a/docs/tutorials/getting-started-5-minutes.md
+++ b/docs/tutorials/getting-started-5-minutes.md
@@ -1,0 +1,88 @@
+# Tutorial: Getting to release confidence in five minutes
+
+This path gets a maintainer from a fresh install to a decision-grade local
+release check. It does not publish. Use it when you want to know what Shipper
+will do and which proof gaps remain before the first irreversible command.
+
+## What you'll need
+
+- Rust 1.95 or newer.
+- A Rust workspace with publishable crates.
+- A clean git working tree, unless you intend to pass `--allow-dirty`.
+- A crates.io token if you want ownership and authenticated registry checks.
+
+## 1. Install Shipper
+
+```bash
+cargo install shipper --locked
+shipper --version
+```
+
+If you are validating this repository from a checkout before release:
+
+```bash
+cargo install --path crates/shipper --locked
+shipper --help
+```
+
+## 2. Ask Doctor for local blockers
+
+```bash
+cd /path/to/your/workspace
+shipper doctor
+```
+
+Treat blocked findings as setup work before planning a publish. Common first
+fixes are logging in to crates.io, cleaning the git tree, or adding missing
+package metadata.
+
+## 3. Generate the publish plan
+
+```bash
+shipper plan
+```
+
+Confirm the publishable crates, skipped crates, and dependency-ordered publish
+sequence match your intent. The `plan_id` is the release fingerprint Shipper
+uses to prevent resuming against a different workspace state.
+
+## 4. Run preflight
+
+```bash
+shipper preflight
+```
+
+Read the finishability result as a release decision:
+
+| Result | Meaning | Next action |
+|---|---|---|
+| `Proven` | Local packaging and registry checks passed for the configured policy. | You can proceed to `shipper publish` if the version and changelog are already final. |
+| `NotProven` | Nothing definitive failed, but at least one proof cannot be completed locally. | Review the listed gaps, then decide whether to publish, add rehearsal proof, or change policy. |
+| `Failed` | A blocker was found before publish. | Fix the finding and rerun `shipper preflight`. |
+
+## 5. Stop before the irreversible step
+
+Do not run `shipper publish` until the versioning, changelog, tag, release
+approval, and proof gaps are intentionally settled. If you do proceed, Shipper
+writes the release evidence under `.shipper/`, including state, events, and the
+final receipt.
+
+Useful follow-up commands:
+
+```bash
+shipper publish
+shipper resume
+shipper inspect-events
+shipper inspect-receipt
+```
+
+## Evidence to keep
+
+After this five-minute path, keep the terminal output from:
+
+- `shipper doctor`
+- `shipper plan`
+- `shipper preflight`
+
+When JSON output is required for CI or an internal developer portal, prefer the
+command's `--format json` option where available.

--- a/policy/process-allowlist.toml
+++ b/policy/process-allowlist.toml
@@ -25,6 +25,7 @@ allowed_processes = [
   "cargo",
   "rustup",
   "rustc",
+  "shipper",
   "cargo-fuzz",
   "cargo-mutants",
   "cargo-llvm-cov",
@@ -34,7 +35,7 @@ allowed_processes = [
   "python3",
 ]
 owner = "release/ci"
-reason = "CI compiles, lints, tests, fuzzes, and measures coverage on the Rust workspace. Tools (cargo-fuzz, cargo-mutants, cargo-llvm-cov, cargo-nextest) are installed via taiki-e/install-action. `sudo` is used for cross-compile prep (apt-get install gcc-aarch64-linux-gnu); `mkdir` for ad-hoc directory creation; `python3` for small helper scripts."
+reason = "CI compiles, lints, tests, fuzzes, measures coverage, and smoke-tests the supported `cargo install --path crates/shipper --locked` facade path. Tools (cargo-fuzz, cargo-mutants, cargo-llvm-cov, cargo-nextest) are installed via taiki-e/install-action. `shipper` is the locally installed facade binary used only by the install-smoke job. `sudo` is used for cross-compile prep (apt-get install gcc-aarch64-linux-gnu); `mkdir` for ad-hoc directory creation; `python3` for small helper scripts."
 created = "2026-05-11"
 review_after = "2026-08-11"
 
@@ -54,12 +55,10 @@ allowed_processes = [
   "gh",
   "tar",
   "sha256sum",
-  "install",
-  "sudo",
   "mkdir",
 ]
 owner = "release/ci"
-reason = "Release workflow dogfoods shipper itself, builds the release binary, packages it (tar + sha256sum), installs it to PATH (via install / sudo), and creates the GitHub release with gh. Trusted Publishing supplies registry credentials via OIDC."
+reason = "Release workflow dogfoods shipper itself, installs the supported facade path with `cargo install --path crates/shipper --locked`, packages release binaries (tar + sha256sum), and creates the GitHub release with gh. Trusted Publishing supplies registry credentials via OIDC."
 created = "2026-05-11"
 review_after = "2026-08-11"
 


### PR DESCRIPTION
## Summary
- add an explicit install section and five-minute release-confidence tutorial for the supported `shipper` facade install path
- add a CI Install Smoke job that runs `cargo install --path crates/shipper --locked` and verifies the installed CLI help surfaces
- make the release workflow dogfood the same facade install path before plan/preflight/publish/resume, and update the process-policy/support-tier receipts

## Validation
- `cargo xtask check-workflow-surfaces --mode blocking-allowlist`
- `cargo xtask check-process-policy --mode blocking-allowlist`
- `cargo xtask check-network-policy --mode blocking-allowlist`
- `cargo xtask check-file-policy --mode blocking-allowlist`
- `cargo xtask policy-report`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo install --path crates/shipper --locked --root H:\Code\Rust\.cargo-installs\shipper-install-path`
- installed `shipper --version`, `shipper --help`, `shipper doctor --help`, `shipper plan --help`, `shipper preflight --help`

## Notes
- No engine/runtime behavior changes.
- This PR keeps the install claim narrow: the facade installs and the key first-run help surfaces execute.