### PR TITLE
feat(reconcile): reconcile sequential ambiguous publishes

### DIFF
--- a/crates/shipper-cli/tests/e2e_resume.rs
+++ b/crates/shipper-cli/tests/e2e_resume.rs
@@ -92,7 +92,7 @@ fn create_fake_cargo_proxy(bin_dir: &Path) {
     {
         fs::write(
             bin_dir.join("cargo.cmd"),
-            "@echo off\r\nif \"%1\"==\"publish\" (\r\n  if \"%SHIPPER_FAKE_PUBLISH_EXIT%\"==\"\" (exit /b 0) else (exit /b %SHIPPER_FAKE_PUBLISH_EXIT%)\r\n)\r\n\"%REAL_CARGO%\" %*\r\nexit /b %ERRORLEVEL%\r\n",
+            "@echo off\r\nif \"%1\"==\"publish\" (\r\n  if not \"%SHIPPER_FAKE_PUBLISH_STDOUT%\"==\"\" echo %SHIPPER_FAKE_PUBLISH_STDOUT%\r\n  if not \"%SHIPPER_FAKE_PUBLISH_STDERR%\"==\"\" echo %SHIPPER_FAKE_PUBLISH_STDERR% 1>&2\r\n  if \"%SHIPPER_FAKE_PUBLISH_EXIT%\"==\"\" (exit /b 0) else (exit /b %SHIPPER_FAKE_PUBLISH_EXIT%)\r\n)\r\n\"%REAL_CARGO%\" %*\r\nexit /b %ERRORLEVEL%\r\n",
         )
         .expect("write fake cargo");
     }
@@ -104,7 +104,7 @@ fn create_fake_cargo_proxy(bin_dir: &Path) {
         let path = bin_dir.join("cargo");
         fs::write(
             &path,
-            "#!/usr/bin/env sh\nif [ \"$1\" = \"publish\" ]; then\n  exit \"${SHIPPER_FAKE_PUBLISH_EXIT:-0}\"\nfi\n\"$REAL_CARGO\" \"$@\"\n",
+            "#!/usr/bin/env sh\nif [ \"$1\" = \"publish\" ]; then\n  if [ -n \"$SHIPPER_FAKE_PUBLISH_STDOUT\" ]; then\n    echo \"$SHIPPER_FAKE_PUBLISH_STDOUT\"\n  fi\n  if [ -n \"$SHIPPER_FAKE_PUBLISH_STDERR\" ]; then\n    echo \"$SHIPPER_FAKE_PUBLISH_STDERR\" >&2\n  fi\n  exit \"${SHIPPER_FAKE_PUBLISH_EXIT:-0}\"\nfi\n\"$REAL_CARGO\" \"$@\"\n",
         )
         .expect("write fake cargo");
         let mut perms = fs::metadata(&path).expect("meta").permissions();
@@ -220,10 +220,10 @@ fn resume_continues_from_failed_state() {
     let state_dir = td.path().join(".shipper");
 
     // Single registry for both publish and resume so plan_id stays consistent.
-    // Publish (fail): version-check 404, post-failure check 404, final-chance 404 → 3 requests
-    // Resume (success): version-check 404, readiness 200 → 2 requests
-    // Total: 5 requests
-    let registry = spawn_registry(vec![404, 404, 404, 404, 200], 5);
+    // Publish (permanent failure): version-check 404, post-failure check 404 -> 2 requests
+    // Resume (success): version-check 404, readiness 200 -> 2 requests
+    // Total: 4 requests
+    let registry = spawn_registry(vec![404, 404, 404, 200], 4);
 
     shipper_cmd()
         .arg("--manifest-path")
@@ -246,6 +246,7 @@ fn resume_continues_from_failed_state() {
         .env("REAL_CARGO", &real_cargo)
         .env("SHIPPER_CARGO_BIN", &fake_cargo)
         .env("SHIPPER_FAKE_PUBLISH_EXIT", "1")
+        .env("SHIPPER_FAKE_PUBLISH_STDERR", "permission denied")
         .assert()
         .failure();
 
@@ -473,17 +474,15 @@ fn resume_after_partial_publish() {
     let state_dir = td.path().join(".shipper");
 
     // Single registry for both publish and resume.
-    // Publish (cargo exit=1 so all cargo publish calls fail):
-    //   core version-check 200 (already on registry → skip): 1 request
+    // Publish (cargo emits a permanent failure):
+    //   core version-check 200 (already on registry -> skip): 1 request
     //   app version-check 404 (not published), cargo fails: 1 request
     //   app post-failure check 404: 1 request
-    //   app final-chance check 404: 1 request
     // Resume (cargo exit=0):
-    //   core already skipped in state → 0 requests
+    //   core already skipped in state -> 0 requests
     //   app version-check 404, cargo succeeds, readiness 200: 2 requests
-    // Total: 6 requests
-    // Add an extra buffer slot so the server stays alive between publish and resume.
-    let registry = spawn_registry(vec![200, 404, 404, 404, 404, 200], 7);
+    // Total: 5 requests
+    let registry = spawn_registry(vec![200, 404, 404, 404, 200], 5);
 
     // First: publish all crates with cargo failing.
     // core gets skipped (registry says 200 → already published), app fails.
@@ -508,6 +507,7 @@ fn resume_after_partial_publish() {
         .env("REAL_CARGO", &real_cargo)
         .env("SHIPPER_CARGO_BIN", &fake_cargo)
         .env("SHIPPER_FAKE_PUBLISH_EXIT", "1")
+        .env("SHIPPER_FAKE_PUBLISH_STDERR", "permission denied")
         .assert()
         .failure();
 

--- a/crates/shipper-core/src/engine/mod.rs
+++ b/crates/shipper-core/src/engine/mod.rs
@@ -75,6 +75,22 @@ pub(crate) fn policy_effects(opts: &RuntimeOptions) -> crate::runtime::policy::P
     crate::runtime::policy::policy_effects(opts)
 }
 
+fn write_reconciliation_report_best_effort(
+    state_dir: &Path,
+    ws: &PlannedWorkspace,
+    events_path: &Path,
+    reporter: &mut dyn Reporter,
+) {
+    if let Err(err) = crate::state::reconciliation::write_report_from_events(
+        state_dir,
+        &ws.plan.plan_id,
+        &ws.plan.registry,
+        events_path,
+    ) {
+        reporter.warn(&format!("failed to write reconciliation report: {err}"));
+    }
+}
+
 fn init_registry_client(registry: Registry, state_dir: &Path) -> Result<RegistryClient> {
     let cache_dir = state_dir.join("cache");
     RegistryClient::new(registry).map(|c| c.with_cache_dir(cache_dir))
@@ -785,21 +801,17 @@ pub fn run_publish(
                 });
                 event_log.write_to_file(&events_path)?;
                 event_log.clear();
-                if let Err(err) = crate::state::reconciliation::write_report_from_events(
-                    &state_dir,
-                    &ws.plan.plan_id,
-                    &ws.plan.registry,
-                    &events_path,
-                ) {
-                    reporter.warn(&format!("failed to write reconciliation report: {err}"));
-                }
+                write_reconciliation_report_best_effort(&state_dir, ws, &events_path, reporter);
+                let reconciliation_report_path = state::reconciliation_path(&state_dir);
 
                 match outcome {
                     ReconciliationOutcome::Published { .. } => {
                         update_state(&mut st, &state_dir, &key, PackageState::Published)?;
                         reporter.info(&format!(
-                            "{}@{}: reconciled as published on resume (no republish)",
-                            p.name, p.version
+                            "{}@{}: reconciliation outcome: Published; action: mark published and continue without republish (evidence: {})",
+                            p.name,
+                            p.version,
+                            reconciliation_report_path.display()
                         ));
                         continue;
                     }
@@ -809,15 +821,20 @@ pub fn run_publish(
                         // the normal publish flow is safe.
                         update_state(&mut st, &state_dir, &key, PackageState::Pending)?;
                         reporter.info(&format!(
-                            "{}@{}: reconciled as not published; proceeding with publish",
-                            p.name, p.version
+                            "{}@{}: reconciliation outcome: NotPublished; action: retry under publish policy (evidence: {})",
+                            p.name,
+                            p.version,
+                            reconciliation_report_path.display()
                         ));
                         // fall through to normal flow
                     }
                     ReconciliationOutcome::StillUnknown { reason, .. } => {
                         reporter.error(&format!(
-                            "{}@{}: resume reconciliation still inconclusive: {}",
-                            p.name, p.version, reason
+                            "{}@{}: reconciliation outcome: StillUnknown; action: stop before blind retry; operator action required (evidence: {}): {}",
+                            p.name,
+                            p.version,
+                            reconciliation_report_path.display(),
+                            reason
                         ));
                         webhook::maybe_send_event(
                             &opts.webhook,
@@ -991,26 +1008,135 @@ pub fn run_publish(
                     // Persist Uploaded state so resume skips cargo publish
                     update_state(&mut st, &state_dir, &key, PackageState::Uploaded)?;
                 } else {
-                    // Even if cargo fails, the publish may have succeeded (timeouts, network splits).
-                    // Always check the registry before deciding.
-                    reporter.warn(&format!(
-                        "{}@{}: cargo publish failed (exit={:?}); checking registry...",
-                        p.name, p.version, out.exit_code
-                    ));
-
-                    if reg.version_exists(&p.name, &p.version)? {
-                        reporter.info(&format!(
-                            "{}@{}: version is present on registry; treating as published",
-                            p.name, p.version
-                        ));
-                        update_state(&mut st, &state_dir, &key, PackageState::Published)?;
-                        last_err = None;
-                        break;
-                    }
-
                     let failure_output = format!("{}\n{}", out.stderr_tail, out.stdout_tail);
                     let (class, msg) = classify_cargo_failure(&out.stderr_tail, &out.stdout_tail);
                     last_err = Some((class.clone(), msg.clone()));
+
+                    if class == ErrorClass::Ambiguous {
+                        event_log.record(PublishEvent {
+                            timestamp: Utc::now(),
+                            event_type: EventType::PackageFailed {
+                                class: class.clone(),
+                                message: msg.clone(),
+                            },
+                            package: pkg_label.clone(),
+                        });
+                        event_log.record(PublishEvent {
+                            timestamp: Utc::now(),
+                            event_type: EventType::PublishReconciling {
+                                method: opts.readiness.method,
+                            },
+                            package: pkg_label.clone(),
+                        });
+                        reporter.warn(&format!(
+                            "{}@{}: cargo exit ambiguous; reconciling against registry truth before retry",
+                            p.name, p.version
+                        ));
+
+                        let readiness_config = crate::types::ReadinessConfig {
+                            enabled: effects.readiness_enabled,
+                            ..opts.readiness.clone()
+                        };
+                        let (outcome, reconcile_evidence) =
+                            sequential_reconcile(&reg, &p.name, &p.version, &readiness_config);
+
+                        event_log.record(PublishEvent {
+                            timestamp: Utc::now(),
+                            event_type: EventType::PublishReconciled {
+                                outcome: outcome.clone(),
+                            },
+                            package: pkg_label.clone(),
+                        });
+                        event_log.write_to_file(&events_path)?;
+                        event_log.clear();
+                        write_reconciliation_report_best_effort(
+                            &state_dir,
+                            ws,
+                            &events_path,
+                            reporter,
+                        );
+                        let reconciliation_report_path = state::reconciliation_path(&state_dir);
+
+                        match outcome {
+                            ReconciliationOutcome::Published { .. } => {
+                                reporter.info(&format!(
+                                    "{}@{}: reconciliation outcome: Published; registry shows version present; action: mark published and continue without retry (evidence: {})",
+                                    p.name,
+                                    p.version,
+                                    reconciliation_report_path.display()
+                                ));
+                                update_state(&mut st, &state_dir, &key, PackageState::Published)?;
+                                event_log.record(PublishEvent {
+                                    timestamp: Utc::now(),
+                                    event_type: EventType::PackagePublished {
+                                        duration_ms: start_instant.elapsed().as_millis() as u64,
+                                    },
+                                    package: pkg_label.clone(),
+                                });
+                                event_log.write_to_file(&events_path)?;
+                                event_log.clear();
+                                readiness_evidence = reconcile_evidence;
+                                last_err = None;
+                                break;
+                            }
+                            ReconciliationOutcome::NotPublished { .. } => {
+                                reporter.info(&format!(
+                                    "{}@{}: reconciliation outcome: NotPublished; registry still absent; action: retry under publish policy (evidence: {})",
+                                    p.name,
+                                    p.version,
+                                    reconciliation_report_path.display()
+                                ));
+                                readiness_evidence = reconcile_evidence;
+                            }
+                            ReconciliationOutcome::StillUnknown { reason, .. } => {
+                                let ambiguous_state = PackageState::Ambiguous {
+                                    message: reason.clone(),
+                                };
+                                update_state(&mut st, &state_dir, &key, ambiguous_state)?;
+                                reporter.error(&format!(
+                                    "{}@{}: reconciliation outcome: StillUnknown; action: stop before blind retry; operator action required (evidence: {}): {}",
+                                    p.name,
+                                    p.version,
+                                    reconciliation_report_path.display(),
+                                    reason
+                                ));
+                                webhook::maybe_send_event(
+                                    &opts.webhook,
+                                    WebhookEvent::PublishFailed {
+                                        plan_id: ws.plan.plan_id.clone(),
+                                        package_name: p.name.clone(),
+                                        package_version: p.version.clone(),
+                                        error_class: format!("{:?}", ErrorClass::Ambiguous),
+                                        message: format!("reconciliation inconclusive: {reason}"),
+                                    },
+                                );
+                                bail!(
+                                    "{}@{}: reconciliation inconclusive; operator action required: {}",
+                                    p.name,
+                                    p.version,
+                                    reason
+                                );
+                            }
+                        }
+                    } else {
+                        // Even if cargo fails, the publish may have succeeded (timeouts, network splits).
+                        // Non-ambiguous failures keep the historical quick registry check; ambiguous
+                        // failures use the full reconciliation state machine above.
+                        reporter.warn(&format!(
+                            "{}@{}: cargo publish failed (exit={:?}); checking registry...",
+                            p.name, p.version, out.exit_code
+                        ));
+
+                        if reg.version_exists(&p.name, &p.version)? {
+                            reporter.info(&format!(
+                                "{}@{}: version is present on registry; treating as published",
+                                p.name, p.version
+                            ));
+                            update_state(&mut st, &state_dir, &key, PackageState::Published)?;
+                            last_err = None;
+                            break;
+                        }
+                    }
 
                     match class {
                         ErrorClass::Permanent => {
@@ -1925,6 +2051,32 @@ mod tests {
                 "#!/usr/bin/env sh\nif [ -n \"$SHIPPER_CARGO_ARGS_LOG\" ]; then\n  echo \"$*\" >>\"$SHIPPER_CARGO_ARGS_LOG\"\nfi\nif [ -n \"$SHIPPER_CARGO_STDOUT\" ]; then\n  echo \"$SHIPPER_CARGO_STDOUT\"\nfi\nif [ -n \"$SHIPPER_CARGO_STDERR\" ]; then\n  echo \"$SHIPPER_CARGO_STDERR\" >&2\nfi\nexit \"${SHIPPER_CARGO_EXIT:-0}\"\n",
             )
             .expect("write fake cargo");
+            let mut perms = fs::metadata(&path).expect("meta").permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&path, perms).expect("chmod");
+        }
+    }
+
+    fn write_fake_cargo_ambiguous_then_permanent(bin_dir: &Path) {
+        #[cfg(windows)]
+        {
+            fs::write(
+                bin_dir.join("cargo.cmd"),
+                "@echo off\r\nif not \"%SHIPPER_CARGO_ARGS_LOG%\"==\"\" echo %*>>\"%SHIPPER_CARGO_ARGS_LOG%\"\r\nset COUNT_FILE=%SHIPPER_CARGO_COUNT_FILE%\r\nif \"%COUNT_FILE%\"==\"\" set COUNT_FILE=%TEMP%\\shipper-cargo-count.txt\r\nif not exist \"%COUNT_FILE%\" (\r\n  echo 1>\"%COUNT_FILE%\"\r\n  exit /b 1\r\n)\r\necho crate version 0.1.0 is already uploaded 1>&2\r\nexit /b 1\r\n",
+            )
+            .expect("write sequenced fake cargo");
+        }
+
+        #[cfg(not(windows))]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let path = bin_dir.join("cargo");
+            fs::write(
+                &path,
+                "#!/usr/bin/env sh\nif [ -n \"$SHIPPER_CARGO_ARGS_LOG\" ]; then\n  echo \"$*\" >>\"$SHIPPER_CARGO_ARGS_LOG\"\nfi\ncount_file=\"${SHIPPER_CARGO_COUNT_FILE:-${TMPDIR:-/tmp}/shipper-cargo-count.txt}\"\nif [ ! -f \"$count_file\" ]; then\n  echo 1 >\"$count_file\"\n  exit 1\nfi\necho 'crate version 0.1.0 is already uploaded' >&2\nexit 1\n",
+            )
+            .expect("write sequenced fake cargo");
             let mut perms = fs::metadata(&path).expect("meta").permissions();
             perms.set_mode(0o755);
             fs::set_permissions(&path, perms).expect("chmod");
@@ -3181,6 +3333,230 @@ mod tests {
                 matches!(pkg_state, PackageState::Skipped { .. }),
                 "expected state.json to show Skipped after resume reconciled against registry; got {pkg_state:?}"
             );
+            server.join();
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn sequential_ambiguous_publish_reconciles_to_published_without_retry() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        let cargo_log = td.path().join("cargo-calls.log");
+        let mut env_vars = fake_program_env_vars(&bin);
+        env_vars.extend([
+            ("SHIPPER_CARGO_EXIT", Some("1".to_string())),
+            ("SHIPPER_CARGO_STDERR", Some(String::new())),
+            ("SHIPPER_CARGO_STDOUT", Some(String::new())),
+            (
+                "SHIPPER_CARGO_ARGS_LOG",
+                Some(cargo_log.to_string_lossy().to_string()),
+            ),
+        ]);
+        temp_env::with_vars(env_vars, || {
+            let server = spawn_registry_server(
+                std::collections::BTreeMap::from([(
+                    "/api/v1/crates/demo/0.1.0".to_string(),
+                    vec![(404, "{}".to_string()), (200, "{}".to_string())],
+                )]),
+                2,
+            );
+            let ws = planned_workspace(td.path(), server.base_url.clone());
+            let state_dir = td.path().join(".shipper");
+            let mut opts = default_opts(state_dir.clone());
+            opts.max_attempts = 2;
+            opts.readiness.enabled = false;
+
+            let mut reporter = CollectingReporter::default();
+            let receipt = run_publish(&ws, &opts, &mut reporter).expect("publish");
+
+            assert!(matches!(receipt.packages[0].state, PackageState::Published));
+            assert!(
+                reporter
+                    .infos
+                    .iter()
+                    .any(|msg| msg.contains("reconciliation outcome: Published")
+                        && msg.contains("without retry")),
+                "infos: {:?}",
+                reporter.infos
+            );
+
+            let cargo_invocations = std::fs::read_to_string(&cargo_log)
+                .map(|s| s.lines().filter(|l| !l.trim().is_empty()).count())
+                .unwrap_or(0);
+            assert_eq!(cargo_invocations, 1, "must not retry after Published");
+
+            let events_path = events::events_path(&state_dir);
+            let events = events::EventLog::read_from_file(&events_path).expect("events");
+            assert!(
+                events
+                    .all_events()
+                    .iter()
+                    .any(|e| { matches!(e.event_type, EventType::PublishReconciling { .. }) })
+            );
+            assert!(events.all_events().iter().any(|e| {
+                matches!(
+                    &e.event_type,
+                    EventType::PublishReconciled {
+                        outcome: ReconciliationOutcome::Published { .. }
+                    }
+                )
+            }));
+
+            server.join();
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn sequential_ambiguous_publish_reconciles_to_not_published_then_retries_once() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        write_fake_cargo_ambiguous_then_permanent(&bin);
+        let cargo_log = td.path().join("cargo-calls.log");
+        let cargo_count = td.path().join("cargo-count.txt");
+        let mut env_vars = fake_program_env_vars(&bin);
+        env_vars.extend([
+            (
+                "SHIPPER_CARGO_ARGS_LOG",
+                Some(cargo_log.to_string_lossy().to_string()),
+            ),
+            (
+                "SHIPPER_CARGO_COUNT_FILE",
+                Some(cargo_count.to_string_lossy().to_string()),
+            ),
+        ]);
+        temp_env::with_vars(env_vars, || {
+            let server = spawn_registry_server(
+                std::collections::BTreeMap::from([(
+                    "/api/v1/crates/demo/0.1.0".to_string(),
+                    vec![
+                        (404, "{}".to_string()),
+                        (404, "{}".to_string()),
+                        (404, "{}".to_string()),
+                    ],
+                )]),
+                3,
+            );
+            let ws = planned_workspace(td.path(), server.base_url.clone());
+            let state_dir = td.path().join(".shipper");
+            let mut opts = default_opts(state_dir.clone());
+            opts.max_attempts = 2;
+            opts.readiness.enabled = false;
+
+            let mut reporter = CollectingReporter::default();
+            let err = run_publish(&ws, &opts, &mut reporter).expect_err("publish should fail");
+            let msg = format!("{err:#}");
+            assert!(msg.contains("permanent failure"), "err: {msg}");
+            assert!(
+                reporter
+                    .infos
+                    .iter()
+                    .any(|msg| msg.contains("reconciliation outcome: NotPublished")
+                        && msg.contains("retry under publish policy")),
+                "infos: {:?}",
+                reporter.infos
+            );
+
+            let cargo_invocations = std::fs::read_to_string(&cargo_log)
+                .map(|s| s.lines().filter(|l| !l.trim().is_empty()).count())
+                .unwrap_or(0);
+            assert_eq!(
+                cargo_invocations, 2,
+                "NotPublished reconciliation should permit one retry"
+            );
+
+            let events_path = events::events_path(&state_dir);
+            let events = events::EventLog::read_from_file(&events_path).expect("events");
+            assert!(events.all_events().iter().any(|e| {
+                matches!(
+                    &e.event_type,
+                    EventType::PublishReconciled {
+                        outcome: ReconciliationOutcome::NotPublished { .. }
+                    }
+                )
+            }));
+
+            server.join();
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn sequential_ambiguous_publish_still_unknown_stops_without_retry() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        let cargo_log = td.path().join("cargo-calls.log");
+        let mut env_vars = fake_program_env_vars(&bin);
+        env_vars.extend([
+            ("SHIPPER_CARGO_EXIT", Some("1".to_string())),
+            ("SHIPPER_CARGO_STDERR", Some(String::new())),
+            ("SHIPPER_CARGO_STDOUT", Some(String::new())),
+            (
+                "SHIPPER_CARGO_ARGS_LOG",
+                Some(cargo_log.to_string_lossy().to_string()),
+            ),
+        ]);
+        temp_env::with_vars(env_vars, || {
+            let server = spawn_registry_server(
+                std::collections::BTreeMap::from([(
+                    "/api/v1/crates/demo/0.1.0".to_string(),
+                    vec![(404, "{}".to_string()), (500, "{}".to_string())],
+                )]),
+                2,
+            );
+            let ws = planned_workspace(td.path(), server.base_url.clone());
+            let state_dir = td.path().join(".shipper");
+            let mut opts = default_opts(state_dir.clone());
+            opts.max_attempts = 2;
+            opts.readiness.enabled = false;
+
+            let mut reporter = CollectingReporter::default();
+            let err = run_publish(&ws, &opts, &mut reporter).expect_err("publish should stop");
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains("reconciliation inconclusive"),
+                "expected inconclusive error, got: {msg}"
+            );
+            assert!(
+                reporter
+                    .errors
+                    .iter()
+                    .any(|msg| msg.contains("reconciliation outcome: StillUnknown")
+                        && msg.contains("stop before blind retry")),
+                "errors: {:?}",
+                reporter.errors
+            );
+
+            let cargo_invocations = std::fs::read_to_string(&cargo_log)
+                .map(|s| s.lines().filter(|l| !l.trim().is_empty()).count())
+                .unwrap_or(0);
+            assert_eq!(cargo_invocations, 1, "must not retry after StillUnknown");
+
+            let state = state::load_state(&state_dir)
+                .expect("load state")
+                .expect("state exists");
+            let progress = state.packages.get("demo@0.1.0").expect("package");
+            assert!(
+                matches!(progress.state, PackageState::Ambiguous { .. }),
+                "expected Ambiguous state, got {:?}",
+                progress.state
+            );
+
+            let events_path = events::events_path(&state_dir);
+            let events = events::EventLog::read_from_file(&events_path).expect("events");
+            assert!(events.all_events().iter().any(|e| {
+                matches!(
+                    &e.event_type,
+                    EventType::PublishReconciled {
+                        outcome: ReconciliationOutcome::StillUnknown { .. }
+                    }
+                )
+            }));
+
             server.join();
         });
     }

--- a/crates/shipper-core/src/engine/parallel/publish.rs
+++ b/crates/shipper-core/src/engine/parallel/publish.rs
@@ -263,6 +263,7 @@ pub(super) fn publish_package(
             log.clear();
         }
         write_reconciliation_report_best_effort(state_dir, ws, events_path, reporter);
+        let reconciliation_report_path = state::reconciliation_path(state_dir);
 
         match outcome {
             ReconciliationOutcome::Published { .. } => {
@@ -272,8 +273,10 @@ pub(super) fn publish_package(
                     let _ = state::save_state(state_dir, &state);
                 }
                 reporter.info(&format!(
-                    "{}@{}: reconciled as published on resume (no republish)",
-                    p.name, p.version
+                    "{}@{}: reconciliation outcome: Published; action: mark published and continue without republish (evidence: {})",
+                    p.name,
+                    p.version,
+                    reconciliation_report_path.display()
                 ));
                 return PackagePublishResult {
                     result: Ok(PackageReceipt {
@@ -301,15 +304,20 @@ pub(super) fn publish_package(
                     let _ = state::save_state(state_dir, &state);
                 }
                 reporter.info(&format!(
-                    "{}@{}: reconciled as not published; proceeding with publish",
-                    p.name, p.version
+                    "{}@{}: reconciliation outcome: NotPublished; action: retry under publish policy (evidence: {})",
+                    p.name,
+                    p.version,
+                    reconciliation_report_path.display()
                 ));
                 // Fall through to the normal retry loop below.
             }
             ReconciliationOutcome::StillUnknown { reason, .. } => {
                 reporter.error(&format!(
-                    "{}@{}: resume reconciliation still inconclusive: {}",
-                    p.name, p.version, reason
+                    "{}@{}: reconciliation outcome: StillUnknown; action: stop before blind retry; operator action required (evidence: {}): {}",
+                    p.name,
+                    p.version,
+                    reconciliation_report_path.display(),
+                    reason
                 ));
                 maybe_send_event(
                     &opts.webhook,
@@ -503,12 +511,15 @@ pub(super) fn publish_package(
                         log.clear();
                     }
                     write_reconciliation_report_best_effort(state_dir, ws, events_path, reporter);
+                    let reconciliation_report_path = state::reconciliation_path(state_dir);
 
                     match outcome {
                         ReconciliationOutcome::Published { .. } => {
                             reporter.info(&format!(
-                                "{}@{}: reconciled as published; no retry",
-                                p.name, p.version
+                                "{}@{}: reconciliation outcome: Published; registry shows version present; action: mark published and continue without retry (evidence: {})",
+                                p.name,
+                                p.version,
+                                reconciliation_report_path.display()
                             ));
                             {
                                 let mut state = st.lock().unwrap();
@@ -536,6 +547,12 @@ pub(super) fn publish_package(
                             break;
                         }
                         ReconciliationOutcome::NotPublished { .. } => {
+                            reporter.info(&format!(
+                                "{}@{}: reconciliation outcome: NotPublished; registry still absent; action: retry under publish policy (evidence: {})",
+                                p.name,
+                                p.version,
+                                reconciliation_report_path.display()
+                            ));
                             // Safe to enter the normal Retryable path below;
                             // registry confirms no duplicate-upload risk.
                             // Preserve negative-polling evidence for the receipt.
@@ -555,6 +572,13 @@ pub(super) fn publish_package(
                                 let _ = log.write_to_file(events_path);
                                 log.clear();
                             }
+                            reporter.error(&format!(
+                                "{}@{}: reconciliation outcome: StillUnknown; action: stop before blind retry; operator action required (evidence: {}): {}",
+                                p.name,
+                                p.version,
+                                reconciliation_report_path.display(),
+                                reason
+                            ));
 
                             // Notify operators: reconciliation was inconclusive
                             // and human judgment is required.

--- a/crates/shipper-core/src/engine/parallel/tests.rs
+++ b/crates/shipper-core/src/engine/parallel/tests.rs
@@ -4132,6 +4132,14 @@ fn reconcile_bdd_ambiguous_resolves_to_published() {
         has_reconciled_published,
         "expected PublishReconciled with Published outcome"
     );
+    let infos = reporter.drain_infos();
+    assert!(
+        infos
+            .iter()
+            .any(|msg| msg.contains("reconciliation outcome: Published")
+                && msg.contains("without retry")),
+        "expected operator-facing Published reconciliation action, infos: {infos:?}"
+    );
 
     server.join();
 }
@@ -4239,6 +4247,14 @@ fn reconcile_bdd_ambiguous_resolves_to_not_published_then_retries() {
     assert!(
         has_reconciled_not_published,
         "expected at least one PublishReconciled with NotPublished outcome"
+    );
+    let infos = reporter.drain_infos();
+    assert!(
+        infos
+            .iter()
+            .any(|msg| msg.contains("reconciliation outcome: NotPublished")
+                && msg.contains("retry under publish policy")),
+        "expected operator-facing NotPublished retry action, infos: {infos:?}"
     );
 
     server.join();
@@ -4358,6 +4374,14 @@ fn reconcile_bdd_resume_from_ambiguous_state_skips_republish() {
         has_reconciled_published,
         "expected PublishReconciled with Published outcome"
     );
+    let infos = reporter.drain_infos();
+    assert!(
+        infos
+            .iter()
+            .any(|msg| msg.contains("reconciliation outcome: Published")
+                && msg.contains("without republish")),
+        "expected operator-facing resume Published action, infos: {infos:?}"
+    );
 
     server.join();
 }
@@ -4458,6 +4482,14 @@ fn reconcile_bdd_resume_from_ambiguous_state_still_unknown_writes_report() {
     assert_eq!(
         report.records[0].operator_action,
         shipper_types::ReconciliationOperatorAction::OperatorActionRequired
+    );
+    let errors = reporter.drain_errors();
+    assert!(
+        errors
+            .iter()
+            .any(|msg| msg.contains("reconciliation outcome: StillUnknown")
+                && msg.contains("stop before blind retry")),
+        "expected operator-facing StillUnknown stop action, errors: {errors:?}"
     );
 
     server.join();
@@ -4596,6 +4628,14 @@ fn reconcile_bdd_ambiguous_resolves_to_still_unknown() {
     assert!(
         has_reconciled_still_unknown,
         "expected PublishReconciled with StillUnknown outcome"
+    );
+    let errors = reporter.drain_errors();
+    assert!(
+        errors
+            .iter()
+            .any(|msg| msg.contains("reconciliation outcome: StillUnknown")
+                && msg.contains("stop before blind retry")),
+        "expected operator-facing StillUnknown stop action, errors: {errors:?}"
     );
     let report_path = crate::state::execution_state::reconciliation_path(&state_dir);
     let report_json = std::fs::read_to_string(&report_path).expect("read reconciliation report");


### PR DESCRIPTION
## Summary
- route sequential ambiguous cargo publish failures through the reconciliation state machine before retrying
- persist reconciliation reports and emit operator-facing Published / NotPublished / StillUnknown actions in sequential and parallel paths
- add sequential coverage for Published, NotPublished retry, and StillUnknown stop behavior; assert parallel UX messages

## Validation
- cargo fmt --all -- --check
- cargo test -p shipper-core sequential_ambiguous_publish --locked
- cargo test -p shipper-core reconcile_bdd_ambiguous --locked
- cargo test -p shipper-core reconcile_bdd_resume_from_ambiguous_state --locked
- cargo clippy -p shipper-core --all-targets --locked -- -D warnings
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask check-generated --mode blocking-allowlist
- cargo xtask policy-report
- git diff --check

## Known local validation gap
- cargo test -p shipper-core --locked: 1921 passed, 1 failed in ops::git::cleanliness::tests::ensure_git_clean_new_phrasing from the existing local git-cleanliness environment issue; this diff does not touch that file.