### PR TITLE
feat(reconcile): persist reconciliation evidence artifact

### DIFF
--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -3006,6 +3006,7 @@ fn clean_single_dir(
 ) -> Result<()> {
     let state_path = dir.join(shipper_core::state::execution_state::STATE_FILE);
     let receipt_path = dir.join(shipper_core::state::execution_state::RECEIPT_FILE);
+    let reconciliation_path = dir.join(shipper_core::state::execution_state::RECONCILIATION_FILE);
     let lock_path = shipper_core::lock::lock_path(dir, Some(workspace_root));
 
     // Check for active lock
@@ -3064,6 +3065,21 @@ fn clean_single_dir(
         println!(
             "Kept: {} (--keep-receipt specified)",
             receipt_path.display()
+        );
+    }
+
+    if !keep_receipt && reconciliation_path.exists() {
+        std::fs::remove_file(&reconciliation_path).with_context(|| {
+            format!(
+                "failed to remove reconciliation file {}",
+                reconciliation_path.display()
+            )
+        })?;
+        println!("Removed: {}", reconciliation_path.display());
+    } else if keep_receipt && reconciliation_path.exists() {
+        println!(
+            "Kept: {} (--keep-receipt specified)",
+            reconciliation_path.display()
         );
     }
 
@@ -3809,6 +3825,8 @@ mode = "fast"
 
         let state_path = abs_state.join(shipper_core::state::execution_state::STATE_FILE);
         let receipt_path = abs_state.join(shipper_core::state::execution_state::RECEIPT_FILE);
+        let reconciliation_path =
+            abs_state.join(shipper_core::state::execution_state::RECONCILIATION_FILE);
         let events_path = abs_state.join(shipper_core::state::events::EVENTS_FILE);
         let preflight_only_events_path =
             abs_state.join("preflight-only-20260421T010101000000000Z-pid123.events.jsonl");
@@ -3816,6 +3834,7 @@ mode = "fast"
 
         fs::write(&state_path, "{}").expect("write state");
         fs::write(&receipt_path, "{}").expect("write receipt");
+        fs::write(&reconciliation_path, "{}").expect("write reconciliation");
         fs::write(&events_path, "{}").expect("write events");
         fs::write(&preflight_only_events_path, "{}").expect("write preflight-only events");
 
@@ -3835,6 +3854,10 @@ mode = "fast"
 
         assert!(!state_path.exists(), "state file should be removed");
         assert!(!receipt_path.exists(), "receipt file should be removed");
+        assert!(
+            !reconciliation_path.exists(),
+            "reconciliation file should be removed"
+        );
         assert!(!events_path.exists(), "events file should be removed");
         assert!(
             !preflight_only_events_path.exists(),

--- a/crates/shipper-cli/tests/e2e_expanded.rs
+++ b/crates/shipper-cli/tests/e2e_expanded.rs
@@ -706,6 +706,7 @@ fn clean_removes_state_and_events_files() {
     fs::write(state_dir.join("state.json"), "{}").expect("write state");
     fs::write(state_dir.join("events.jsonl"), "").expect("write events");
     fs::write(state_dir.join("receipt.json"), "{}").expect("write receipt");
+    fs::write(state_dir.join("reconciliation.json"), "{}").expect("write reconciliation");
 
     shipper_cmd()
         .arg("--manifest-path")
@@ -721,6 +722,7 @@ fn clean_removes_state_and_events_files() {
     assert!(!state_dir.join("state.json").exists());
     assert!(!state_dir.join("events.jsonl").exists());
     assert!(!state_dir.join("receipt.json").exists());
+    assert!(!state_dir.join("reconciliation.json").exists());
 }
 
 #[test]
@@ -733,6 +735,7 @@ fn clean_keep_receipt_preserves_receipt_file() {
     fs::write(state_dir.join("state.json"), "{}").expect("write state");
     fs::write(state_dir.join("events.jsonl"), "").expect("write events");
     fs::write(state_dir.join("receipt.json"), "{}").expect("write receipt");
+    fs::write(state_dir.join("reconciliation.json"), "{}").expect("write reconciliation");
 
     shipper_cmd()
         .arg("--manifest-path")
@@ -756,6 +759,10 @@ fn clean_keep_receipt_preserves_receipt_file() {
     assert!(
         state_dir.join("receipt.json").exists(),
         "receipt.json should be preserved with --keep-receipt"
+    );
+    assert!(
+        state_dir.join("reconciliation.json").exists(),
+        "reconciliation.json should be preserved with --keep-receipt"
     );
 }
 

--- a/crates/shipper-core/src/engine/mod.rs
+++ b/crates/shipper-core/src/engine/mod.rs
@@ -785,6 +785,14 @@ pub fn run_publish(
                 });
                 event_log.write_to_file(&events_path)?;
                 event_log.clear();
+                if let Err(err) = crate::state::reconciliation::write_report_from_events(
+                    &state_dir,
+                    &ws.plan.plan_id,
+                    &ws.plan.registry,
+                    &events_path,
+                ) {
+                    reporter.warn(&format!("failed to write reconciliation report: {err}"));
+                }
 
                 match outcome {
                     ReconciliationOutcome::Published { .. } => {

--- a/crates/shipper-core/src/engine/parallel/publish.rs
+++ b/crates/shipper-core/src/engine/parallel/publish.rs
@@ -92,6 +92,22 @@ pub(super) fn emit_retry_backoff(
     );
 }
 
+fn write_reconciliation_report_best_effort(
+    state_dir: &Path,
+    ws: &PlannedWorkspace,
+    events_path: &Path,
+    reporter: &Arc<SendReporter>,
+) {
+    if let Err(err) = crate::state::reconciliation::write_report_from_events(
+        state_dir,
+        &ws.plan.plan_id,
+        &ws.plan.registry,
+        events_path,
+    ) {
+        reporter.warn(&format!("failed to write reconciliation report: {err}"));
+    }
+}
+
 /// Publish a single package with retries (parallel-safe version)
 #[allow(clippy::too_many_arguments)]
 pub(super) fn publish_package(
@@ -246,6 +262,7 @@ pub(super) fn publish_package(
             let _ = log.write_to_file(events_path);
             log.clear();
         }
+        write_reconciliation_report_best_effort(state_dir, ws, events_path, reporter);
 
         match outcome {
             ReconciliationOutcome::Published { .. } => {
@@ -482,7 +499,10 @@ pub(super) fn publish_package(
                             },
                             package: pkg_label.clone(),
                         });
+                        let _ = log.write_to_file(events_path);
+                        log.clear();
                     }
+                    write_reconciliation_report_best_effort(state_dir, ws, events_path, reporter);
 
                     match outcome {
                         ReconciliationOutcome::Published { .. } => {

--- a/crates/shipper-core/src/engine/parallel/tests.rs
+++ b/crates/shipper-core/src/engine/parallel/tests.rs
@@ -4364,6 +4364,107 @@ fn reconcile_bdd_resume_from_ambiguous_state_skips_republish() {
 
 #[test]
 #[serial]
+fn reconcile_bdd_resume_from_ambiguous_state_still_unknown_writes_report() {
+    // Scenario:
+    //   A prior run left demo@0.1.0 in PackageState::Ambiguous. On resume,
+    //   the entry "already published" check returns 404, then registry
+    //   reconciliation cannot reach truth. Shipper must halt, must not
+    //   republish, and must leave a reconciliation artifact for operators.
+    let td = tempdir().expect("tempdir");
+    let bin = td.path().join("bin");
+    write_fake_tools(&bin);
+
+    let server = spawn_registry_server(
+        BTreeMap::from([(
+            "/api/v1/crates/demo/0.1.0".to_string(),
+            vec![(404, "{}".to_string()), (500, "{}".to_string())],
+        )]),
+        2,
+    );
+
+    let ws = planned_workspace(td.path(), server.base_url.clone());
+    let reg = RegistryClient::new(ws.plan.registry.api_base.as_str());
+    let opts = reconcile_scenario_opts(PathBuf::from(".shipper"));
+    let state_dir = td.path().join(".shipper");
+
+    let mut initial_state =
+        init_state_for_package(&ws.plan.plan_id, &ws.plan.registry, "demo", "0.1.0");
+    if let Some(pr) = initial_state.packages.get_mut("demo@0.1.0") {
+        pr.state = PackageState::Ambiguous {
+            message: "prior reconciliation inconclusive".to_string(),
+        };
+    }
+    let st = Arc::new(Mutex::new(initial_state));
+    let event_log = Arc::new(Mutex::new(events::EventLog::new()));
+    let events_path = events::events_path(&state_dir);
+    let reporter = make_send_reporter();
+    let cargo_log = td.path().join("cargo-calls.log");
+
+    temp_env::with_vars(
+        [
+            (
+                "SHIPPER_CARGO_BIN",
+                Some(fake_cargo_path(&bin).to_str().expect("utf8")),
+            ),
+            (
+                "SHIPPER_CARGO_ARGS_LOG",
+                Some(cargo_log.to_str().expect("utf8")),
+            ),
+            ("SHIPPER_CARGO_EXIT", Some("0")),
+        ],
+        || {
+            let result = publish_package(
+                &ws.plan.packages[0],
+                &ws,
+                &opts,
+                &reg,
+                &st,
+                &state_dir,
+                &event_log,
+                &events_path,
+                &reporter,
+            );
+
+            let err = result
+                .result
+                .expect_err("resume-path StillUnknown must halt with Err");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("resume reconciliation still inconclusive"),
+                "expected resume inconclusive error, got: {msg}"
+            );
+        },
+    );
+
+    let cargo_invoked = std::fs::read_to_string(&cargo_log)
+        .map(|s| !s.trim().is_empty())
+        .unwrap_or(false);
+    assert!(
+        !cargo_invoked,
+        "cargo should not be invoked when resume reconciliation is StillUnknown"
+    );
+
+    let report_path = crate::state::execution_state::reconciliation_path(&state_dir);
+    let report_json = std::fs::read_to_string(&report_path).expect("read reconciliation report");
+    let report: shipper_types::ReconciliationReport =
+        serde_json::from_str(&report_json).expect("parse reconciliation report");
+    assert_eq!(report.schema_version, "shipper.reconciliation.v1");
+    assert_eq!(report.records.len(), 1);
+    assert_eq!(
+        report.records[0].trigger,
+        shipper_types::ReconciliationTrigger::ResumeAmbiguousState
+    );
+    assert_eq!(report.records[0].cargo_exit_class, None);
+    assert_eq!(
+        report.records[0].operator_action,
+        shipper_types::ReconciliationOperatorAction::OperatorActionRequired
+    );
+
+    server.join();
+}
+
+#[test]
+#[serial]
 fn reconcile_bdd_ambiguous_resolves_to_still_unknown() {
     // Scenario: cargo exits ambiguously and the registry is itself unhealthy —
     // every reconciliation query returns 5xx. `version_exists` bails with Err
@@ -4495,6 +4596,16 @@ fn reconcile_bdd_ambiguous_resolves_to_still_unknown() {
     assert!(
         has_reconciled_still_unknown,
         "expected PublishReconciled with StillUnknown outcome"
+    );
+    let report_path = crate::state::execution_state::reconciliation_path(&state_dir);
+    let report_json = std::fs::read_to_string(&report_path).expect("read reconciliation report");
+    let report: shipper_types::ReconciliationReport =
+        serde_json::from_str(&report_json).expect("parse reconciliation report");
+    assert_eq!(report.schema_version, "shipper.reconciliation.v1");
+    assert_eq!(report.records.len(), 1);
+    assert_eq!(
+        report.records[0].operator_action,
+        shipper_types::ReconciliationOperatorAction::OperatorActionRequired
     );
 
     server.join();

--- a/crates/shipper-core/src/engine/publish/finalize.rs
+++ b/crates/shipper-core/src/engine/publish/finalize.rs
@@ -64,6 +64,7 @@ pub(in crate::engine) fn finish_sequential_run(
         run_started,
         git_context,
         environment,
+        events_path,
     )
 }
 
@@ -98,6 +99,7 @@ pub(in crate::engine) fn finish_parallel_run(
         run_started,
         git_context,
         environment,
+        events_path,
     )
 }
 
@@ -109,6 +111,7 @@ fn write_receipt(
     run_started: DateTime<Utc>,
     git_context: Option<GitContext>,
     environment: EnvironmentFingerprint,
+    events_path: &Path,
 ) -> Result<Receipt> {
     let receipt = Receipt {
         receipt_version: "shipper.receipt.v2".to_string(),
@@ -122,6 +125,12 @@ fn write_receipt(
         environment,
     };
 
+    crate::state::reconciliation::write_report_from_events(
+        state_dir,
+        &ws.plan.plan_id,
+        &ws.plan.registry,
+        events_path,
+    )?;
     state::write_receipt(state_dir, &receipt)?;
     Ok(receipt)
 }

--- a/crates/shipper-core/src/state/execution_state/mod.rs
+++ b/crates/shipper-core/src/state/execution_state/mod.rs
@@ -21,7 +21,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 
 use crate::runtime::environment::collect_environment_fingerprint;
-use shipper_types::{ExecutionState, Receipt};
+use shipper_types::{ExecutionState, Receipt, ReconciliationReport};
 
 #[cfg(test)]
 mod tests;
@@ -40,6 +40,7 @@ pub const CURRENT_PLAN_VERSION: &str = "shipper.plan.v1";
 
 pub const STATE_FILE: &str = "state.json";
 pub const RECEIPT_FILE: &str = "receipt.json";
+pub const RECONCILIATION_FILE: &str = "reconciliation.json";
 
 pub fn state_path(state_dir: &Path) -> PathBuf {
     state_dir.join(STATE_FILE)
@@ -47,6 +48,10 @@ pub fn state_path(state_dir: &Path) -> PathBuf {
 
 pub fn receipt_path(state_dir: &Path) -> PathBuf {
     state_dir.join(RECEIPT_FILE)
+}
+
+pub fn reconciliation_path(state_dir: &Path) -> PathBuf {
+    state_dir.join(RECONCILIATION_FILE)
 }
 
 pub fn load_state(state_dir: &Path) -> Result<Option<ExecutionState>> {
@@ -75,6 +80,14 @@ pub fn write_receipt(state_dir: &Path, receipt: &Receipt) -> Result<()> {
 
     let path = receipt_path(state_dir);
     atomic_write_json(&path, receipt)
+}
+
+pub fn write_reconciliation_report(state_dir: &Path, report: &ReconciliationReport) -> Result<()> {
+    fs::create_dir_all(state_dir)
+        .with_context(|| format!("failed to create state dir {}", state_dir.display()))?;
+
+    let path = reconciliation_path(state_dir);
+    atomic_write_json(&path, report)
 }
 
 /// Clear state file (state.json) from state directory

--- a/crates/shipper-core/src/state/mod.rs
+++ b/crates/shipper-core/src/state/mod.rs
@@ -6,4 +6,5 @@
 pub mod consistency;
 pub mod events;
 pub mod execution_state;
+pub mod reconciliation;
 pub mod rehearsal;

--- a/crates/shipper-core/src/state/reconciliation.rs
+++ b/crates/shipper-core/src/state/reconciliation.rs
@@ -1,0 +1,278 @@
+//! Persist reconciliation evidence derived from the authoritative event log.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use shipper_types::{
+    ErrorClass, EventType, ReadinessMethod, ReconciliationEvidenceKind,
+    ReconciliationEvidenceSource, ReconciliationOperatorAction, ReconciliationRecord,
+    ReconciliationReport, ReconciliationTrigger, Registry,
+};
+
+use super::events::EventLog;
+use super::execution_state;
+
+pub const RECONCILIATION_SCHEMA_VERSION: &str = "shipper.reconciliation.v1";
+
+pub fn write_report_from_events(
+    state_dir: &Path,
+    plan_id: &str,
+    registry: &Registry,
+    events_path: &Path,
+) -> Result<Option<ReconciliationReport>> {
+    let log = EventLog::read_from_file(events_path)
+        .with_context(|| format!("failed to read event log from {}", events_path.display()))?;
+    let records = records_from_event_log(&log);
+    let report_path = execution_state::reconciliation_path(state_dir);
+
+    if records.is_empty() {
+        if report_path.exists() {
+            std::fs::remove_file(&report_path).with_context(|| {
+                format!(
+                    "failed to remove stale reconciliation report {}",
+                    report_path.display()
+                )
+            })?;
+        }
+        return Ok(None);
+    }
+
+    let evidence_sources = vec![ReconciliationEvidenceSource {
+        kind: ReconciliationEvidenceKind::EventLog,
+        path: events_path.display().to_string(),
+    }];
+
+    let report = ReconciliationReport {
+        schema_version: RECONCILIATION_SCHEMA_VERSION.to_string(),
+        plan_id: plan_id.to_string(),
+        registry: registry.clone(),
+        generated_at: Utc::now(),
+        evidence_sources,
+        records,
+    };
+
+    execution_state::write_reconciliation_report(state_dir, &report)?;
+    Ok(Some(report))
+}
+
+fn records_from_event_log(log: &EventLog) -> Vec<ReconciliationRecord> {
+    let mut methods: BTreeMap<String, ReadinessMethod> = BTreeMap::new();
+    let mut ambiguous_cargo_failures = BTreeSet::new();
+    let mut records = Vec::new();
+
+    for event in log.all_events() {
+        match &event.event_type {
+            EventType::PackageFailed {
+                class: ErrorClass::Ambiguous,
+                ..
+            } => {
+                ambiguous_cargo_failures.insert(event.package.clone());
+            }
+            EventType::PublishReconciling { method } => {
+                methods.insert(event.package.clone(), *method);
+            }
+            EventType::PublishReconciled { outcome } => {
+                let trigger = if ambiguous_cargo_failures.contains(&event.package) {
+                    ReconciliationTrigger::CargoAmbiguousExit
+                } else {
+                    ReconciliationTrigger::ResumeAmbiguousState
+                };
+                ambiguous_cargo_failures.remove(&event.package);
+                let cargo_exit_class = match trigger {
+                    ReconciliationTrigger::CargoAmbiguousExit => Some(ErrorClass::Ambiguous),
+                    ReconciliationTrigger::ResumeAmbiguousState => None,
+                };
+                let operator_action = match outcome {
+                    shipper_types::ReconciliationOutcome::Published { .. } => {
+                        ReconciliationOperatorAction::MarkPublishedContinue
+                    }
+                    shipper_types::ReconciliationOutcome::NotPublished { .. } => {
+                        ReconciliationOperatorAction::RetryAllowed
+                    }
+                    shipper_types::ReconciliationOutcome::StillUnknown { .. } => {
+                        ReconciliationOperatorAction::OperatorActionRequired
+                    }
+                };
+                let (name, version) = split_package_label(&event.package);
+                records.push(ReconciliationRecord {
+                    package: event.package.clone(),
+                    name,
+                    version,
+                    trigger,
+                    method: methods.get(&event.package).copied(),
+                    cargo_exit_class,
+                    outcome: outcome.clone(),
+                    operator_action,
+                });
+            }
+            _ => {}
+        }
+    }
+
+    records
+}
+
+fn split_package_label(package: &str) -> (String, String) {
+    if let Some((name, version)) = package.rsplit_once('@') {
+        return (name.to_string(), version.to_string());
+    }
+    (package.to_string(), String::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use shipper_types::{
+        ErrorClass, EventType, PublishEvent, ReadinessMethod, ReconciliationOutcome,
+    };
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn writes_reconciliation_report_from_reconciled_events() {
+        let td = tempdir().expect("tempdir");
+        let state_dir = td.path().join(".shipper");
+        let events_path = super::super::events::events_path(&state_dir);
+        let mut log = EventLog::new();
+        log.record(PublishEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::PackageFailed {
+                class: ErrorClass::Ambiguous,
+                message: "cargo exited before registry truth was known".to_string(),
+            },
+            package: "shipper-core@0.4.0".to_string(),
+        });
+        log.record(PublishEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::PublishReconciling {
+                method: ReadinessMethod::Both,
+            },
+            package: "shipper-core@0.4.0".to_string(),
+        });
+        log.record(PublishEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::PublishReconciled {
+                outcome: ReconciliationOutcome::Published {
+                    attempts: 2,
+                    elapsed_ms: 1500,
+                },
+            },
+            package: "shipper-core@0.4.0".to_string(),
+        });
+        log.write_to_file(&events_path).expect("write events");
+
+        let report =
+            write_report_from_events(&state_dir, "plan-123", &Registry::crates_io(), &events_path)
+                .expect("write report")
+                .expect("report");
+
+        assert_eq!(report.schema_version, RECONCILIATION_SCHEMA_VERSION);
+        assert_eq!(report.plan_id, "plan-123");
+        assert_eq!(report.evidence_sources.len(), 1);
+        assert_eq!(
+            report.evidence_sources[0].kind,
+            ReconciliationEvidenceKind::EventLog
+        );
+        assert_eq!(report.records.len(), 1);
+        let record = &report.records[0];
+        assert_eq!(record.package, "shipper-core@0.4.0");
+        assert_eq!(record.name, "shipper-core");
+        assert_eq!(record.version, "0.4.0");
+        assert_eq!(record.trigger, ReconciliationTrigger::CargoAmbiguousExit);
+        assert_eq!(record.method, Some(ReadinessMethod::Both));
+        assert_eq!(record.cargo_exit_class, Some(ErrorClass::Ambiguous));
+        assert_eq!(
+            record.operator_action,
+            ReconciliationOperatorAction::MarkPublishedContinue
+        );
+        assert!(execution_state::reconciliation_path(&state_dir).exists());
+    }
+
+    #[test]
+    fn removes_stale_report_when_current_events_have_no_reconciliation() {
+        let td = tempdir().expect("tempdir");
+        let state_dir = td.path().join(".shipper");
+        std::fs::create_dir_all(&state_dir).expect("mkdir");
+        let report_path = execution_state::reconciliation_path(&state_dir);
+        std::fs::write(&report_path, "{}").expect("write stale");
+        let events_path = super::super::events::events_path(&state_dir);
+
+        let report =
+            write_report_from_events(&state_dir, "plan-123", &Registry::crates_io(), &events_path)
+                .expect("write report");
+
+        assert!(report.is_none());
+        assert!(!report_path.exists());
+    }
+
+    #[test]
+    fn classifies_later_resume_reconciliation_after_prior_cargo_ambiguity() {
+        let td = tempdir().expect("tempdir");
+        let state_dir = td.path().join(".shipper");
+        let events_path = super::super::events::events_path(&state_dir);
+        let mut log = EventLog::new();
+        log.record(PublishEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::PackageFailed {
+                class: ErrorClass::Ambiguous,
+                message: "cargo exited before registry truth was known".to_string(),
+            },
+            package: "shipper-core@0.4.0".to_string(),
+        });
+        log.record(PublishEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::PublishReconciling {
+                method: ReadinessMethod::Both,
+            },
+            package: "shipper-core@0.4.0".to_string(),
+        });
+        log.record(PublishEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::PublishReconciled {
+                outcome: ReconciliationOutcome::StillUnknown {
+                    attempts: 1,
+                    elapsed_ms: 20,
+                    reason: "registry unavailable".to_string(),
+                },
+            },
+            package: "shipper-core@0.4.0".to_string(),
+        });
+        log.record(PublishEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::PublishReconciling {
+                method: ReadinessMethod::Both,
+            },
+            package: "shipper-core@0.4.0".to_string(),
+        });
+        log.record(PublishEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::PublishReconciled {
+                outcome: ReconciliationOutcome::Published {
+                    attempts: 1,
+                    elapsed_ms: 15,
+                },
+            },
+            package: "shipper-core@0.4.0".to_string(),
+        });
+        log.write_to_file(&events_path).expect("write events");
+
+        let report =
+            write_report_from_events(&state_dir, "plan-123", &Registry::crates_io(), &events_path)
+                .expect("write report")
+                .expect("report");
+
+        assert_eq!(report.records.len(), 2);
+        assert_eq!(
+            report.records[0].trigger,
+            ReconciliationTrigger::CargoAmbiguousExit
+        );
+        assert_eq!(
+            report.records[1].trigger,
+            ReconciliationTrigger::ResumeAmbiguousState
+        );
+        assert_eq!(report.records[1].cargo_exit_class, None);
+    }
+}

--- a/crates/shipper-core/src/state/store/fs.rs
+++ b/crates/shipper-core/src/state/store/fs.rs
@@ -62,6 +62,7 @@ impl StateStore for FileStore {
     fn clear(&self) -> Result<()> {
         let state_path = state::state_path(&self.state_dir);
         let receipt_path = state::receipt_path(&self.state_dir);
+        let reconciliation_path = state::reconciliation_path(&self.state_dir);
         let events_path = crate::state::events::events_path(&self.state_dir);
 
         // Remove files if they exist
@@ -72,6 +73,14 @@ impl StateStore for FileStore {
         if receipt_path.exists() {
             std::fs::remove_file(&receipt_path).with_context(|| {
                 format!("failed to remove receipt file {}", receipt_path.display())
+            })?;
+        }
+        if reconciliation_path.exists() {
+            std::fs::remove_file(&reconciliation_path).with_context(|| {
+                format!(
+                    "failed to remove reconciliation file {}",
+                    reconciliation_path.display()
+                )
             })?;
         }
         if events_path.exists() {

--- a/crates/shipper-core/src/state/store/tests.rs
+++ b/crates/shipper-core/src/state/store/tests.rs
@@ -599,12 +599,18 @@ fn file_store_clear_removes_events_too() {
     store.save_events(&events).expect("save events");
     store.save_state(&sample_state()).expect("save state");
     store.save_receipt(&sample_receipt()).expect("save receipt");
+    let reconciliation_path = crate::state::execution_state::reconciliation_path(td.path());
+    std::fs::write(&reconciliation_path, "{}").expect("save reconciliation");
 
     store.clear().expect("clear");
 
     assert!(store.load_state().expect("load state").is_none());
     assert!(store.load_receipt().expect("load receipt").is_none());
     assert!(store.load_events().expect("load events").is_none());
+    assert!(
+        !reconciliation_path.exists(),
+        "reconciliation report should be removed"
+    );
 }
 
 #[test]

--- a/crates/shipper-types/src/lib.rs
+++ b/crates/shipper-types/src/lib.rs
@@ -1100,6 +1100,68 @@ pub enum ReconciliationOutcome {
     },
 }
 
+/// Persisted report of registry-truth reconciliation outcomes for a release run.
+///
+/// This artifact is written to `.shipper/reconciliation.json` when a publish or
+/// resume run emits at least one [`EventType::PublishReconciled`] event. It is
+/// derived from the authoritative event log so humans, CI, and agents can
+/// inspect the ambiguity-resolution record without replaying every event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReconciliationReport {
+    pub schema_version: String,
+    pub plan_id: String,
+    pub registry: Registry,
+    pub generated_at: DateTime<Utc>,
+    pub evidence_sources: Vec<ReconciliationEvidenceSource>,
+    pub records: Vec<ReconciliationRecord>,
+}
+
+/// File or artifact referenced by a reconciliation report.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReconciliationEvidenceSource {
+    pub kind: ReconciliationEvidenceKind,
+    pub path: String,
+}
+
+/// Kind of artifact referenced by [`ReconciliationEvidenceSource`].
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReconciliationEvidenceKind {
+    EventLog,
+    State,
+    Receipt,
+}
+
+/// One package-level reconciliation outcome.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReconciliationRecord {
+    pub package: String,
+    pub name: String,
+    pub version: String,
+    pub trigger: ReconciliationTrigger,
+    pub method: Option<ReadinessMethod>,
+    pub cargo_exit_class: Option<ErrorClass>,
+    pub outcome: ReconciliationOutcome,
+    pub operator_action: ReconciliationOperatorAction,
+}
+
+/// Why reconciliation was attempted.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReconciliationTrigger {
+    CargoAmbiguousExit,
+    ResumeAmbiguousState,
+}
+
+/// Machine-readable operator action implied by a reconciliation outcome.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReconciliationOperatorAction {
+    MarkPublishedContinue,
+    RetryAllowed,
+    OperatorActionRequired,
+}
+
 /// Progress tracking for a single package in an execution.
 ///
 /// This struct is persisted to disk during publishing to enable


