### PR TITLE
refactor(doctor): split run_doctor into SRP submodules

### DIFF
--- a/crates/shipper-cli/src/doctor/checks/auth.rs
+++ b/crates/shipper-cli/src/doctor/checks/auth.rs
@@ -1,0 +1,39 @@
+//! Registry authentication check.
+
+use anyhow::Result;
+
+use shipper_core::plan;
+use shipper_core::types::AuthType;
+
+use crate::doctor::findings::{Finding, FindingLevel};
+
+pub(in crate::doctor) fn check(ws: &plan::PlannedWorkspace) -> Result<Vec<Finding>> {
+    let auth_type = shipper_core::auth::detect_auth_type(&ws.plan.registry.name)?;
+    let auth_label = match auth_type {
+        Some(AuthType::Token) => "token (detected)",
+        Some(AuthType::TrustedPublishing) => "trusted (detected)",
+        Some(AuthType::Unknown) => "unknown",
+        None => "NONE FOUND (set CARGO_REGISTRY_TOKEN)",
+    };
+    println!("auth_type: {}", auth_label);
+
+    let mut findings = Vec::new();
+    if auth_type.is_none() {
+        findings.push(Finding {
+            id: "registry-auth-missing",
+            severity: FindingLevel::Blocked,
+            status: FindingLevel::Blocked,
+            title: "crates.io auth is missing",
+            why_it_matters:
+                "ownership checks and live publish require registry credentials before Shipper can prove or execute a release",
+            evidence: "auth_type: NONE FOUND (set CARGO_REGISTRY_TOKEN)".to_string(),
+            try_next: vec![
+                "run `cargo login <token>` for local token auth",
+                "configure Trusted Publishing for GitHub Actions releases",
+                "rerun `shipper doctor` and `shipper preflight`",
+            ],
+            docs: Some("docs/how-to/run-in-github-actions.md"),
+        });
+    }
+    Ok(findings)
+}

--- a/crates/shipper-cli/src/doctor/checks/connectivity.rs
+++ b/crates/shipper-cli/src/doctor/checks/connectivity.rs
@@ -1,0 +1,45 @@
+//! Registry reachability check.
+
+use anyhow::Result;
+
+use shipper_core::engine::Reporter;
+use shipper_core::plan;
+
+use crate::doctor::findings::{Finding, FindingLevel};
+
+pub(in crate::doctor) fn check(
+    ws: &plan::PlannedWorkspace,
+    reporter: &mut dyn Reporter,
+) -> Result<Vec<Finding>> {
+    reporter.info("checking registry connectivity...");
+    let reg_client = shipper_core::registry::RegistryClient::new(ws.plan.registry.clone())?;
+
+    let mut findings = Vec::new();
+    match reg_client.crate_exists("serde") {
+        Ok(_) => println!("registry_reachable: true"),
+        Err(e) => {
+            let evidence = format!("registry_reachable: false ({e:#})");
+            reporter.warn(&evidence);
+            findings.push(Finding {
+                id: "registry-unreachable",
+                severity: FindingLevel::Blocked,
+                status: FindingLevel::Blocked,
+                title: "registry is unreachable",
+                why_it_matters:
+                    "preflight, publish readiness checks, and reconciliation need registry truth",
+                evidence,
+                try_next: vec![
+                    "check network access to the configured registry",
+                    "verify `--registry` and `--api-base` settings",
+                    "rerun `shipper doctor` before publishing",
+                ],
+                docs: Some("docs/failure-modes.md"),
+            });
+        }
+    }
+
+    let index_base = ws.plan.registry.get_index_base();
+    println!("index_base: {}", index_base);
+
+    Ok(findings)
+}

