### PR TITLE
test(config): cover runtime_options CLI/file merge logic

### DIFF
--- a/crates/shipper-config/src/runtime_options/registry.rs
+++ b/crates/shipper-config/src/runtime_options/registry.rs
@@ -97,4 +97,181 @@ mod tests {
         assert_eq!(registry.name, "-custom");
         assert_eq!(registry.api_base, "https://crates.io");
     }
+
+    use super::{is_safe_synthetic_registry_name, resolve, resolve_named_registry};
+    use crate::{CliOverrides, MultiRegistryConfig, RegistryConfig};
+
+    fn empty_cli() -> CliOverrides {
+        CliOverrides::default()
+    }
+
+    fn config_with_registries(registries: Vec<RegistryConfig>) -> MultiRegistryConfig {
+        MultiRegistryConfig {
+            registries,
+            ..MultiRegistryConfig::default()
+        }
+    }
+
+    fn registry_config(name: &str, api_base: &str) -> RegistryConfig {
+        RegistryConfig {
+            name: name.to_string(),
+            api_base: api_base.to_string(),
+            index_base: None,
+            token: None,
+            default: false,
+        }
+    }
+
+    #[test]
+    fn resolve_no_cli_flags_returns_empty_vec() {
+        let config = config_with_registries(vec![registry_config(
+            "internal",
+            "https://internal.example.com",
+        )]);
+
+        let resolved = resolve(&config, &empty_cli());
+
+        assert!(resolved.is_empty());
+    }
+
+    #[test]
+    fn resolve_all_registries_returns_every_configured_registry() {
+        let config = config_with_registries(vec![
+            registry_config("first", "https://first.example.com"),
+            registry_config("second", "https://second.example.com"),
+        ]);
+
+        let mut cli = empty_cli();
+        cli.all_registries = true;
+
+        let resolved = resolve(&config, &cli);
+
+        assert_eq!(resolved.len(), 2);
+        assert_eq!(resolved[0].name, "first");
+        assert_eq!(resolved[0].api_base, "https://first.example.com");
+        assert_eq!(resolved[1].name, "second");
+        assert_eq!(resolved[1].api_base, "https://second.example.com");
+    }
+
+    #[test]
+    fn resolve_all_registries_falls_back_to_crates_io_when_none_configured() {
+        let config = MultiRegistryConfig::default();
+
+        let mut cli = empty_cli();
+        cli.all_registries = true;
+
+        let resolved = resolve(&config, &cli);
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].name, "crates-io");
+        assert_eq!(resolved[0].api_base, "https://crates.io");
+    }
+
+    #[test]
+    fn resolve_named_registries_resolves_each_by_name() {
+        let config = config_with_registries(vec![
+            registry_config("alpha", "https://alpha.example.com"),
+            registry_config("beta", "https://beta.example.com"),
+        ]);
+
+        let mut cli = empty_cli();
+        cli.registries = Some(vec!["alpha".to_string(), "beta".to_string()]);
+
+        let resolved = resolve(&config, &cli);
+
+        assert_eq!(resolved.len(), 2);
+        assert_eq!(resolved[0].name, "alpha");
+        assert_eq!(resolved[1].name, "beta");
+    }
+
+    #[test]
+    fn resolve_named_registries_falls_back_to_default_for_unknown_name() {
+        let config = MultiRegistryConfig::default();
+
+        let mut cli = empty_cli();
+        cli.registries = Some(vec!["crates-io".to_string()]);
+
+        let resolved = resolve(&config, &cli);
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].name, "crates-io");
+        assert_eq!(resolved[0].api_base, "https://crates.io");
+    }
+
+    #[test]
+    fn resolve_named_registries_uses_synthetic_subdomain_for_safe_unknown_name() {
+        let config = MultiRegistryConfig::default();
+
+        let mut cli = empty_cli();
+        cli.registries = Some(vec!["company-mirror".to_string()]);
+
+        let resolved = resolve(&config, &cli);
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].name, "company-mirror");
+        assert_eq!(resolved[0].api_base, "https://company-mirror.crates.io");
+    }
+
+    #[test]
+    fn resolve_all_registries_takes_precedence_over_named_registries() {
+        let config = config_with_registries(vec![
+            registry_config("a", "https://a.example.com"),
+            registry_config("b", "https://b.example.com"),
+        ]);
+
+        let mut cli = empty_cli();
+        cli.all_registries = true;
+        cli.registries = Some(vec!["a".to_string()]);
+
+        let resolved = resolve(&config, &cli);
+
+        // all_registries wins → both registries returned, ignoring `--registries a`.
+        assert_eq!(resolved.len(), 2);
+    }
+
+    #[test]
+    fn resolve_named_registry_uses_config_index_base_when_present() {
+        let mut entry = registry_config("staging", "https://staging.example.com");
+        entry.index_base = Some("https://index.staging.example.com".to_string());
+        let config = config_with_registries(vec![entry]);
+
+        let resolved = resolve_named_registry(&config, "staging");
+
+        assert_eq!(resolved.name, "staging");
+        assert_eq!(
+            resolved.index_base.as_deref(),
+            Some("https://index.staging.example.com")
+        );
+    }
+
+    #[test]
+    fn resolve_named_registry_unknown_falls_back_to_default_branch() {
+        let config = MultiRegistryConfig::default();
+
+        let resolved = resolve_named_registry(&config, "crates-io");
+
+        assert_eq!(resolved.name, "crates-io");
+        assert_eq!(resolved.api_base, "https://crates.io");
+    }
+
+    #[test]
+    fn is_safe_synthetic_registry_name_accepts_valid_names() {
+        assert!(is_safe_synthetic_registry_name("foo"));
+        assert!(is_safe_synthetic_registry_name("foo-bar"));
+        assert!(is_safe_synthetic_registry_name("a1b2c3"));
+        assert!(is_safe_synthetic_registry_name("a"));
+        assert!(is_safe_synthetic_registry_name(&"a".repeat(63)));
+    }
+
+    #[test]
+    fn is_safe_synthetic_registry_name_rejects_invalid_names() {
+        assert!(!is_safe_synthetic_registry_name(""));
+        assert!(!is_safe_synthetic_registry_name("-leading-hyphen"));
+        assert!(!is_safe_synthetic_registry_name("trailing-hyphen-"));
+        assert!(!is_safe_synthetic_registry_name("UPPER"));
+        assert!(!is_safe_synthetic_registry_name("has.dot"));
+        assert!(!is_safe_synthetic_registry_name("has/slash"));
+        assert!(!is_safe_synthetic_registry_name("has space"));
+        assert!(!is_safe_synthetic_registry_name(&"a".repeat(64)));
+    }
 }

