### PR TITLE
feat(plan): make plan output decision-grade

### DIFF
--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -34,11 +34,15 @@ use std::time::Duration;
 use anyhow::{Context, Result, bail};
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::Shell;
+use serde::Serialize;
 
 use shipper_core::config::{CliOverrides, ShipperConfig};
 use shipper_core::engine::{self, Reporter};
 use shipper_core::plan;
-use shipper_core::types::{Finishability, PreflightReport, Registry, ReleaseSpec, RuntimeOptions};
+use shipper_core::types::{
+    Finishability, PlannedPackage, PreflightReport, Registry, ReleasePlan, ReleaseSpec,
+    RuntimeOptions,
+};
 
 mod output;
 
@@ -797,7 +801,7 @@ pub fn run() -> Result<()> {
 
     match cli.cmd.expect("subcommand checked above") {
         Commands::Plan => {
-            print_plan(&planned, cli.verbose);
+            print_plan(&planned, cli.verbose, &cli.format);
         }
         Commands::Preflight { preflight_only } => {
             let rep = engine::run_preflight_in_place_with_options(
@@ -1502,7 +1506,53 @@ fn print_version(verbose: bool) {
     }
 }
 
-fn print_plan(ws: &plan::PlannedWorkspace, verbose: bool) {
+#[derive(Debug, Serialize)]
+struct PlanReport {
+    plan_id: String,
+    registry: PlanRegistryReport,
+    workspace_root: String,
+    publishable_count: usize,
+    skipped_count: usize,
+    internal_dependency_edges: usize,
+    publish_levels: usize,
+    packages: Vec<PlanPackageReport>,
+    skipped: Vec<PlanSkippedPackageReport>,
+}
+
+#[derive(Debug, Serialize)]
+struct PlanRegistryReport {
+    name: String,
+    api_base: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    index_base: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct PlanPackageReport {
+    order: usize,
+    name: String,
+    version: String,
+    manifest_path: String,
+    level: Option<usize>,
+    dependencies: Vec<String>,
+    order_reason: String,
+}
+
+#[derive(Debug, Serialize)]
+struct PlanSkippedPackageReport {
+    name: String,
+    version: String,
+    reason: String,
+}
+
+fn print_plan(ws: &plan::PlannedWorkspace, verbose: bool, format: &str) {
+    if format == "json" {
+        let report = build_plan_report(ws);
+        let json = serde_json::to_string_pretty(&report).expect("serialize plan report");
+        println!("{}", json);
+        return;
+    }
+
     println!("plan_id: {}", ws.plan.plan_id);
     println!(
         "registry: {} ({})",
@@ -1513,6 +1563,14 @@ fn print_plan(ws: &plan::PlannedWorkspace, verbose: bool) {
 
     let total_packages = ws.plan.packages.len();
     println!("Total packages to publish: {}", total_packages);
+    println!("Plan summary:");
+    println!("  Publishable packages: {}", total_packages);
+    println!("  Skipped packages: {}", ws.skipped.len());
+    println!(
+        "  Internal dependency edges: {}",
+        internal_dependency_edges(&ws.plan)
+    );
+    println!("  Publish levels: {}", ws.plan.group_by_levels().len());
     println!();
 
     if !ws.skipped.is_empty() {
@@ -1529,9 +1587,103 @@ fn print_plan(ws: &plan::PlannedWorkspace, verbose: bool) {
     } else {
         // Simple output
         for (idx, p) in ws.plan.packages.iter().enumerate() {
-            println!("{:>3}. {}@{}", idx + 1, p.name, p.version);
+            println!(
+                "{:>3}. {}@{} ({})",
+                idx + 1,
+                p.name,
+                p.version,
+                dependency_summary(&ws.plan, p)
+            );
         }
     }
+}
+
+fn build_plan_report(ws: &plan::PlannedWorkspace) -> PlanReport {
+    let levels = ws.plan.group_by_levels();
+    let packages = ws
+        .plan
+        .packages
+        .iter()
+        .enumerate()
+        .map(|(idx, package)| {
+            let dependencies = dependency_names(&ws.plan, package);
+            let level = levels
+                .iter()
+                .find(|level| {
+                    level
+                        .packages
+                        .iter()
+                        .any(|level_pkg| level_pkg.name == package.name)
+                })
+                .map(|level| level.level);
+
+            PlanPackageReport {
+                order: idx + 1,
+                name: package.name.clone(),
+                version: package.version.clone(),
+                manifest_path: package.manifest_path.display().to_string(),
+                level,
+                dependencies,
+                order_reason: dependency_summary(&ws.plan, package),
+            }
+        })
+        .collect();
+
+    let skipped = ws
+        .skipped
+        .iter()
+        .map(|package| PlanSkippedPackageReport {
+            name: package.name.clone(),
+            version: package.version.clone(),
+            reason: package.reason.clone(),
+        })
+        .collect();
+
+    PlanReport {
+        plan_id: ws.plan.plan_id.clone(),
+        registry: PlanRegistryReport {
+            name: ws.plan.registry.name.clone(),
+            api_base: ws.plan.registry.api_base.clone(),
+            index_base: ws.plan.registry.index_base.clone(),
+        },
+        workspace_root: ws.workspace_root.display().to_string(),
+        publishable_count: ws.plan.packages.len(),
+        skipped_count: ws.skipped.len(),
+        internal_dependency_edges: internal_dependency_edges(&ws.plan),
+        publish_levels: levels.len(),
+        packages,
+        skipped,
+    }
+}
+
+fn internal_dependency_edges(plan: &ReleasePlan) -> usize {
+    plan.dependencies.values().map(Vec::len).sum()
+}
+
+fn dependency_summary(plan: &ReleasePlan, package: &PlannedPackage) -> String {
+    let dependencies = dependency_names(plan, package);
+    if dependencies.is_empty() {
+        "no workspace dependencies".to_string()
+    } else {
+        format!("depends on: {}", dependencies.join(", "))
+    }
+}
+
+fn dependency_names(plan: &ReleasePlan, package: &PlannedPackage) -> Vec<String> {
+    plan.dependencies
+        .get(&package.name)
+        .map(|dependencies| {
+            dependencies
+                .iter()
+                .filter_map(|dependency| {
+                    plan.packages
+                        .iter()
+                        .find(|candidate| candidate.name == *dependency)
+                        .map(|candidate| format!("{}@{}", candidate.name, candidate.version))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn print_detailed_plan(ws: &plan::PlannedWorkspace) {
@@ -1559,24 +1711,13 @@ fn print_detailed_plan(ws: &plan::PlannedWorkspace) {
     println!("Dependency Graph:");
     println!();
     for (idx, p) in ws.plan.packages.iter().enumerate() {
-        let deps = ws.plan.dependencies.get(&p.name);
-        let deps_str = match deps {
-            Some(deps) if !deps.is_empty() => {
-                let dep_versions: Vec<String> = deps
-                    .iter()
-                    .filter_map(|dep_name| {
-                        ws.plan
-                            .packages
-                            .iter()
-                            .find(|pkg| &pkg.name == dep_name)
-                            .map(|pkg| format!("{}@{}", dep_name, pkg.version))
-                    })
-                    .collect();
-                format!("depends on: {}", dep_versions.join(", "))
-            }
-            _ => String::from("no workspace dependencies"),
-        };
-        println!("  {:>3}. {}@{} ({})", idx + 1, p.name, p.version, deps_str);
+        println!(
+            "  {:>3}. {}@{} ({})",
+            idx + 1,
+            p.name,
+            p.version,
+            dependency_summary(&ws.plan, p)
+        );
     }
     println!();
 

--- a/crates/shipper-cli/tests/bdd_workflow.rs
+++ b/crates/shipper-cli/tests/bdd_workflow.rs
@@ -3063,12 +3063,12 @@ mod plan_quiet_mode {
 mod plan_json_format {
     use super::*;
 
-    // Scenario: Plan with --format json still succeeds (plan uses text output)
+    // Scenario: Plan with --format json emits the decision-grade plan contract
     //
     // Given: a workspace with core-lib, utils-lib, top-app
     // When: I run "shipper plan --format json"
     // Then: exit code is 0
-    // And: stdout contains the plan data (plan always uses text format)
+    // And: stdout is structured JSON with graph counts and dependency reasons
     #[test]
     fn given_multi_crate_when_plan_json_then_valid_json_output() {
         let td = tempdir().expect("tempdir");
@@ -3087,14 +3087,32 @@ mod plan_json_format {
             .clone();
 
         let stdout = String::from_utf8(output).expect("utf8");
-        // Plan command outputs text format regardless of --format flag
-        assert!(
-            stdout.contains("core-lib@0.1.0"),
-            "plan output should contain core-lib, got: {stdout}"
+        let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid plan JSON");
+
+        assert!(json["plan_id"].is_string(), "missing plan_id: {stdout}");
+        assert_eq!(json["publishable_count"].as_u64(), Some(3));
+        assert_eq!(json["skipped_count"].as_u64(), Some(0));
+        assert_eq!(json["internal_dependency_edges"].as_u64(), Some(3));
+        assert_eq!(json["publish_levels"].as_u64(), Some(3));
+
+        let packages = json["packages"].as_array().expect("packages array");
+        assert_eq!(packages.len(), 3, "unexpected packages: {stdout}");
+        assert_eq!(packages[0]["name"].as_str(), Some("core-lib"));
+        assert_eq!(
+            packages[0]["order_reason"].as_str(),
+            Some("no workspace dependencies")
         );
-        assert!(
-            stdout.contains("Total packages to publish:"),
-            "plan output should contain package count, got: {stdout}"
+        assert_eq!(packages[1]["name"].as_str(), Some("utils-lib"));
+        assert_eq!(
+            packages[1]["dependencies"]
+                .as_array()
+                .expect("dependencies")[0]
+                .as_str(),
+            Some("core-lib@0.1.0")
+        );
+        assert_eq!(
+            packages[2]["order_reason"].as_str(),
+            Some("depends on: core-lib@0.1.0, utils-lib@0.1.0")
         );
     }
 }

--- a/crates/shipper-cli/tests/cli_e2e.rs
+++ b/crates/shipper-cli/tests/cli_e2e.rs
@@ -186,8 +186,13 @@ fn plan_command_snapshot() {
     workspace_root: <WORKSPACE_ROOT>
 
     Total packages to publish: 1
+    Plan summary:
+      Publishable packages: 1
+      Skipped packages: 0
+      Internal dependency edges: 0
+      Publish levels: 1
 
-      1. demo@0.1.0
+      1. demo@0.1.0 (no workspace dependencies)
     "
     );
 }

--- a/crates/shipper-cli/tests/e2e_expanded.rs
+++ b/crates/shipper-cli/tests/e2e_expanded.rs
@@ -175,6 +175,17 @@ fn normalize_tempdir_stderr(raw: &str, tempdir: &Path) -> String {
     )
 }
 
+fn normalize_tempdir_json_output(raw: &str, tempdir: &Path) -> String {
+    let tempdir = tempdir.to_string_lossy();
+    let escaped_tempdir = tempdir.replace('\\', "\\\\");
+    normalize_output(
+        &raw.replace(&escaped_tempdir, "<WORKSPACE_ROOT>")
+            .replace(tempdir.as_ref(), "<WORKSPACE_ROOT>")
+            .replace(&tempdir.replace('\\', "/"), "<WORKSPACE_ROOT>")
+            .replace("\\\\", "/"),
+    )
+}
+
 /// Create a simple workspace with a single publishable crate.
 fn create_workspace(root: &Path) {
     write_file(
@@ -2522,7 +2533,10 @@ fn plan_format_json_flag_snapshot() {
         .clone();
 
     let stdout = String::from_utf8(output).expect("utf8");
-    assert_snapshot!("plan_format_json_flag", normalize_output(&stdout));
+    assert_snapshot!(
+        "plan_format_json_flag",
+        normalize_tempdir_json_output(&stdout, td.path())
+    );
 }
 
 // ===========================================================================
@@ -3285,7 +3299,10 @@ fn plan_format_json_multi_crate_snapshot() {
         .clone();
 
     let stdout = String::from_utf8(output).expect("utf8");
-    assert_snapshot!("plan_format_json_multi_crate", normalize_output(&stdout));
+    assert_snapshot!(
+        "plan_format_json_multi_crate",
+        normalize_tempdir_json_output(&stdout, td.path())
+    );
 }
 
 // ===========================================================================

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_all_publish_false.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_all_publish_false.snap
@@ -7,6 +7,11 @@ registry: crates-io (https://crates.io)
 workspace_root: <WORKSPACE_ROOT>
 
 Total packages to publish: 0
+Plan summary:
+  Publishable packages: 0
+  Skipped packages: 2
+  Internal dependency edges: 0
+  Publish levels: 0
 
 Skipped packages:
   - internal-a@0.1.0 (publish = false)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_deeply_nested_crate.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_deeply_nested_crate.snap
@@ -7,5 +7,10 @@ registry: crates-io (https://crates.io)
 workspace_root: <WORKSPACE_ROOT>
 
 Total packages to publish: 1
+Plan summary:
+  Publishable packages: 1
+  Skipped packages: 0
+  Internal dependency edges: 0
+  Publish levels: 1
 
-  1. deep-crate@1.0.0
+  1. deep-crate@1.0.0 (no workspace dependencies)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_format_json_flag.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_format_json_flag.snap
@@ -1,11 +1,28 @@
 ---
 source: crates/shipper-cli/tests/e2e_expanded.rs
-expression: normalize_output(&stdout)
+expression: "normalize_tempdir_json_output(&stdout, td.path())"
 ---
-plan_id: <PLAN_ID>
-registry: crates-io (https://crates.io)
-workspace_root: <WORKSPACE_ROOT>
-
-Total packages to publish: 1
-
-  1. demo@0.1.0
+{
+  "plan_id": "affac35fb544fb5b3de322fb4c6b26c2be6c9bf3eb7d7edd4af4a29b7b59fd3f",
+  "registry": {
+    "name": "crates-io",
+    "api_base": "https://crates.io"
+  },
+  "workspace_root": "<WORKSPACE_ROOT>",
+  "publishable_count": 1,
+  "skipped_count": 0,
+  "internal_dependency_edges": 0,
+  "publish_levels": 1,
+  "packages": [
+    {
+      "order": 1,
+      "name": "demo",
+      "version": "0.1.0",
+      "manifest_path": "<WORKSPACE_ROOT>/demo/Cargo.toml",
+      "level": 0,
+      "dependencies": [],
+      "order_reason": "no workspace dependencies"
+    }
+  ],
+  "skipped": []
+}

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_format_json_multi_crate.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_format_json_multi_crate.snap
@@ -1,13 +1,50 @@
 ---
 source: crates/shipper-cli/tests/e2e_expanded.rs
-expression: normalize_output(&stdout)
+expression: "normalize_tempdir_json_output(&stdout, td.path())"
 ---
-plan_id: <PLAN_ID>
-registry: crates-io (https://crates.io)
-workspace_root: <WORKSPACE_ROOT>
-
-Total packages to publish: 3
-
-  1. core-lib@0.2.0
-  2. mid-lib@0.3.0
-  3. top-app@0.4.0
+{
+  "plan_id": "f50f53d98fbd6f2bb7b4a3bbb9e0abf353d277d4c3e6766ec6cd331a78b9c268",
+  "registry": {
+    "name": "crates-io",
+    "api_base": "https://crates.io"
+  },
+  "workspace_root": "<WORKSPACE_ROOT>",
+  "publishable_count": 3,
+  "skipped_count": 0,
+  "internal_dependency_edges": 2,
+  "publish_levels": 3,
+  "packages": [
+    {
+      "order": 1,
+      "name": "core-lib",
+      "version": "0.2.0",
+      "manifest_path": "<WORKSPACE_ROOT>/core-lib/Cargo.toml",
+      "level": 0,
+      "dependencies": [],
+      "order_reason": "no workspace dependencies"
+    },
+    {
+      "order": 2,
+      "name": "mid-lib",
+      "version": "0.3.0",
+      "manifest_path": "<WORKSPACE_ROOT>/mid-lib/Cargo.toml",
+      "level": 1,
+      "dependencies": [
+        "core-lib@0.2.0"
+      ],
+      "order_reason": "depends on: core-lib@0.2.0"
+    },
+    {
+      "order": 3,
+      "name": "top-app",
+      "version": "0.4.0",
+      "manifest_path": "<WORKSPACE_ROOT>/top-app/Cargo.toml",
+      "level": 2,
+      "dependencies": [
+        "mid-lib@0.3.0"
+      ],
+      "order_reason": "depends on: mid-lib@0.3.0"
+    }
+  ],
+  "skipped": []
+}

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_multi_crate.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_multi_crate.snap
@@ -7,7 +7,12 @@ registry: crates-io (https://crates.io)
 workspace_root: <WORKSPACE_ROOT>
 
 Total packages to publish: 3
+Plan summary:
+  Publishable packages: 3
+  Skipped packages: 0
+  Internal dependency edges: 2
+  Publish levels: 3
 
-  1. core-lib@0.2.0
-  2. mid-lib@0.3.0
-  3. top-app@0.4.0
+  1. core-lib@0.2.0 (no workspace dependencies)
+  2. mid-lib@0.3.0 (depends on: core-lib@0.2.0)
+  3. top-app@0.4.0 (depends on: mid-lib@0.3.0)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_multiple_packages_filter.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_multiple_packages_filter.snap
@@ -7,6 +7,11 @@ registry: crates-io (https://crates.io)
 workspace_root: <WORKSPACE_ROOT>
 
 Total packages to publish: 2
+Plan summary:
+  Publishable packages: 2
+  Skipped packages: 0
+  Internal dependency edges: 1
+  Publish levels: 2
 
-  1. core-lib@0.2.0
-  2. mid-lib@0.3.0
+  1. core-lib@0.2.0 (no workspace dependencies)
+  2. mid-lib@0.3.0 (depends on: core-lib@0.2.0)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_publish_false.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_publish_false.snap
@@ -7,8 +7,13 @@ registry: crates-io (https://crates.io)
 workspace_root: <WORKSPACE_ROOT>
 
 Total packages to publish: 1
+Plan summary:
+  Publishable packages: 1
+  Skipped packages: 1
+  Internal dependency edges: 0
+  Publish levels: 1
 
 Skipped packages:
   - beta-internal@0.0.1 (publish = false)
 
-  1. alpha@0.1.0
+  1. alpha@0.1.0 (no workspace dependencies)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_quiet_mode.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_quiet_mode.snap
@@ -7,5 +7,10 @@ registry: crates-io (https://crates.io)
 workspace_root: <WORKSPACE_ROOT>
 
 Total packages to publish: 1
+Plan summary:
+  Publishable packages: 1
+  Skipped packages: 0
+  Internal dependency edges: 0
+  Publish levels: 1
 
-  1. demo@0.1.0
+  1. demo@0.1.0 (no workspace dependencies)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_retry_jitter_out_of_range.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_retry_jitter_out_of_range.snap
@@ -9,5 +9,10 @@ registry: crates-io (https://crates.io)
 workspace_root: <WORKSPACE_ROOT>
 
 Total packages to publish: 1
+Plan summary:
+  Publishable packages: 1
+  Skipped packages: 0
+  Internal dependency edges: 0
+  Publish levels: 1
 
-  1. demo@0.1.0--- stderr ---
+  1. demo@0.1.0 (no workspace dependencies)--- stderr ---

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_single_crate.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_single_crate.snap
@@ -7,5 +7,10 @@ registry: crates-io (https://crates.io)
 workspace_root: <WORKSPACE_ROOT>
 
 Total packages to publish: 1
+Plan summary:
+  Publishable packages: 1
+  Skipped packages: 0
+  Internal dependency edges: 0
+  Publish levels: 1
 
-  1. demo@0.1.0
+  1. demo@0.1.0 (no workspace dependencies)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_single_package_filter.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_single_package_filter.snap
@@ -7,5 +7,10 @@ registry: crates-io (https://crates.io)
 workspace_root: <WORKSPACE_ROOT>
 
 Total packages to publish: 1
+Plan summary:
+  Publishable packages: 1
+  Skipped packages: 0
+  Internal dependency edges: 0
+  Publish levels: 1
 
-  1. core-lib@0.2.0
+  1. core-lib@0.2.0 (no workspace dependencies)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_verbose_multi_crate.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_verbose_multi_crate.snap
@@ -7,6 +7,11 @@ registry: crates-io (https://crates.io)
 workspace_root: <WORKSPACE_ROOT>
 
 Total packages to publish: 3
+Plan summary:
+  Publishable packages: 3
+  Skipped packages: 0
+  Internal dependency edges: 2
+  Publish levels: 3
 
 === Dependency Analysis ===
 

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_verbose_single_package_filter.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_verbose_single_package_filter.snap
@@ -7,6 +7,11 @@ registry: crates-io (https://crates.io)
 workspace_root: <WORKSPACE_ROOT>
 
 Total packages to publish: 1
+Plan summary:
+  Publishable packages: 1
+  Skipped packages: 0
+  Internal dependency edges: 0
+  Publish levels: 1
 
 === Dependency Analysis ===
 

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__verbose_single_crate_plan.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__verbose_single_crate_plan.snap
@@ -7,6 +7,11 @@ registry: crates-io (https://crates.io)
 workspace_root: <WORKSPACE_ROOT>
 
 Total packages to publish: 1
+Plan summary:
+  Publishable packages: 1
+  Skipped packages: 0
+  Internal dependency edges: 0
+  Publish levels: 1
 
 === Dependency Analysis ===
 


### PR DESCRIPTION
Summary:
- add first-screen plan graph counts for publishable/skipped packages, dependency edges, and publish levels
- include dependency reasons in human plan order output
- make `shipper plan --format json` emit a structured plan report for CI/agent consumers
- update CLI snapshots for plan output surfaces

Validation:
- cargo fmt --all -- --check
- cargo test -p shipper-cli --test e2e_expanded --locked
- cargo clippy -p shipper-cli --all-targets --locked -- -D warnings
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask policy-report
- git diff --check