### PR DESCRIPTION
## Summary
- add .shipper/reconciliation.json as an event-derived report for publish reconciliation outcomes
- write the report after reconciliation events in publish/resume paths and at finalization, removing stale reports when no reconciliation occurred
- include reconciliation.json in clean/StateStore cleanup semantics, preserving it with --keep-receipt

## Validation
- cargo fmt --all -- --check
- cargo test -p shipper-core reconciliation --locked
- cargo test -p shipper-core reconcile_bdd_resume_from_ambiguous_state_still_unknown_writes_report --locked
- cargo test -p shipper-core reconcile_bdd_ambiguous_resolves_to_still_unknown --locked
- cargo test -p shipper-core file_store_clear_removes_events_too --locked
- cargo test -p shipper-cli run_clean_force_removes_lock_and_state_files --locked
- cargo test -p shipper-cli --test e2e_expanded clean_keep_receipt_preserves_receipt_file --locked
- cargo test -p shipper-cli --test e2e_expanded clean_removes_state_and_events_files --locked
- cargo test -p shipper-cli --test e2e_expanded clean_keep_receipt --locked
- cargo test -p shipper-cli --test bdd_workflow clean_keep_receipt --locked
- cargo test -p shipper-types --locked
- cargo clippy -p shipper-core --all-targets --locked -- -D warnings
- cargo clippy -p shipper-cli --all-targets --locked -- -D warnings
- cargo clippy -p shipper-types --all-targets --locked -- -D warnings
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask check-generated --mode blocking-allowlist
- cargo xtask policy-report
- git diff --check

## Known validation gap
- cargo test -p shipper-core --locked ran 1,919 tests; 1 unrelated existing git cleanliness test failed locally: ops::git::cleanliness::tests::ensure_git_clean_new_phrasing returned Ok where the test expected a dirty-repo error. This branch does not touch crates/shipper-core/src/ops/git/cleanliness.rs.