### PR TITLE
test(cargo-failure): cover ambiguous boundaries and classifier edges

### DIFF
--- a/crates/shipper-cargo-failure/src/lib.rs
+++ b/crates/shipper-cargo-failure/src/lib.rs
@@ -1705,3 +1705,224 @@ mod property_tests {
         }
     }
 }
+
+#[cfg(test)]
+mod gap_tests {
+    use super::*;
+
+    #[test]
+    fn permanent_required_dependency_is_missing_from_the_registry() {
+        let o = classify_publish_failure("required dependency is missing from the registry", "");
+        assert_eq!(o.class, CargoFailureClass::Permanent);
+    }
+
+    #[test]
+    fn permanent_candidate_versions_didnt_match_standalone() {
+        let o = classify_publish_failure("candidate versions found which didn't match: 0.6.5", "");
+        assert_eq!(o.class, CargoFailureClass::Permanent);
+    }
+
+    #[test]
+    fn permanent_no_matching_package_named_standalone() {
+        let o = classify_publish_failure("no matching package named `foo` found", "");
+        assert_eq!(o.class, CargoFailureClass::Permanent);
+    }
+
+    #[test]
+    fn permanent_failed_to_select_a_version_standalone() {
+        let o = classify_publish_failure(
+            "failed to select a version for the requirement `bar = \"^1.0\"`",
+            "",
+        );
+        assert_eq!(o.class, CargoFailureClass::Permanent);
+    }
+
+    #[test]
+    fn crlf_line_endings_do_not_block_retryable_match() {
+        let o = classify_publish_failure("error\r\nconnection refused\r\n", "");
+        assert_eq!(o.class, CargoFailureClass::Retryable);
+    }
+
+    #[test]
+    fn crlf_line_endings_do_not_block_permanent_match() {
+        let o = classify_publish_failure("error\r\ntoken is invalid\r\n", "");
+        assert_eq!(o.class, CargoFailureClass::Permanent);
+    }
+
+    #[test]
+    fn stderr_stdout_separator_is_single_newline() {
+        let o = classify_publish_failure("connection ", "refused");
+        assert_eq!(o.class, CargoFailureClass::Ambiguous);
+    }
+
+    #[test]
+    fn pattern_spanning_stderr_newline_stdout_does_not_match() {
+        let o = classify_publish_failure("dn", "s lookup failed");
+        assert_eq!(o.class, CargoFailureClass::Ambiguous);
+    }
+
+    #[test]
+    fn outcome_is_copy() {
+        let a = classify_publish_failure("429", "");
+        let b = a;
+        assert_eq!(a, b);
+        assert_eq!(a.class, CargoFailureClass::Retryable);
+    }
+
+    #[test]
+    fn outcome_clone_equals_original() {
+        let a = classify_publish_failure("token is invalid", "");
+        let b = a;
+        assert_eq!(a, b.clone());
+    }
+
+    #[test]
+    fn class_variants_are_pairwise_distinct() {
+        assert_ne!(CargoFailureClass::Retryable, CargoFailureClass::Permanent);
+        assert_ne!(CargoFailureClass::Retryable, CargoFailureClass::Ambiguous);
+        assert_ne!(CargoFailureClass::Permanent, CargoFailureClass::Ambiguous);
+    }
+
+    #[test]
+    fn class_self_equality() {
+        assert_eq!(CargoFailureClass::Retryable, CargoFailureClass::Retryable);
+        assert_eq!(CargoFailureClass::Permanent, CargoFailureClass::Permanent);
+        assert_eq!(CargoFailureClass::Ambiguous, CargoFailureClass::Ambiguous);
+    }
+
+    #[test]
+    fn outcome_message_is_static_lifetime() {
+        fn requires_static(_s: &'static str) {}
+        let o = classify_publish_failure("503", "");
+        requires_static(o.message);
+    }
+
+    #[test]
+    fn massive_stdout_only_input_classifies_retryable() {
+        let big = format!("{}\n429\n{}", "x".repeat(10_000), "y".repeat(10_000));
+        let o = classify_publish_failure("", &big);
+        assert_eq!(o.class, CargoFailureClass::Retryable);
+    }
+
+    #[test]
+    fn massive_input_no_patterns_is_ambiguous() {
+        let big = "abcdefg ".repeat(20_000);
+        let o = classify_publish_failure(&big, &big);
+        assert_eq!(o.class, CargoFailureClass::Ambiguous);
+    }
+
+    #[test]
+    fn null_byte_does_not_block_subsequent_retryable_match() {
+        let o = classify_publish_failure("\0connection refused\0", "");
+        assert_eq!(o.class, CargoFailureClass::Retryable);
+    }
+
+    #[test]
+    fn null_byte_does_not_block_subsequent_permanent_match() {
+        let o = classify_publish_failure("\0token is invalid\0", "");
+        assert_eq!(o.class, CargoFailureClass::Permanent);
+    }
+
+    #[test]
+    fn tab_separated_pattern_matches() {
+        let o = classify_publish_failure("error:\ttoo many requests", "");
+        assert_eq!(o.class, CargoFailureClass::Retryable);
+    }
+
+    #[test]
+    fn ambiguous_message_is_actionable_for_reconciliation() {
+        let o = classify_publish_failure("", "");
+        assert!(o.message.contains("ambiguous"));
+        assert!(o.message.contains("registry"));
+    }
+
+    #[test]
+    fn ambiguous_upload_in_progress_then_eof() {
+        let o = classify_publish_failure(
+            "Uploading my-crate v0.1.0 (registry `crates-io`)\nerror: unexpected EOF",
+            "",
+        );
+        assert_eq!(o.class, CargoFailureClass::Ambiguous);
+    }
+
+    #[test]
+    fn ambiguous_io_error_unspecified_without_pattern() {
+        let o = classify_publish_failure("error: an I/O error occurred", "");
+        assert_eq!(o.class, CargoFailureClass::Ambiguous);
+    }
+
+    #[test]
+    fn ambiguous_http_502_substring_still_retryable_because_502_pattern_present() {
+        let o = classify_publish_failure("got 502 from upstream", "");
+        assert_eq!(o.class, CargoFailureClass::Retryable);
+    }
+
+    #[test]
+    fn permanent_pattern_invalid_appears_inside_a_word() {
+        let o = classify_publish_failure("the manifest is invalidated", "");
+        assert_eq!(o.class, CargoFailureClass::Permanent);
+    }
+
+    #[test]
+    fn retryable_500_inside_word_still_matches() {
+        let o = classify_publish_failure("bytes_transferred=15000", "");
+        assert_eq!(o.class, CargoFailureClass::Retryable);
+    }
+
+    #[test]
+    fn stderr_only_with_trailing_newline_classifies_correctly() {
+        let o = classify_publish_failure("permission denied\n", "");
+        assert_eq!(o.class, CargoFailureClass::Permanent);
+    }
+
+    #[test]
+    fn stdout_only_with_leading_newline_classifies_correctly() {
+        let o = classify_publish_failure("", "\nbroken pipe");
+        assert_eq!(o.class, CargoFailureClass::Retryable);
+    }
+
+    #[test]
+    fn upload_then_429_is_retryable_even_when_upload_text_might_imply_ambiguity() {
+        let o = classify_publish_failure("Uploading my-crate v0.1.0\n429 Too Many Requests", "");
+        assert_eq!(o.class, CargoFailureClass::Retryable);
+    }
+
+    #[test]
+    fn upload_then_already_uploaded_is_permanent() {
+        let o = classify_publish_failure(
+            "Uploading my-crate v0.1.0\ncrate version is already uploaded",
+            "",
+        );
+        assert_eq!(o.class, CargoFailureClass::Permanent);
+    }
+
+    #[test]
+    fn realworld_sparse_index_503() {
+        let o = classify_publish_failure(
+            "error: download of config.json failed\n\
+             Caused by:\n  failed to get successful HTTP response from \
+             `https://index.crates.io/config.json` (146.75.30.39), got 503\n\
+             body:\nService Unavailable",
+            "",
+        );
+        assert_eq!(o.class, CargoFailureClass::Retryable);
+    }
+
+    #[test]
+    fn realworld_missing_dependency_pre_verify() {
+        let o = classify_publish_failure(
+            "error: required dependency is missing from the registry: \
+             foo-internal v0.1.0 (required by bar v0.1.0)",
+            "",
+        );
+        assert_eq!(o.class, CargoFailureClass::Permanent);
+    }
+
+    #[test]
+    fn ascii_uppercase_input_classifies_identically_to_lowercase() {
+        let upper = classify_publish_failure("ERROR: CONNECTION RESET BY PEER", "");
+        let lower = classify_publish_failure("error: connection reset by peer", "");
+        assert_eq!(upper.class, lower.class);
+        assert_eq!(upper.message, lower.message);
+    }
+}

--- a/crates/shipper-cargo-failure/src/lib.rs
+++ b/crates/shipper-cargo-failure/src/lib.rs
@@ -1852,20 +1852,8 @@ mod gap_tests {
     }
 
     #[test]
-    fn ambiguous_http_502_substring_still_retryable_because_502_pattern_present() {
+    fn http_502_pattern_is_retryable() {
         let o = classify_publish_failure("got 502 from upstream", "");
-        assert_eq!(o.class, CargoFailureClass::Retryable);
-    }
-
-    #[test]
-    fn permanent_pattern_invalid_appears_inside_a_word() {
-        let o = classify_publish_failure("the manifest is invalidated", "");
-        assert_eq!(o.class, CargoFailureClass::Permanent);
-    }
-
-    #[test]
-    fn retryable_500_inside_word_still_matches() {
-        let o = classify_publish_failure("bytes_transferred=15000", "");
         assert_eq!(o.class, CargoFailureClass::Retryable);
     }
 

--- a/crates/shipper-cargo-failure/tests/classifier_contract_integration.rs
+++ b/crates/shipper-cargo-failure/tests/classifier_contract_integration.rs
@@ -1,4 +1,4 @@
-use shipper_cargo_failure::{CargoFailureClass, classify_publish_failure};
+use shipper_cargo_failure::{CargoFailureClass, CargoFailureOutcome, classify_publish_failure};
 
 #[test]
 fn classifies_common_registry_throttling_errors_as_retryable() {
@@ -16,4 +16,52 @@ fn classifies_manifest_validation_errors_as_permanent() {
 fn unknown_output_stays_ambiguous() {
     let outcome = classify_publish_failure("tool exited with status 101", "see logs");
     assert_eq!(outcome.class, CargoFailureClass::Ambiguous);
+}
+
+#[test]
+fn public_api_outcome_is_copy_and_eq() {
+    let a: CargoFailureOutcome = classify_publish_failure("503", "");
+    let b: CargoFailureOutcome = a;
+    assert_eq!(a, b);
+}
+
+#[test]
+fn public_api_class_is_copy() {
+    let c = CargoFailureClass::Retryable;
+    let d = c;
+    assert_eq!(c, d);
+}
+
+#[test]
+fn public_api_ambiguous_default_message_through_public_surface() {
+    let o = classify_publish_failure("", "");
+    assert_eq!(o.class, CargoFailureClass::Ambiguous);
+    assert!(o.message.contains("ambiguous"));
+}
+
+#[test]
+fn public_api_ambiguous_drives_reconciliation_path() {
+    let o = classify_publish_failure("Uploading my-crate v0.1.0", "");
+    assert_eq!(o.class, CargoFailureClass::Ambiguous);
+}
+
+#[test]
+fn public_api_retryable_dominates_permanent_across_streams() {
+    let o = classify_publish_failure("token is invalid", "503");
+    assert_eq!(o.class, CargoFailureClass::Retryable);
+}
+
+#[test]
+fn public_api_dep_resolution_is_permanent_not_ambiguous() {
+    let o = classify_publish_failure(
+        "error: failed to select a version for the requirement `x = \"^0.1\"`",
+        "",
+    );
+    assert_eq!(o.class, CargoFailureClass::Permanent);
+}
+
+#[test]
+fn public_api_no_matching_package_is_permanent() {
+    let o = classify_publish_failure("error: no matching package named `nope` found", "");
+    assert_eq!(o.class, CargoFailureClass::Permanent);
 }


### PR DESCRIPTION
﻿## Summary

Tests-only PR closing gaps in shipper-cargo-failure. Adds 36 tests after review cleanup. No production code changes.

This crate sorts cargo publish failure text into Retryable / Permanent / Ambiguous, which directly drives Shipper's retry-vs-reconcile decision after every publish attempt. The added coverage pins realistic boundaries without promoting known substring false positives as desired contract.

## Coverage added

Classifier boundary tests:
- Dependency-resolution and missing-package strings classify as Permanent.
- CRLF line endings classify the same as LF.
- stderr/stdout are scanned consistently, but patterns split across the stream separator do not accidentally match.
- Large inputs and null bytes do not panic and still classify subsequent real patterns.
- Ambiguous upload/incomplete I/O cases stay Ambiguous for reconciliation.
- Retryable evidence still dominates permanent-looking text when both are present.

Public API integration tests:
- CargoFailureOutcome and CargoFailureClass Copy/Eq behavior remains visible through the public surface.
- Ambiguous default messages keep reconciliation-oriented wording.
- Dependency resolution and no-matching-package failures remain Permanent through the public API.

Review cleanup:
- Removed two tests that would have enshrined broad substring false positives as desired behavior.
- Renamed the HTTP 502 case to describe its Retryable assertion directly.

## Validation

- [x] cargo test -p shipper-cargo-failure --locked
- [x] cargo clippy -p shipper-cargo-failure --all-targets --locked -- -D warnings
- [x] cargo fmt --all -- --check
- [x] cargo xtask check-file-policy --mode blocking-allowlist
- [x] cargo xtask policy-report
- [x] git diff --check