--- a/crates/shipper-config/src/runtime_options/retry.rs
+++ b/crates/shipper-config/src/runtime_options/retry.rs
@@ -54,3 +54,207 @@ fn select_policy_value<T>(custom_policy: bool, custom_value: T, policy_value: T)
         policy_value
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_cli() -> CliOverrides {
+        CliOverrides::default()
+    }
+
+    fn config_with_policy(policy: RetryPolicy) -> RetryConfig {
+        RetryConfig {
+            policy,
+            ..RetryConfig::default()
+        }
+    }
+
+    #[test]
+    fn select_policy_value_returns_policy_value_when_not_custom() {
+        let selected = select_policy_value(false, 10u32, 5u32);
+        assert_eq!(selected, 5);
+    }
+
+    #[test]
+    fn select_policy_value_returns_custom_value_when_custom_policy() {
+        let selected = select_policy_value(true, 10u32, 5u32);
+        assert_eq!(selected, 10);
+    }
+
+    #[test]
+    fn select_policy_value_works_with_duration() {
+        let custom = Duration::from_secs(7);
+        let policy = Duration::from_secs(3);
+
+        assert_eq!(select_policy_value(true, custom, policy), custom);
+        assert_eq!(select_policy_value(false, custom, policy), policy);
+    }
+
+    #[test]
+    fn resolve_default_policy_uses_policy_defaults_not_custom_fields() {
+        // Set custom fields that should be IGNORED because policy != Custom.
+        let config = RetryConfig {
+            policy: RetryPolicy::Default,
+            max_attempts: 999,
+            base_delay: Duration::from_secs(99),
+            ..RetryConfig::default()
+        };
+
+        let policy_defaults = RetryPolicy::Default.to_config();
+
+        let resolved = resolve(&config, &empty_cli());
+
+        assert_eq!(resolved.max_attempts, policy_defaults.max_attempts);
+        assert_eq!(resolved.base_delay, policy_defaults.base_delay);
+        assert_ne!(resolved.max_attempts, 999);
+    }
+
+    #[test]
+    fn resolve_aggressive_policy_uses_aggressive_defaults() {
+        let config = config_with_policy(RetryPolicy::Aggressive);
+        let policy_defaults = RetryPolicy::Aggressive.to_config();
+
+        let resolved = resolve(&config, &empty_cli());
+
+        assert_eq!(resolved.max_attempts, policy_defaults.max_attempts);
+        assert_eq!(resolved.base_delay, policy_defaults.base_delay);
+        assert_eq!(resolved.max_delay, policy_defaults.max_delay);
+        assert_eq!(resolved.strategy, policy_defaults.strategy);
+        assert_eq!(resolved.jitter, policy_defaults.jitter);
+    }
+
+    #[test]
+    fn resolve_conservative_policy_uses_conservative_defaults() {
+        let config = config_with_policy(RetryPolicy::Conservative);
+        let policy_defaults = RetryPolicy::Conservative.to_config();
+
+        let resolved = resolve(&config, &empty_cli());
+
+        assert_eq!(resolved.max_attempts, policy_defaults.max_attempts);
+        assert_eq!(resolved.base_delay, policy_defaults.base_delay);
+    }
+
+    #[test]
+    fn resolve_custom_policy_uses_config_fields_directly() {
+        let config = RetryConfig {
+            policy: RetryPolicy::Custom,
+            max_attempts: 17,
+            base_delay: Duration::from_millis(250),
+            max_delay: Duration::from_secs(45),
+            jitter: 0.25,
+            ..RetryConfig::default()
+        };
+
+        let resolved = resolve(&config, &empty_cli());
+
+        assert_eq!(resolved.max_attempts, 17);
+        assert_eq!(resolved.base_delay, Duration::from_millis(250));
+        assert_eq!(resolved.max_delay, Duration::from_secs(45));
+        assert_eq!(resolved.jitter, 0.25);
+    }
+
+    #[test]
+    fn resolve_cli_max_attempts_overrides_policy_default() {
+        let config = config_with_policy(RetryPolicy::Default);
+        let mut cli = empty_cli();
+        cli.max_attempts = Some(42);
+
+        let resolved = resolve(&config, &cli);
+
+        assert_eq!(resolved.max_attempts, 42);
+    }
+
+    #[test]
+    fn resolve_cli_max_attempts_overrides_custom_policy() {
+        let config = RetryConfig {
+            policy: RetryPolicy::Custom,
+            max_attempts: 17,
+            ..RetryConfig::default()
+        };
+
+        let mut cli = empty_cli();
+        cli.max_attempts = Some(99);
+
+        let resolved = resolve(&config, &cli);
+
+        assert_eq!(resolved.max_attempts, 99);
+    }
+
+    #[test]
+    fn resolve_cli_base_delay_overrides_policy() {
+        let config = config_with_policy(RetryPolicy::Default);
+        let mut cli = empty_cli();
+        cli.base_delay = Some(Duration::from_millis(123));
+
+        let resolved = resolve(&config, &cli);
+
+        assert_eq!(resolved.base_delay, Duration::from_millis(123));
+    }
+
+    #[test]
+    fn resolve_cli_max_delay_overrides_policy() {
+        let config = config_with_policy(RetryPolicy::Default);
+        let mut cli = empty_cli();
+        cli.max_delay = Some(Duration::from_secs(300));
+
+        let resolved = resolve(&config, &cli);
+
+        assert_eq!(resolved.max_delay, Duration::from_secs(300));
+    }
+
+    #[test]
+    fn resolve_cli_strategy_overrides_policy() {
+        let config = config_with_policy(RetryPolicy::Default);
+        let mut cli = empty_cli();
+        cli.retry_strategy = Some(RetryStrategyType::Linear);
+
+        let resolved = resolve(&config, &cli);
+
+        assert_eq!(resolved.strategy, RetryStrategyType::Linear);
+    }
+
+    #[test]
+    fn resolve_cli_jitter_overrides_policy() {
+        let config = config_with_policy(RetryPolicy::Default);
+        let mut cli = empty_cli();
+        cli.retry_jitter = Some(0.75);
+
+        let resolved = resolve(&config, &cli);
+
+        assert_eq!(resolved.jitter, 0.75);
+    }
+
+    #[test]
+    fn resolve_per_error_is_cloned_through_unchanged() {
+        let config = RetryConfig {
+            per_error: PerErrorConfig::default(),
+            ..RetryConfig::default()
+        };
+
+        let resolved = resolve(&config, &empty_cli());
+
+        assert_eq!(
+            format!("{:?}", resolved.per_error),
+            format!("{:?}", config.per_error)
+        );
+    }
+
+    #[test]
+    fn resolve_cli_overrides_take_precedence_independently() {
+        // Mixed: some CLI overrides set, others unset; non-set should follow policy.
+        let config = config_with_policy(RetryPolicy::Conservative);
+        let mut cli = empty_cli();
+        cli.max_attempts = Some(7);
+        // base_delay, max_delay, strategy, jitter all None — should follow Conservative.
+
+        let policy_defaults = RetryPolicy::Conservative.to_config();
+        let resolved = resolve(&config, &cli);
+
+        assert_eq!(resolved.max_attempts, 7);
+        assert_eq!(resolved.base_delay, policy_defaults.base_delay);
+        assert_eq!(resolved.max_delay, policy_defaults.max_delay);
+        assert_eq!(resolved.strategy, policy_defaults.strategy);
+        assert_eq!(resolved.jitter, policy_defaults.jitter);
+    }
+}