--- a/crates/shipper-cli/src/doctor/checks/encryption.rs
+++ b/crates/shipper-cli/src/doctor/checks/encryption.rs
@@ -1,0 +1,40 @@
+//! State-encryption configuration check.
+
+use shipper_core::types::RuntimeOptions;
+
+use crate::doctor::findings::{Finding, FindingLevel};
+
+pub(in crate::doctor) fn check(opts: &RuntimeOptions) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    if !opts.encryption.enabled {
+        return findings;
+    }
+
+    println!();
+    println!("encryption: enabled");
+    if opts.encryption.passphrase.is_some() {
+        println!("encryption_key_source: config");
+    } else if let Some(ref env_var) = opts.encryption.env_var {
+        let present = std::env::var(env_var).is_ok();
+        println!("encryption_key_source: env ({})", env_var);
+        println!("encryption_key_present: {}", present);
+        if !present {
+            findings.push(Finding {
+                id: "encryption-key-missing",
+                severity: FindingLevel::Blocked,
+                status: FindingLevel::Blocked,
+                title: "state encryption key is missing",
+                why_it_matters:
+                    "encrypted state cannot be written or resumed unless the configured key source is present",
+                evidence: format!("encryption_key_present: false ({env_var})"),
+                try_next: vec![
+                    "set the configured encryption environment variable",
+                    "or disable state encryption for this run",
+                    "rerun `shipper doctor`",
+                ],
+                docs: Some("docs/configuration.md"),
+            });
+        }
+    }
+    findings
+}

--- a/crates/shipper-cli/src/doctor/checks/git.rs
+++ b/crates/shipper-cli/src/doctor/checks/git.rs
@@ -1,0 +1,13 @@
+//! Git working-tree context probe (informational; no findings emitted).
+
+pub(in crate::doctor) fn check() {
+    match shipper_core::git::collect_git_context() {
+        Some(git) => {
+            let dirty = git.dirty.unwrap_or(false);
+            println!("git_commit: {}", git.commit.unwrap_or_else(|| "-".into()));
+            println!("git_branch: {}", git.branch.unwrap_or_else(|| "-".into()));
+            println!("git_dirty: {}", dirty);
+        }
+        None => println!("git_context: not a git repository"),
+    }
+}

--- a/crates/shipper-cli/src/doctor/checks/mod.rs
+++ b/crates/shipper-cli/src/doctor/checks/mod.rs
@@ -1,0 +1,12 @@
+//! Individual doctor checks, each focused on a single subsystem.
+//!
+//! Every check prints its own section to stdout and returns the
+//! [`Finding`](super::findings::Finding) records it discovered (empty if
+//! everything looks healthy).
+
+pub(super) mod auth;
+pub(super) mod connectivity;
+pub(super) mod encryption;
+pub(super) mod git;
+pub(super) mod state_dir;
+pub(super) mod tools;

--- a/crates/shipper-cli/src/doctor/checks/state_dir.rs
+++ b/crates/shipper-cli/src/doctor/checks/state_dir.rs
@@ -1,0 +1,43 @@
+//! State-directory existence and writability check.
+
+use shipper_core::plan;
+use shipper_core::types::RuntimeOptions;
+
+use crate::doctor::findings::{Finding, FindingLevel};
+
+pub(in crate::doctor) fn check(ws: &plan::PlannedWorkspace, opts: &RuntimeOptions) -> Vec<Finding> {
+    let abs_state = if opts.state_dir.is_absolute() {
+        opts.state_dir.clone()
+    } else {
+        ws.workspace_root.join(&opts.state_dir)
+    };
+    println!("state_dir: {}", abs_state.display());
+
+    let mut findings = Vec::new();
+    if abs_state.exists() {
+        if let Ok(meta) = std::fs::metadata(&abs_state) {
+            let writable = !meta.permissions().readonly();
+            println!("state_dir_writable: {}", writable);
+            if !writable {
+                findings.push(Finding {
+                    id: "state-dir-readonly",
+                    severity: FindingLevel::Blocked,
+                    status: FindingLevel::Blocked,
+                    title: "state directory is read-only",
+                    why_it_matters:
+                        "publish and resume need to write state, events, receipts, and lock files continuously",
+                    evidence: format!("state_dir: {}", abs_state.display()),
+                    try_next: vec![
+                        "fix filesystem permissions for the state directory",
+                        "choose a writable directory with `--state-dir <path>`",
+                        "rerun `shipper doctor`",
+                    ],
+                    docs: Some("docs/reference/state-files.md"),
+                });
+            }
+        }
+    } else {
+        println!("state_dir_exists: false (will be created)");
+    }
+    findings
+}

