### PR TITLE
tests(core/engine/publish/resume): cover ResumeGate logic and event emission

### DIFF
--- a/crates/shipper-core/src/engine/publish/resume.rs
+++ b/crates/shipper-core/src/engine/publish/resume.rs
@@ -80,3 +80,312 @@ pub(in crate::engine) fn record_terminal_resume_skip(
     event_log.clear();
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    use tempfile::TempDir;
+
+    use crate::encryption::EncryptionConfig;
+    use crate::types::{
+        ParallelConfig, PublishPolicy, ReadinessConfig, ReadinessMethod, Registry, VerifyMode,
+    };
+    use crate::webhook::WebhookConfig;
+
+    #[derive(Default)]
+    struct CollectingReporter {
+        infos: Vec<String>,
+        warns: Vec<String>,
+        #[allow(dead_code)]
+        errors: Vec<String>,
+    }
+
+    impl Reporter for CollectingReporter {
+        fn info(&mut self, msg: &str) {
+            self.infos.push(msg.to_string());
+        }
+        fn warn(&mut self, msg: &str) {
+            self.warns.push(msg.to_string());
+        }
+        fn error(&mut self, msg: &str) {
+            self.errors.push(msg.to_string());
+        }
+    }
+
+    fn pkg(name: &str) -> PlannedPackage {
+        PlannedPackage {
+            name: name.to_string(),
+            version: "1.2.3".to_string(),
+            manifest_path: PathBuf::from(format!("{name}/Cargo.toml")),
+            regime: None,
+        }
+    }
+
+    fn progress(state: PackageState) -> PackageProgress {
+        PackageProgress {
+            name: "p".to_string(),
+            version: "1.2.3".to_string(),
+            attempts: 0,
+            state,
+            last_updated_at: Utc::now(),
+        }
+    }
+
+    fn opts_with_resume_from(resume_from: Option<&str>) -> RuntimeOptions {
+        RuntimeOptions {
+            allow_dirty: true,
+            skip_ownership_check: true,
+            strict_ownership: false,
+            no_verify: false,
+            max_attempts: 1,
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(2),
+            retry_strategy: shipper_retry::RetryStrategyType::Exponential,
+            retry_jitter: 0.0,
+            retry_per_error: shipper_retry::PerErrorConfig::default(),
+            verify_timeout: Duration::from_millis(20),
+            verify_poll_interval: Duration::from_millis(1),
+            state_dir: PathBuf::from(".shipper"),
+            force_resume: false,
+            policy: PublishPolicy::default(),
+            verify_mode: VerifyMode::default(),
+            readiness: ReadinessConfig {
+                enabled: false,
+                method: ReadinessMethod::Api,
+                initial_delay: Duration::from_millis(0),
+                max_delay: Duration::from_millis(0),
+                max_total_wait: Duration::from_millis(0),
+                poll_interval: Duration::from_millis(0),
+                jitter_factor: 0.0,
+                index_path: None,
+                prefer_index: false,
+            },
+            output_lines: 10,
+            force: false,
+            lock_timeout: Duration::from_secs(60),
+            parallel: ParallelConfig::default(),
+            webhook: WebhookConfig::default(),
+            encryption: EncryptionConfig::default(),
+            registries: vec![Registry::crates_io()],
+            resume_from: resume_from.map(|s| s.to_string()),
+            rehearsal_registry: None,
+            rehearsal_skip: false,
+            rehearsal_smoke_install: None,
+        }
+    }
+
+    // ---- apply_resume_from_gate ----
+
+    #[test]
+    fn gate_publishes_when_no_resume_from_configured() {
+        let mut reached = false;
+        let mut reporter = CollectingReporter::default();
+        let opts = opts_with_resume_from(None);
+
+        let decision = apply_resume_from_gate(
+            &pkg("a"),
+            &progress(PackageState::Pending),
+            &opts,
+            &mut reached,
+            &mut reporter,
+        );
+
+        assert!(matches!(decision, ResumeGate::Publish));
+        assert!(
+            reached,
+            "absence of resume_from should mark resume point as reached"
+        );
+        assert!(reporter.warns.is_empty());
+        assert!(reporter.infos.is_empty());
+    }
+
+    #[test]
+    fn gate_publishes_once_resume_point_already_reached() {
+        // Even with resume_from set, prior packages flipped the flag — gate
+        // must short-circuit to Publish without inspecting state.
+        let mut reached = true;
+        let mut reporter = CollectingReporter::default();
+        let opts = opts_with_resume_from(Some("b"));
+
+        let decision = apply_resume_from_gate(
+            &pkg("c"),
+            &progress(PackageState::Pending),
+            &opts,
+            &mut reached,
+            &mut reporter,
+        );
+
+        assert!(matches!(decision, ResumeGate::Publish));
+        assert!(reached);
+        assert!(reporter.warns.is_empty());
+        assert!(reporter.infos.is_empty());
+    }
+
+    #[test]
+    fn gate_flips_reached_and_publishes_when_target_matches() {
+        let mut reached = false;
+        let mut reporter = CollectingReporter::default();
+        let opts = opts_with_resume_from(Some("b"));
+
+        let decision = apply_resume_from_gate(
+            &pkg("b"),
+            &progress(PackageState::Pending),
+            &opts,
+            &mut reached,
+            &mut reporter,
+        );
+
+        assert!(matches!(decision, ResumeGate::Publish));
+        assert!(
+            reached,
+            "matching resume_from name should mark resume point as reached"
+        );
+        // No skip narration when we match — caller will start publishing.
+        assert!(reporter.warns.is_empty());
+        assert!(reporter.infos.is_empty());
+    }
+
+    #[test]
+    fn gate_skips_pending_packages_before_resume_point_with_warn() {
+        let mut reached = false;
+        let mut reporter = CollectingReporter::default();
+        let opts = opts_with_resume_from(Some("b"));
+
+        let decision = apply_resume_from_gate(
+            &pkg("a"),
+            &progress(PackageState::Pending),
+            &opts,
+            &mut reached,
+            &mut reporter,
+        );
+
+        assert!(matches!(decision, ResumeGate::Skip));
+        assert!(
+            !reached,
+            "pending package before resume point must NOT flip reached"
+        );
+        assert_eq!(reporter.warns.len(), 1, "{:?}", reporter.warns);
+        assert!(reporter.warns[0].contains("a@1.2.3"));
+        assert!(reporter.warns[0].contains("before resume point b"));
+        assert!(
+            reporter.infos.is_empty(),
+            "pending pre-resume should warn, not info"
+        );
+    }
+
+    #[test]
+    fn gate_logs_info_for_already_published_before_resume_point() {
+        let mut reached = false;
+        let mut reporter = CollectingReporter::default();
+        let opts = opts_with_resume_from(Some("b"));
+
+        let decision = apply_resume_from_gate(
+            &pkg("a"),
+            &progress(PackageState::Published),
+            &opts,
+            &mut reached,
+            &mut reporter,
+        );
+
+        assert!(matches!(decision, ResumeGate::Skip));
+        assert!(!reached);
+        assert!(
+            reporter.warns.is_empty(),
+            "already-Published should be info, not warn"
+        );
+        assert_eq!(reporter.infos.len(), 1, "{:?}", reporter.infos);
+        assert!(reporter.infos[0].contains("a@1.2.3"));
+        assert!(reporter.infos[0].contains("already complete"));
+    }
+
+    #[test]
+    fn gate_logs_info_for_already_skipped_before_resume_point() {
+        let mut reached = false;
+        let mut reporter = CollectingReporter::default();
+        let opts = opts_with_resume_from(Some("b"));
+
+        let decision = apply_resume_from_gate(
+            &pkg("a"),
+            &progress(PackageState::Skipped {
+                reason: "already published".into(),
+            }),
+            &opts,
+            &mut reached,
+            &mut reporter,
+        );
+
+        assert!(matches!(decision, ResumeGate::Skip));
+        assert!(!reached);
+        assert!(reporter.warns.is_empty());
+        assert_eq!(reporter.infos.len(), 1);
+        assert!(reporter.infos[0].contains("already complete"));
+    }
+
+    // ---- record_terminal_resume_skip ----
+
+    #[test]
+    fn record_terminal_resume_skip_emits_info_and_event() {
+        let dir = TempDir::new().expect("tempdir");
+        let events_path = dir.path().join("events.jsonl");
+        let mut event_log = events::EventLog::new();
+        let mut reporter = CollectingReporter::default();
+
+        record_terminal_resume_skip(
+            &pkg("a"),
+            &progress(PackageState::Published),
+            "a@1.2.3",
+            &events_path,
+            &mut event_log,
+            &mut reporter,
+        )
+        .expect("write events");
+
+        // Reporter narration
+        assert_eq!(reporter.infos.len(), 1);
+        assert!(reporter.infos[0].contains("a@1.2.3"));
+        assert!(reporter.infos[0].contains("already complete"));
+
+        // Event was persisted and cleared from the in-memory log.
+        let contents = std::fs::read_to_string(&events_path).expect("read events");
+        assert!(!contents.is_empty(), "events file should be written");
+        assert!(
+            contents.contains("PackageSkipped") || contents.contains("package_skipped"),
+            "expected PackageSkipped event, got: {contents}"
+        );
+        assert!(
+            contents.contains("a@1.2.3"),
+            "event should carry the package label"
+        );
+    }
+
+    #[test]
+    fn record_terminal_resume_skip_writes_skipped_reason_with_state_short_form() {
+        let dir = TempDir::new().expect("tempdir");
+        let events_path = dir.path().join("events.jsonl");
+        let mut event_log = events::EventLog::new();
+        let mut reporter = CollectingReporter::default();
+
+        record_terminal_resume_skip(
+            &pkg("a"),
+            &progress(PackageState::Skipped {
+                reason: "irrelevant".into(),
+            }),
+            "a@1.2.3",
+            &events_path,
+            &mut event_log,
+            &mut reporter,
+        )
+        .expect("write events");
+
+        // The reason in the recorded event should include "resume: state already <short-state>"
+        let contents = std::fs::read_to_string(&events_path).expect("read events");
+        assert!(
+            contents.contains("resume: state already"),
+            "expected resume-skip reason prefix, got: {contents}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds inline unit tests for crate::engine::publish::resume, which owns the decision matrix behind every --resume-from invocation.

The tests pin the behavior that keeps resume safe and auditable: packages before the requested resume point are skipped or narrated correctly, already-terminal states stay informational, and terminal resume skips still emit the event evidence that state/receipt reconstruction depends on.

## Coverage added

### pply_resume_from_gate

- Publishes when no --resume-from is configured and flips eached=true.
- Publishes immediately when eached is already 	rue.
- Flips eached=true and publishes when package name matches --resume-from.
- Skips with a warn() line when a Pending package precedes the resume point.
- Skips with an info() line when an already Published or Skipped package precedes the resume point.

### ecord_terminal_resume_skip

- Emits operator narration through eporter.info().
- Persists a PackageSkipped event to vents.jsonl with the package label.
- Pins the esume: state already <short-state> reason shape.

No production behavior changes; tests only.

## Validation

- [x] cargo test -p shipper-core --lib engine::publish::resume --locked
- [x] cargo clippy -p shipper-core --lib --all-features --locked -- -D warnings
- [x] cargo fmt --all -- --check
- [x] cargo xtask check-file-policy --mode blocking-allowlist
- [x] cargo xtask policy-report
- [x] git diff --check
