### PR TITLE
feat(cli): add release-plan error hints

### DIFF
--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -665,7 +665,13 @@ pub fn run() -> Result<()> {
         },
     };
 
-    let mut planned = plan::build_plan(&spec)?;
+    let command_name = cli
+        .cmd
+        .as_ref()
+        .map(command_name_for_hint)
+        .unwrap_or("command");
+    let mut planned = plan::build_plan(&spec)
+        .with_context(|| plan_failure_hint(&spec.manifest_path, &cli.packages, command_name))?;
 
     // Load configuration file
     let config =
@@ -1402,6 +1408,48 @@ fn resume_failure_hint(state_dir: &Path) -> String {
          * run `shipper status` to compare local versions to the registry",
         dir = state_dir.display()
     )
+}
+
+fn plan_failure_hint(manifest_path: &Path, packages: &[String], command_name: &str) -> String {
+    let mut hint = format!(
+        "failed to load release plan for `{command_name}` - next steps:\n  \
+         * verify `--manifest-path` points at the workspace Cargo.toml: {}\n  \
+         * run `cargo metadata --manifest-path \"{}\"` to inspect the underlying Cargo error",
+        manifest_path.display(),
+        manifest_path.display()
+    );
+
+    if packages.is_empty() {
+        hint.push_str("\n  * run `shipper plan` first to inspect publishable and skipped crates");
+    } else {
+        hint.push_str(
+            "\n  * run `shipper plan` without `--package` to list publishable crates\n  \
+             * verify each selected `--package` is publishable and not marked `publish = false`",
+        );
+    }
+
+    hint
+}
+
+fn command_name_for_hint(command: &Commands) -> &'static str {
+    match command {
+        Commands::Plan => "plan",
+        Commands::Preflight { .. } => "preflight",
+        Commands::Publish => "publish",
+        Commands::Resume => "resume",
+        Commands::Rehearse => "rehearse",
+        Commands::Status => "status",
+        Commands::Doctor => "doctor",
+        Commands::InspectEvents => "inspect-events",
+        Commands::InspectReceipt => "inspect-receipt",
+        Commands::Ci(_) => "ci",
+        Commands::Clean { .. } => "clean",
+        Commands::Yank { .. } => "yank",
+        Commands::PlanYank { .. } => "plan-yank",
+        Commands::FixForward { .. } => "fix-forward",
+        Commands::Config(_) => "config",
+        Commands::Completion { .. } => "completion",
+    }
 }
 
 fn parse_duration(s: &str) -> Result<Duration> {

--- a/crates/shipper-cli/tests/e2e_expanded.rs
+++ b/crates/shipper-cli/tests/e2e_expanded.rs
@@ -962,7 +962,10 @@ fn error_nonexistent_package_snapshot() {
 
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert_snapshot!("error_nonexistent_package", normalize_stderr(&stderr));
+    assert_snapshot!(
+        "error_nonexistent_package",
+        normalize_tempdir_stderr(&stderr, td.path())
+    );
 }
 
 /// Snapshot: error when an invalid --retry-strategy value is provided.

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__error_nonexistent_package.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__error_nonexistent_package.snap
@@ -1,5 +1,12 @@
 ---
 source: crates/shipper-cli/tests/e2e_expanded.rs
-expression: normalize_stderr(&stderr)
+expression: "normalize_tempdir_stderr(&stderr, td.path())"
 ---
-Error: selected package not found or not publishable: nonexistent
+Error: failed to load release plan for `plan` - next steps:
+  * verify `--manifest-path` points at the workspace Cargo.toml: <TMPDIR>/Cargo.toml
+  * run `cargo metadata --manifest-path "<TMPDIR>/Cargo.toml"` to inspect the underlying Cargo error
+  * run `shipper plan` without `--package` to list publishable crates
+  * verify each selected `--package` is publishable and not marked `publish = false`
+
+Caused by:
+    selected package not found or not publishable: nonexistent

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__publish_invalid_manifest_content.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__publish_invalid_manifest_content.snap
@@ -2,11 +2,15 @@
 source: crates/shipper-cli/tests/e2e_expanded.rs
 expression: "normalize_stderr(&stderr.replace(td.path().to_str().unwrap(),\n\"<TMPDIR>\").replace(&td.path().to_str().unwrap().replace('\\\\', \"/\"),\n\"<TMPDIR>\",),)"
 ---
-Error: failed to execute cargo metadata
+Error: failed to load release plan for `publish` - next steps:
+  * verify `--manifest-path` points at the workspace Cargo.toml: <TMPDIR>/Cargo.toml
+  * run `cargo metadata --manifest-path "<TMPDIR>/Cargo.toml"` to inspect the underlying Cargo error
+  * run `shipper plan` first to inspect publishable and skipped crates
 
 Caused by:
-    `cargo metadata` exited with an error: error: key with no value, expected `=`
-     --> <TMPDIR>/Cargo.toml:1:6
-      |
-    1 | this is not valid toml {{{{
-      |      ^
+    0: failed to execute cargo metadata
+    1: `cargo metadata` exited with an error: error: key with no value, expected `=`
+        --> <TMPDIR>/Cargo.toml:1:6
+         |
+       1 | this is not valid toml {{{{
+         |      ^

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__publish_missing_manifest.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__publish_missing_manifest.snap
@@ -2,7 +2,11 @@
 source: crates/shipper-cli/tests/e2e_expanded.rs
 expression: "normalize_tempdir_stderr(&stderr, td.path())"
 ---
-Error: failed to execute cargo metadata
+Error: failed to load release plan for `publish` - next steps:
+  * verify `--manifest-path` points at the workspace Cargo.toml: <TMPDIR>/no-such/Cargo.toml
+  * run `cargo metadata --manifest-path "<TMPDIR>/no-such/Cargo.toml"` to inspect the underlying Cargo error
+  * run `shipper plan` first to inspect publishable and skipped crates
 
 Caused by:
-    `cargo metadata` exited with an error: error: manifest path `<TMPDIR>/no-such/Cargo.toml` does not exist
+    0: failed to execute cargo metadata
+    1: `cargo metadata` exited with an error: error: manifest path `<TMPDIR>/no-such/Cargo.toml` does not exist

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__resume_missing_manifest.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__resume_missing_manifest.snap
@@ -2,7 +2,11 @@
 source: crates/shipper-cli/tests/e2e_expanded.rs
 expression: "normalize_tempdir_stderr(&stderr, td.path())"
 ---
-Error: failed to execute cargo metadata
+Error: failed to load release plan for `resume` - next steps:
+  * verify `--manifest-path` points at the workspace Cargo.toml: <TMPDIR>/nonexistent/Cargo.toml
+  * run `cargo metadata --manifest-path "<TMPDIR>/nonexistent/Cargo.toml"` to inspect the underlying Cargo error
+  * run `shipper plan` first to inspect publishable and skipped crates
 
 Caused by:
-    `cargo metadata` exited with an error: error: manifest path `<TMPDIR>/nonexistent/Cargo.toml` does not exist
+    0: failed to execute cargo metadata
+    1: `cargo metadata` exited with an error: error: manifest path `<TMPDIR>/nonexistent/Cargo.toml` does not exist


### PR DESCRIPTION
Summary:
- add release-plan loading context with command-specific next actions
- include package-filter guidance for invalid --package selections
- update CLI snapshots for missing/invalid manifest and package-selection errors

Validation:
- cargo fmt --all -- --check
- cargo test -p shipper-cli --test e2e_expanded --locked
- cargo clippy -p shipper-cli --all-targets --locked -- -D warnings
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask policy-report
- git diff --check