--- a/crates/shipper-cli/src/doctor/checks/tools.rs
+++ b/crates/shipper-cli/src/doctor/checks/tools.rs
@@ -1,0 +1,29 @@
+//! External-tool version probes (cargo, git).
+
+use std::process::Command;
+
+use shipper_core::engine::Reporter;
+
+pub(in crate::doctor) fn check(reporter: &mut dyn Reporter) {
+    print_cmd_version("cargo", reporter);
+    print_cmd_version("git", reporter);
+}
+
+pub(crate) fn print_cmd_version(cmd: &str, reporter: &mut dyn Reporter) {
+    let out = Command::new(cmd).arg("--version").output();
+    match out {
+        Ok(o) if o.status.success() => {
+            let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            println!("{cmd}: {s}");
+        }
+        Ok(o) => {
+            reporter.warn(&format!(
+                "{cmd} --version failed: {}",
+                String::from_utf8_lossy(&o.stderr).trim()
+            ));
+        }
+        Err(e) => {
+            reporter.warn(&format!("unable to run {cmd} --version: {e}"));
+        }
+    }
+}

--- a/crates/shipper-cli/src/doctor/findings.rs
+++ b/crates/shipper-cli/src/doctor/findings.rs
@@ -1,0 +1,56 @@
+//! Diagnostic finding records and rendering for `shipper doctor`.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FindingLevel {
+    Blocked,
+}
+
+impl FindingLevel {
+    fn as_str(self) -> &'static str {
+        match self {
+            FindingLevel::Blocked => "blocked",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Finding {
+    pub id: &'static str,
+    pub severity: FindingLevel,
+    pub status: FindingLevel,
+    pub title: &'static str,
+    pub why_it_matters: &'static str,
+    pub evidence: String,
+    pub try_next: Vec<&'static str>,
+    pub docs: Option<&'static str>,
+}
+
+pub(super) fn print_findings(findings: &[Finding]) {
+    println!();
+    println!("Findings:");
+    println!("---------");
+    if findings.is_empty() {
+        println!("  none");
+        return;
+    }
+
+    for finding in findings {
+        println!(
+            "  [{}] {} ({})",
+            finding.status.as_str(),
+            finding.title,
+            finding.id
+        );
+        println!("    status: {}", finding.status.as_str());
+        println!("    severity: {}", finding.severity.as_str());
+        println!("    why: {}", finding.why_it_matters);
+        println!("    evidence: {}", finding.evidence);
+        println!("    try next:");
+        for step in &finding.try_next {
+            println!("      - {step}");
+        }
+        if let Some(docs) = finding.docs {
+            println!("    docs: {docs}");
+        }
+    }
+}

--- a/crates/shipper-cli/src/doctor/mod.rs
+++ b/crates/shipper-cli/src/doctor/mod.rs
@@ -1,0 +1,56 @@
+//! `shipper doctor` — environment diagnostics.
+//!
+//! The orchestrator [`run`] prints a header, runs each check in
+//! [`checks`] in turn, and renders the aggregated [`findings`] at the
+//! end. Each check is responsible for one subsystem (auth, state dir,
+//! tools, connectivity, git, encryption) so that adding a new diagnostic
+//! is an additive change rather than an edit of a long function.
+
+use anyhow::Result;
+
+use shipper_core::engine::Reporter;
+use shipper_core::plan;
+use shipper_core::types::RuntimeOptions;
+
+mod checks;
+mod findings;
+
+#[cfg(test)]
+pub(crate) use checks::tools::print_cmd_version;
+
+pub(crate) fn run(
+    ws: &plan::PlannedWorkspace,
+    opts: &RuntimeOptions,
+    reporter: &mut dyn Reporter,
+) -> Result<()> {
+    let mut all = Vec::new();
+
+    println!("Shipper Doctor - Diagnostics Report");
+    println!("----------------------------------");
+    println!("workspace_root: {}", ws.workspace_root.display());
+    println!(
+        "registry: {} ({})",
+        ws.plan.registry.name, ws.plan.registry.api_base
+    );
+
+    all.extend(checks::auth::check(ws)?);
+    all.extend(checks::state_dir::check(ws, opts));
+
+    println!();
+    checks::tools::check(reporter);
+
+    println!();
+    all.extend(checks::connectivity::check(ws, reporter)?);
+
+    println!();
+    checks::git::check();
+
+    all.extend(checks::encryption::check(opts));
+
+    findings::print_findings(&all);
+
+    println!();
+    println!("Diagnostics complete.");
+
+    Ok(())
+}

--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -28,7 +28,6 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
@@ -44,6 +43,7 @@ use shipper_core::types::{
     RuntimeOptions,
 };
 
+mod doctor;
 mod output;
 
 use crate::output::progress::ProgressReporter;
@@ -992,7 +992,7 @@ pub fn run() -> Result<()> {
                 }
                 let mut current_planned = planned.clone();
                 current_planned.plan.registry = reg;
-                run_doctor(&current_planned, &opts, &mut reporter)?;
+                doctor::run(&current_planned, &opts, &mut reporter)?;
             }
         }
         Commands::InspectEvents => {
@@ -2224,242 +2224,6 @@ fn run_status(ws: &plan::PlannedWorkspace, reporter: &mut dyn Reporter) -> Resul
     Ok(())
 }
 