--- a/crates/shipper-config/src/runtime_options/secrets.rs
+++ b/crates/shipper-config/src/runtime_options/secrets.rs
@@ -42,3 +42,209 @@ fn default_env_var(config: &EncryptionSettings) -> Option<String> {
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_cli() -> CliOverrides {
+        CliOverrides::default()
+    }
+
+    fn empty_webhook() -> WebhookConfig {
+        WebhookConfig::default()
+    }
+
+    fn empty_encryption() -> EncryptionConfigInner {
+        EncryptionConfigInner::default()
+    }
+
+    #[test]
+    fn resolve_webhook_returns_config_clone_when_cli_overrides_absent() {
+        let mut config = empty_webhook();
+        config.url = "https://hooks.example.com/abc".to_string();
+        config.secret = Some("file-secret".to_string());
+
+        let resolved = resolve_webhook(&config, &empty_cli());
+
+        assert_eq!(resolved.url, "https://hooks.example.com/abc");
+        assert_eq!(resolved.secret.as_deref(), Some("file-secret"));
+    }
+
+    #[test]
+    fn resolve_webhook_cli_url_overrides_config_url() {
+        let mut config = empty_webhook();
+        config.url = "https://hooks.example.com/from-config".to_string();
+
+        let mut cli = empty_cli();
+        cli.webhook_url = Some("https://hooks.example.com/from-cli".to_string());
+
+        let resolved = resolve_webhook(&config, &cli);
+
+        assert_eq!(resolved.url, "https://hooks.example.com/from-cli");
+    }
+
+    #[test]
+    fn resolve_webhook_cli_secret_overrides_config_secret() {
+        let mut config = empty_webhook();
+        config.secret = Some("file-secret".to_string());
+
+        let mut cli = empty_cli();
+        cli.webhook_secret = Some("cli-secret".to_string());
+
+        let resolved = resolve_webhook(&config, &cli);
+
+        assert_eq!(resolved.secret.as_deref(), Some("cli-secret"));
+    }
+
+    #[test]
+    fn resolve_webhook_cli_secret_can_introduce_secret_when_config_has_none() {
+        let config = empty_webhook();
+        assert!(config.secret.is_none());
+
+        let mut cli = empty_cli();
+        cli.webhook_secret = Some("only-from-cli".to_string());
+
+        let resolved = resolve_webhook(&config, &cli);
+
+        assert_eq!(resolved.secret.as_deref(), Some("only-from-cli"));
+    }
+
+    #[test]
+    fn resolve_webhook_preserves_non_overridden_fields() {
+        let mut config = empty_webhook();
+        config.url = "https://hooks.example.com/keep".to_string();
+        config.secret = Some("keep-me".to_string());
+        config.timeout_secs = 99;
+
+        let resolved = resolve_webhook(&config, &empty_cli());
+
+        assert_eq!(resolved.url, "https://hooks.example.com/keep");
+        assert_eq!(resolved.secret.as_deref(), Some("keep-me"));
+        assert_eq!(resolved.timeout_secs, 99);
+    }
+
+    #[test]
+    fn resolve_encryption_disabled_by_default_with_no_overrides() {
+        let resolved = resolve_encryption(&empty_encryption(), &empty_cli());
+
+        assert!(!resolved.enabled);
+        assert!(resolved.passphrase.is_none());
+        assert!(resolved.env_var.is_none());
+    }
+
+    #[test]
+    fn resolve_encryption_cli_encrypt_flag_enables_when_config_disabled() {
+        let mut cli = empty_cli();
+        cli.encrypt = true;
+
+        let resolved = resolve_encryption(&empty_encryption(), &cli);
+
+        assert!(resolved.enabled);
+    }
+
+    #[test]
+    fn resolve_encryption_config_enabled_alone_enables_without_cli_flag() {
+        let mut config = empty_encryption();
+        config.enabled = true;
+
+        let resolved = resolve_encryption(&config, &empty_cli());
+
+        assert!(resolved.enabled);
+    }
+
+    #[test]
+    fn resolve_encryption_cli_passphrase_wins_over_config_passphrase() {
+        let mut config = empty_encryption();
+        config.enabled = true;
+        config.passphrase = Some("from-config".to_string());
+
+        let mut cli = empty_cli();
+        cli.encrypt_passphrase = Some("from-cli".to_string());
+
+        let resolved = resolve_encryption(&config, &cli);
+
+        assert_eq!(resolved.passphrase.as_deref(), Some("from-cli"));
+    }
+
+    #[test]
+    fn resolve_encryption_falls_back_to_config_passphrase_when_cli_unset() {
+        let mut config = empty_encryption();
+        config.enabled = true;
+        config.passphrase = Some("from-config".to_string());
+
+        let resolved = resolve_encryption(&config, &empty_cli());
+
+        assert_eq!(resolved.passphrase.as_deref(), Some("from-config"));
+    }
+
+    #[test]
+    fn resolve_encryption_defaults_env_var_when_enabled_without_passphrase() {
+        let mut cli = empty_cli();
+        cli.encrypt = true;
+
+        let resolved = resolve_encryption(&empty_encryption(), &cli);
+
+        assert!(resolved.enabled);
+        assert!(resolved.passphrase.is_none());
+        assert_eq!(resolved.env_var.as_deref(), Some("SHIPPER_ENCRYPT_KEY"));
+    }
+
+    #[test]
+    fn resolve_encryption_does_not_default_env_var_when_passphrase_present() {
+        let mut cli = empty_cli();
+        cli.encrypt = true;
+        cli.encrypt_passphrase = Some("inline-passphrase".to_string());
+
+        let resolved = resolve_encryption(&empty_encryption(), &cli);
+
+        assert!(resolved.enabled);
+        assert!(resolved.passphrase.is_some());
+        assert!(resolved.env_var.is_none());
+    }
+
+    #[test]
+    fn resolve_encryption_does_not_default_env_var_when_disabled() {
+        let resolved = resolve_encryption(&empty_encryption(), &empty_cli());
+
+        assert!(!resolved.enabled);
+        assert!(resolved.env_var.is_none());
+    }
+
+    #[test]
+    fn resolve_encryption_explicit_env_key_overrides_default() {
+        let mut config = empty_encryption();
+        config.enabled = true;
+        config.env_key = Some("CUSTOM_ENCRYPT_VAR".to_string());
+
+        let resolved = resolve_encryption(&config, &empty_cli());
+
+        assert_eq!(resolved.env_var.as_deref(), Some("CUSTOM_ENCRYPT_VAR"));
+    }
+
+    #[test]
+    fn resolve_encryption_explicit_env_key_is_kept_even_with_passphrase() {
+        let mut config = empty_encryption();
+        config.enabled = true;
+        config.passphrase = Some("p".to_string());
+        config.env_key = Some("CUSTOM_KEY".to_string());
+
+        let resolved = resolve_encryption(&config, &empty_cli());
+
+        assert_eq!(resolved.passphrase.as_deref(), Some("p"));
+        assert_eq!(resolved.env_var.as_deref(), Some("CUSTOM_KEY"));
+    }
+
+    #[test]
+    fn resolve_encryption_both_sources_enable_uses_or_semantics() {
+        let mut config = empty_encryption();
+        config.enabled = true;
+
+        let mut cli = empty_cli();
+        cli.encrypt = true;
+
+        let resolved = resolve_encryption(&config, &cli);
+
+        assert!(resolved.enabled);
+    }
+}


### PR DESCRIPTION
## Summary

Refreshed this stale draft on current main and reduced it to the three runtime-options coverage gaps that were not already superseded by merged tests.

Adds focused tests for:

- secrets: an explicit encryption env key is preserved even when a config passphrase is also present.
- retry: a partial CLI override on a preset retry policy overrides only the supplied field while unset fields continue to use the preset policy defaults.
- registry: a named registry resolved through CLI selection preserves the configured index_base.

No behavior change; tests only.

## Review notes

- Most original #279 coverage was already present on main under renamed or stronger tests.
- Independent read-only conflict disposition identified these three remaining useful cases.

## Test plan

- [x] cargo test -p shipper-config --locked
- [x] cargo clippy -p shipper-config --all-targets --locked -- -D warnings
- [x] cargo fmt --all -- --check
- [x] cargo xtask check-file-policy --mode blocking-allowlist
- [x] cargo xtask policy-report
- [x] git diff --check