### PR TITLE
feat(preflight): add JSON evidence contract

### DIFF
--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -1545,6 +1545,44 @@ struct PlanSkippedPackageReport {
     reason: String,
 }
 
+#[derive(Debug, Serialize)]
+struct PreflightJsonReport<'a> {
+    schema_version: &'static str,
+    #[serde(flatten)]
+    report: &'a PreflightReport,
+    proofs: Vec<PreflightEvidenceItem>,
+    gaps: Vec<PreflightEvidenceItem>,
+    failed_checks: Vec<PreflightEvidenceItem>,
+    live_release_evidence: Vec<PreflightEvidenceItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    registry_profile: Option<PreflightRegistryProfileReport>,
+    artifacts: Vec<PreflightArtifactReport>,
+}
+
+#[derive(Debug, Serialize)]
+struct PreflightEvidenceItem {
+    id: &'static str,
+    status: &'static str,
+    summary: String,
+    packages: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct PreflightRegistryProfileReport {
+    name: String,
+    first_publish_count: usize,
+    update_count: usize,
+    minimum_registry_pacing: String,
+    notes: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct PreflightArtifactReport {
+    kind: &'static str,
+    path: Option<String>,
+    description: &'static str,
+}
+
 fn print_plan(ws: &plan::PlannedWorkspace, verbose: bool, format: &str) {
     if format == "json" {
         let report = build_plan_report(ws);
@@ -1823,7 +1861,8 @@ fn print_detailed_plan(ws: &plan::PlannedWorkspace) {
 fn print_preflight(rep: &PreflightReport, format: &str) {
     match format {
         "json" => {
-            let json = serde_json::to_string_pretty(rep).expect("serialize preflight report");
+            let report = build_preflight_json_report(rep);
+            let json = serde_json::to_string_pretty(&report).expect("serialize preflight report");
             println!("{}", json);
         }
         _ => {
@@ -1965,6 +2004,149 @@ fn print_preflight(rep: &PreflightReport, format: &str) {
     }
 }
 
+fn build_preflight_json_report(rep: &PreflightReport) -> PreflightJsonReport<'_> {
+    let total = rep.packages.len();
+    let dry_run_passed = rep.packages.iter().filter(|p| p.dry_run_passed).count();
+    let dry_run_failed = rep
+        .packages
+        .iter()
+        .filter(|p| !p.dry_run_passed)
+        .collect::<Vec<_>>();
+    let ownership_unverified = rep
+        .packages
+        .iter()
+        .filter(|p| !p.ownership_verified)
+        .collect::<Vec<_>>();
+
+    let mut proofs = Vec::new();
+    if dry_run_failed.is_empty() {
+        proofs.push(PreflightEvidenceItem {
+            id: "local_dry_run",
+            status: "passed",
+            summary: format!(
+                "Local package dry-run passed for {} of {} {}.",
+                dry_run_passed,
+                total,
+                package_noun(total)
+            ),
+            packages: rep.packages.iter().map(package_ref).collect(),
+        });
+    } else if dry_run_passed > 0 {
+        proofs.push(PreflightEvidenceItem {
+            id: "local_dry_run_partial",
+            status: "partial",
+            summary: format!(
+                "Local package dry-run passed for {} of {} {}.",
+                dry_run_passed,
+                total,
+                package_noun(total)
+            ),
+            packages: rep
+                .packages
+                .iter()
+                .filter(|p| p.dry_run_passed)
+                .map(package_ref)
+                .collect(),
+        });
+    }
+
+    proofs.push(PreflightEvidenceItem {
+        id: "registry_version_checks",
+        status: "completed",
+        summary: format!(
+            "Registry version/new-crate checks completed for {} {}.",
+            total,
+            package_noun(total)
+        ),
+        packages: rep.packages.iter().map(package_ref).collect(),
+    });
+
+    if let Some(estimate) = &rep.estimated_publish_duration {
+        proofs.push(PreflightEvidenceItem {
+            id: "registry_pacing_estimate",
+            status: "completed",
+            summary: format!(
+                "Registry pacing estimate generated from the {} profile.",
+                estimate.registry_profile
+            ),
+            packages: Vec::new(),
+        });
+    }
+
+    let mut gaps = Vec::new();
+    if !ownership_unverified.is_empty() {
+        gaps.push(PreflightEvidenceItem {
+            id: "ownership_unverified",
+            status: "not_proven",
+            summary: format!(
+                "Ownership was not verified for {} of {} {}.",
+                ownership_unverified.len(),
+                total,
+                package_noun(total)
+            ),
+            packages: ownership_unverified
+                .iter()
+                .copied()
+                .map(package_ref)
+                .collect(),
+        });
+    }
+    if !rep.token_detected {
+        gaps.push(PreflightEvidenceItem {
+            id: "registry_auth_missing",
+            status: "not_proven",
+            summary: "No registry token or Trusted Publishing context was detected.".to_string(),
+            packages: Vec::new(),
+        });
+    }
+
+    let failed_checks = dry_run_failed
+        .iter()
+        .copied()
+        .map(|package| PreflightEvidenceItem {
+            id: "local_dry_run",
+            status: "failed",
+            summary: format!("Dry-run failed for {}.", package_ref(package)),
+            packages: vec![package_ref(package)],
+        })
+        .collect();
+
+    let live_release_evidence = vec![PreflightEvidenceItem {
+        id: "registry_acceptance_visibility",
+        status: "pending_publish",
+        summary:
+            "Registry acceptance and post-publish visibility are recorded during publish/resume."
+                .to_string(),
+        packages: rep.packages.iter().map(package_ref).collect(),
+    }];
+
+    PreflightJsonReport {
+        schema_version: "shipper.preflight.v1",
+        report: rep,
+        proofs,
+        gaps,
+        failed_checks,
+        live_release_evidence,
+        registry_profile: rep.estimated_publish_duration.as_ref().map(|estimate| {
+            PreflightRegistryProfileReport {
+                name: estimate.registry_profile.clone(),
+                first_publish_count: estimate.first_publish_count,
+                update_count: estimate.update_count,
+                minimum_registry_pacing: humantime::format_duration(
+                    estimate.minimum_registry_pacing,
+                )
+                .to_string(),
+                notes: estimate.notes.clone(),
+            }
+        }),
+        artifacts: vec![PreflightArtifactReport {
+            kind: "preflight_json_stdout",
+            path: None,
+            description: "This JSON document is the preflight evidence artifact when captured by CI.",
+        }],
+    }
+}
+
 fn print_preflight_proof_explanation(rep: &PreflightReport, total: usize, dry_run_passed: usize) {
     let dry_run_failed = rep
         .packages
@@ -2034,10 +2216,11 @@ fn print_preflight_proof_explanation(rep: &PreflightReport, total: usize, dry_ru
 }
 
 fn package_refs<'a>(packages: impl Iterator<Item = &'a PreflightPackage>) -> String {
-    packages
-        .map(|package| format!("{}@{}", package.name, package.version))
-        .collect::<Vec<_>>()
-        .join(", ")
+    packages.map(package_ref).collect::<Vec<_>>().join(", ")
+}
+
+fn package_ref(package: &PreflightPackage) -> String {
+    format!("{}@{}", package.name, package.version)
 }
 
 fn package_noun(count: usize) -> &'static str {

--- a/crates/shipper-cli/tests/cli_e2e.rs
+++ b/crates/shipper-cli/tests/cli_e2e.rs
@@ -544,10 +544,14 @@ fn preflight_command_with_json_flag() {
     let stdout = String::from_utf8(out).expect("utf8");
     // Verify it's valid JSON
     let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(json["schema_version"], "shipper.preflight.v1");
     assert!(json["plan_id"].is_string());
     assert_eq!(json["token_detected"], false);
     assert!(json["finishability"].is_string());
     assert!(json["packages"].is_array());
+    assert!(json["proofs"].is_array());
+    assert!(json["gaps"].is_array());
+    assert!(json["failed_checks"].is_array());
     registry.join();
 }
 
@@ -1187,6 +1191,11 @@ fn preflight_command_json_output_structure() {
     assert!(json.get("packages").is_some());
     assert!(json.get("timestamp").is_some());
     assert_eq!(
+        json.pointer("/schema_version")
+            .and_then(serde_json::Value::as_str),
+        Some("shipper.preflight.v1")
+    );
+    assert_eq!(
         json.pointer("/estimated_publish_duration/registry_profile"),
         Some(&serde_json::Value::String("crates-io".to_string()))
     );
@@ -1198,6 +1207,41 @@ fn preflight_command_json_output_structure() {
     assert!(
         json.pointer("/estimated_publish_duration/minimum_registry_pacing")
             .is_some()
+    );
+    assert_eq!(
+        json.pointer("/registry_profile/name")
+            .and_then(serde_json::Value::as_str),
+        Some("crates-io")
+    );
+    assert_eq!(
+        json.pointer("/registry_profile/first_publish_count")
+            .and_then(serde_json::Value::as_u64),
+        Some(1)
+    );
+
+    let proofs = json["proofs"].as_array().expect("proofs array");
+    assert!(proofs.iter().any(|item| {
+        item["id"].as_str() == Some("local_dry_run") && item["status"].as_str() == Some("passed")
+    }));
+    assert!(proofs.iter().any(|item| {
+        item["id"].as_str() == Some("registry_version_checks")
+            && item["status"].as_str() == Some("completed")
+    }));
+
+    let gaps = json["gaps"].as_array().expect("gaps array");
+    assert!(gaps.iter().any(|item| {
+        item["id"].as_str() == Some("ownership_unverified")
+            && item["status"].as_str() == Some("not_proven")
+    }));
+    assert!(gaps.iter().any(|item| {
+        item["id"].as_str() == Some("registry_auth_missing")
+            && item["status"].as_str() == Some("not_proven")
+    }));
+
+    assert_eq!(
+        json.pointer("/artifacts/0/kind")
+            .and_then(serde_json::Value::as_str),
+        Some("preflight_json_stdout")
     );
 
     // Verify packages array structure

--- a/crates/shipper-cli/tests/e2e_preflight.rs
+++ b/crates/shipper-cli/tests/e2e_preflight.rs
@@ -429,10 +429,19 @@ fn preflight_json_format_produces_valid_json() {
 
     let stdout = String::from_utf8(out).expect("utf8");
     let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(json["schema_version"], "shipper.preflight.v1");
     assert!(json["plan_id"].is_string());
     assert!(json["packages"].is_array());
     assert_eq!(json["packages"].as_array().unwrap().len(), 1);
     assert_eq!(json["packages"][0]["name"], "alpha");
+    assert!(json["proofs"].is_array());
+    assert!(json["gaps"].is_array());
+    assert!(json["failed_checks"].is_array());
+    assert_eq!(
+        json.pointer("/registry_profile/name")
+            .and_then(serde_json::Value::as_str),
+        Some("crates-io")
+    );
 
     registry.join();
 }

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -308,7 +308,20 @@ Use `--format json` to get machine-readable output for CI integration:
 shipper preflight --format json
 ```
 
-The JSON output contains the full `PreflightReport` structure including `plan_id`, `token_detected`, `finishability`, `timestamp`, and a `packages` array with per-package results.
+The JSON output is a versioned preflight evidence object. It preserves the
+legacy `PreflightReport` fields (`plan_id`, `token_detected`, `finishability`,
+`timestamp`, `estimated_publish_duration`, and `packages`) and adds fields that
+agents and CI can route on:
+
+| Field | Meaning |
+|-------|---------|
+| `schema_version` | JSON contract version, currently `shipper.preflight.v1` |
+| `proofs[]` | Checks Shipper completed and can treat as evidence |
+| `gaps[]` | Checks that did not prove a release prerequisite |
+| `failed_checks[]` | Checks that failed and block a proven release |
+| `live_release_evidence[]` | Evidence Shipper records during `publish`/`resume`, not local preflight |
+| `registry_profile` | Registry pacing profile summary derived during preflight |
+| `artifacts[]` | Artifact descriptors for captured preflight evidence |
 
 ### Package Status Columns
 


### PR DESCRIPTION
## Summary
- keep legacy preflight JSON fields intact while adding schema_version, proofs, gaps, ailed_checks, live_release_evidence, egistry_profile, and rtifacts
- derive the additive evidence arrays from the same preflight facts used by human output
- document the versioned JSON evidence object in docs/preflight.md

## Compatibility
- Existing top-level PreflightReport fields remain present for current CI/agent consumers.
- New fields are additive routeable evidence for future integrations.

## Validation
- cargo test -p shipper-cli --test cli_e2e preflight_command_json_output_structure --locked
- cargo test -p shipper-cli --test cli_e2e preflight_command_with_json_flag --locked
- cargo test -p shipper-cli --test e2e_preflight preflight_json_format_produces_valid_json --locked
- cargo test -p shipper-cli --test e2e_preflight --locked
- cargo test -p shipper-cli --test cli_e2e --locked
- cargo test -p shipper-cli --test e2e_expanded --locked
- cargo fmt --all -- --check
- cargo clippy -p shipper-cli --all-targets --locked -- -D warnings
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask policy-report
- git diff --check