-fn run_doctor(
-    ws: &plan::PlannedWorkspace,
-    opts: &RuntimeOptions,
-    reporter: &mut dyn Reporter,
-) -> Result<()> {
-    let mut findings = Vec::new();
-
-    println!("Shipper Doctor - Diagnostics Report");
-    println!("----------------------------------");
-    println!("workspace_root: {}", ws.workspace_root.display());
-    println!(
-        "registry: {} ({})",
-        ws.plan.registry.name, ws.plan.registry.api_base
-    );
-
-    // 1. Check Authentication
-    let auth_type = shipper_core::auth::detect_auth_type(&ws.plan.registry.name)?;
-    let auth_label = match auth_type {
-        Some(shipper_core::types::AuthType::Token) => "token (detected)",
-        Some(shipper_core::types::AuthType::TrustedPublishing) => "trusted (detected)",
-        Some(shipper_core::types::AuthType::Unknown) => "unknown",
-        None => "NONE FOUND (set CARGO_REGISTRY_TOKEN)",
-    };
-    println!("auth_type: {}", auth_label);
-    if auth_type.is_none() {
-        findings.push(DoctorFinding {
-            id: "registry-auth-missing",
-            severity: DoctorFindingLevel::Blocked,
-            status: DoctorFindingLevel::Blocked,
-            title: "crates.io auth is missing",
-            why_it_matters:
-                "ownership checks and live publish require registry credentials before Shipper can prove or execute a release",
-            evidence: "auth_type: NONE FOUND (set CARGO_REGISTRY_TOKEN)".to_string(),
-            try_next: vec![
-                "run `cargo login <token>` for local token auth",
-                "configure Trusted Publishing for GitHub Actions releases",
-                "rerun `shipper doctor` and `shipper preflight`",
-            ],
-            docs: Some("docs/how-to/run-in-github-actions.md"),
-        });
-    }
-
-    // 2. Check State Directory
-    let abs_state = if opts.state_dir.is_absolute() {
-        opts.state_dir.clone()
-    } else {
-        ws.workspace_root.join(&opts.state_dir)
-    };
-    println!("state_dir: {}", abs_state.display());
-
-    if abs_state.exists() {
-        if let Ok(meta) = std::fs::metadata(&abs_state) {
-            let writable = !meta.permissions().readonly();
-            println!("state_dir_writable: {}", writable);
-            if !writable {
-                findings.push(DoctorFinding {
-                    id: "state-dir-readonly",
-                    severity: DoctorFindingLevel::Blocked,
-                    status: DoctorFindingLevel::Blocked,
-                    title: "state directory is read-only",
-                    why_it_matters:
-                        "publish and resume need to write state, events, receipts, and lock files continuously",
-                    evidence: format!("state_dir: {}", abs_state.display()),
-                    try_next: vec![
-                        "fix filesystem permissions for the state directory",
-                        "choose a writable directory with `--state-dir <path>`",
-                        "rerun `shipper doctor`",
-                    ],
-                    docs: Some("docs/reference/state-files.md"),
-                });
-            }
-        }
-    } else {
-        println!("state_dir_exists: false (will be created)");
-    }
-
-    // 3. Check Tools
-    println!();
-    print_cmd_version("cargo", reporter);
-    print_cmd_version("git", reporter);
-
-    // 4. Network Connectivity (Best Effort)
-    println!();
-    reporter.info("checking registry connectivity...");
-    let reg_client = shipper_core::registry::RegistryClient::new(ws.plan.registry.clone())?;
-
-    match reg_client.crate_exists("serde") {
-        Ok(_) => println!("registry_reachable: true"),
-        Err(e) => {
-            let evidence = format!("registry_reachable: false ({e:#})");
-            reporter.warn(&evidence);
-            findings.push(DoctorFinding {
-                id: "registry-unreachable",
-                severity: DoctorFindingLevel::Blocked,
-                status: DoctorFindingLevel::Blocked,
-                title: "registry is unreachable",
-                why_it_matters:
-                    "preflight, publish readiness checks, and reconciliation need registry truth",
-                evidence,
-                try_next: vec![
-                    "check network access to the configured registry",
-                    "verify `--registry` and `--api-base` settings",
-                    "rerun `shipper doctor` before publishing",
-                ],
-                docs: Some("docs/failure-modes.md"),
-            });
-        }
-    }
-
-    let index_base = ws.plan.registry.get_index_base();
-    println!("index_base: {}", index_base);
-
-    // 5. Check Git State
-    println!();
-    match shipper_core::git::collect_git_context() {
-        Some(git) => {
-            let dirty = git.dirty.unwrap_or(false);
-            println!("git_commit: {}", git.commit.unwrap_or_else(|| "-".into()));
-            println!("git_branch: {}", git.branch.unwrap_or_else(|| "-".into()));
-            println!("git_dirty: {}", dirty);
-        }
-        None => println!("git_context: not a git repository"),
-    }
-
-    // 6. Encryption Check
-    if opts.encryption.enabled {
-        println!();
-        println!("encryption: enabled");
-        if opts.encryption.passphrase.is_some() {
-            println!("encryption_key_source: config");
-        } else if let Some(ref env_var) = opts.encryption.env_var {
-            let present = std::env::var(env_var).is_ok();
-            println!("encryption_key_source: env ({})", env_var);
-            println!("encryption_key_present: {}", present);
-            if !present {
-                findings.push(DoctorFinding {
-                    id: "encryption-key-missing",
-                    severity: DoctorFindingLevel::Blocked,
-                    status: DoctorFindingLevel::Blocked,
-                    title: "state encryption key is missing",
-                    why_it_matters:
-                        "encrypted state cannot be written or resumed unless the configured key source is present",
-                    evidence: format!("encryption_key_present: false ({env_var})"),
-                    try_next: vec![
-                        "set the configured encryption environment variable",
-                        "or disable state encryption for this run",
-                        "rerun `shipper doctor`",
-                    ],
-                    docs: Some("docs/configuration.md"),
-                });
-            }
-        }
-    }
-
-    print_doctor_findings(&findings);
-
-    println!();
-    println!("Diagnostics complete.");
-
-    Ok(())
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DoctorFindingLevel {
-    Blocked,
-}
-
-impl DoctorFindingLevel {
-    fn as_str(self) -> &'static str {
-        match self {
-            DoctorFindingLevel::Blocked => "blocked",
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct DoctorFinding {
-    id: &'static str,
-    severity: DoctorFindingLevel,
-    status: DoctorFindingLevel,
-    title: &'static str,
-    why_it_matters: &'static str,
-    evidence: String,
-    try_next: Vec<&'static str>,
-    docs: Option<&'static str>,
-}
-
-fn print_doctor_findings(findings: &[DoctorFinding]) {
-    println!();
-    println!("Findings:");
-    println!("---------");
-    if findings.is_empty() {
-        println!("  none");
-        return;
-    }
-
-    for finding in findings {
-        println!(
-            "  [{}] {} ({})",
-            finding.status.as_str(),
-            finding.title,
-            finding.id
-        );
-        println!("    status: {}", finding.status.as_str());
-        println!("    severity: {}", finding.severity.as_str());
-        println!("    why: {}", finding.why_it_matters);
-        println!("    evidence: {}", finding.evidence);
-        println!("    try next:");
-        for step in &finding.try_next {
-            println!("      - {step}");
-        }
-        if let Some(docs) = finding.docs {
-            println!("    docs: {docs}");
-        }
-    }
-}
-
-fn print_cmd_version(cmd: &str, reporter: &mut dyn Reporter) {
-    let out = Command::new(cmd).arg("--version").output();
-    match out {
-        Ok(o) if o.status.success() => {
-            let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
-            println!("{cmd}: {s}");
-        }
-        Ok(o) => {
-            reporter.warn(&format!(
-                "{cmd} --version failed: {}",
-                String::from_utf8_lossy(&o.stderr).trim()
-            ));
-        }
-        Err(e) => {
-            reporter.warn(&format!("unable to run {cmd} --version: {e}"));
-        }
-    }
-}
-
 fn run_ci(ci_cmd: CiCommands, state_dir: &Path, workspace_root: &Path) -> Result<()> {
     let abs_state = if state_dir.is_absolute() {
         state_dir.to_path_buf()
@@ -2990,7 +2754,7 @@ mod tests {
     #[test]
     fn print_cmd_version_reports_missing_command() {
         let mut reporter = TestReporter::default();
-        print_cmd_version("definitely-not-a-real-command-shipper", &mut reporter);
+        doctor::print_cmd_version("definitely-not-a-real-command-shipper", &mut reporter);
         assert!(reporter.warns.iter().any(|w| w.contains("unable to run")));
     }
 
@@ -3029,7 +2793,7 @@ mod tests {
         };
 
         let mut reporter = TestReporter::default();
-        print_cmd_version(cmd_path.to_str().expect("utf8"), &mut reporter);
+        doctor::print_cmd_version(cmd_path.to_str().expect("utf8"), &mut reporter);
         assert!(
             reporter
                 .warns
@@ -3117,7 +2881,7 @@ mod tests {
             ],
             || {
                 let mut reporter = TestReporter::default();
-                run_doctor(&ws, &opts, &mut reporter).expect("doctor");
+                doctor::run(&ws, &opts, &mut reporter).expect("doctor");
             },
         );
     }
@@ -3189,7 +2953,7 @@ mod tests {
             ],
             || {
                 let mut reporter = TestReporter::default();
-                run_doctor(&ws, &opts, &mut reporter).expect("doctor");
+                doctor::run(&ws, &opts, &mut reporter).expect("doctor");
             },
         );
     }


### PR DESCRIPTION
## Summary

Refreshes the existing doctor SRP refactor on top of current main after #296 and #297.

un_doctor is split into focused modules under crates/shipper-cli/src/doctor/:

`	ext
doctor/
├── mod.rs
├── findings.rs
└── checks/
    ├── auth.rs
    ├── connectivity.rs
    ├── encryption.rs
    ├── git.rs
    ├── state_dir.rs
    └── tools.rs
`

Each check owns one diagnostic phase and returns structured findings for the shared renderer. The refreshed branch preserves #297's workspace-root-aware dirty-git remediation by moving that finding into doctor/checks/git.rs.

Scope stays behavior-preserving apart from retaining already-merged main behavior: this PR is about making Doctor easier to extend for the first-five-minutes release-closure path.

## Validation

- [x] cargo fmt --all -- --check
- [x] cargo test -p shipper-cli --test e2e_doctor --locked
- [x] cargo test -p shipper-cli --test bdd_doctor --locked
- [x] cargo test -p shipper-cli --test cli_e2e doctor --locked
- [x] cargo test -p shipper-cli --lib --locked
- [x] cargo clippy -p shipper-cli --all-targets --all-features --locked -- -D warnings
- [x] cargo xtask check-file-policy --mode blocking-allowlist
- [x] cargo xtask policy-report
- [x] git diff --check
