### PR TITLE
feat(doctor): report dirty git remediation

### DIFF
--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -2685,12 +2685,29 @@ fn run_doctor(
 
     // 5. Check Git State
     println!();
-    match shipper_core::git::collect_git_context() {
+    match shipper_core::git::collect_git_context_at(&ws.workspace_root) {
         Some(git) => {
             let dirty = git.dirty.unwrap_or(false);
             println!("git_commit: {}", git.commit.unwrap_or_else(|| "-".into()));
             println!("git_branch: {}", git.branch.unwrap_or_else(|| "-".into()));
             println!("git_dirty: {}", dirty);
+            if dirty {
+                findings.push(DoctorFinding {
+                    id: "git-working-tree-dirty",
+                    severity: DoctorFindingLevel::Blocked,
+                    status: DoctorFindingLevel::Blocked,
+                    title: "git working tree is dirty",
+                    why_it_matters:
+                        "release evidence must describe the exact source tree being planned, proven, published, and resumed",
+                    evidence: "git_dirty: true".to_string(),
+                    try_next: vec![
+                        "commit, stash, or revert unrelated changes before release",
+                        "rerun `shipper doctor` and `shipper preflight`",
+                        "use `--allow-dirty` only for intentional local rehearsal",
+                    ],
+                    docs: Some("docs/failure-modes.md"),
+                });
+            }
         }
         None => println!("git_context: not a git repository"),
     }

--- a/crates/shipper-cli/tests/cli_e2e.rs
+++ b/crates/shipper-cli/tests/cli_e2e.rs
@@ -259,9 +259,7 @@ fn doctor_command_snapshot() {
     registry_reachable: true
     index_base: https://index.crates.io
 
-    git_commit: <GIT_COMMIT>
-    git_branch: <GIT_BRANCH>
-    git_dirty: <GIT_DIRTY>
+    git_context: not a git repository
 
     Findings:
     ---------
@@ -326,9 +324,7 @@ fn doctor_command_detects_trusted_publishing_auth() {
     registry_reachable: true
     index_base: https://index.crates.io
 
-    git_commit: <GIT_COMMIT>
-    git_branch: <GIT_BRANCH>
-    git_dirty: <GIT_DIRTY>
+    git_context: not a git repository
 
     Findings:
     ---------

--- a/crates/shipper-cli/tests/e2e_doctor.rs
+++ b/crates/shipper-cli/tests/e2e_doctor.rs
@@ -2,6 +2,7 @@
 
 use std::fs;
 use std::path::Path;
+use std::process::Command as StdCommand;
 use std::thread;
 
 use assert_cmd::Command;
@@ -43,6 +44,19 @@ edition = "2021"
 
 fn shipper_cmd() -> Command {
     Command::new(assert_cmd::cargo::cargo_bin!("shipper-cli"))
+}
+
+fn init_git_repo(root: &Path) {
+    let output = StdCommand::new("git")
+        .arg("init")
+        .current_dir(root)
+        .output()
+        .expect("git init");
+    assert!(
+        output.status.success(),
+        "git init failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 struct TestRegistry {
@@ -290,6 +304,45 @@ fn doctor_reports_state_file_if_present() {
         .success()
         .stdout(contains("state_dir:"))
         .stdout(contains("state_dir_writable: true"));
+
+    registry.join();
+}
+
+/// 8. Doctor turns dirty git state into an actionable finding.
+#[test]
+fn doctor_reports_dirty_git_remediation() {
+    let td = tempdir().expect("tempdir");
+    create_workspace(td.path());
+    init_git_repo(td.path());
+    fs::create_dir_all(td.path().join("cargo-home")).expect("mkdir");
+
+    let registry = spawn_registry(1);
+
+    shipper_cmd()
+        .current_dir(td.path())
+        .arg("--manifest-path")
+        .arg(td.path().join("Cargo.toml"))
+        .arg("--api-base")
+        .arg(&registry.base_url)
+        .arg("doctor")
+        .env("CARGO_HOME", td.path().join("cargo-home"))
+        .env_remove("CARGO_REGISTRY_TOKEN")
+        .env_remove("CARGO_REGISTRIES_CRATES_IO_TOKEN")
+        .assert()
+        .success()
+        .stdout(contains("git_dirty: true"))
+        .stdout(contains(
+            "[blocked] git working tree is dirty (git-working-tree-dirty)",
+        ))
+        .stdout(contains(
+            "why: release evidence must describe the exact source tree being planned, proven, published, and resumed",
+        ))
+        .stdout(contains(
+            "- commit, stash, or revert unrelated changes before release",
+        ))
+        .stdout(contains(
+            "- use `--allow-dirty` only for intentional local rehearsal",
+        ));
 
     registry.join();
 }

--- a/crates/shipper-core/src/git.rs
+++ b/crates/shipper-core/src/git.rs
@@ -6,4 +6,6 @@
 //!
 //! See `crates/shipper-core/src/ops/git/CLAUDE.md` for architectural notes.
 
-pub use crate::ops::git::{collect_git_context, ensure_git_clean, is_git_clean};
+pub use crate::ops::git::{
+    collect_git_context, collect_git_context_at, ensure_git_clean, is_git_clean,
+};

--- a/crates/shipper-core/src/ops/git/mod.rs
+++ b/crates/shipper-core/src/ops/git/mod.rs
@@ -15,6 +15,7 @@
 //! See `CLAUDE.md` in this folder for architectural rules.
 
 use std::env;
+use std::path::Path;
 
 pub(crate) mod bin_override;
 pub(crate) mod cleanliness;
@@ -35,17 +36,23 @@ use crate::types::GitContext;
 /// `git` binary. Without the override, queries go through `context`.
 pub fn collect_git_context() -> Option<GitContext> {
     let repo_root = std::env::current_dir().ok()?;
+    collect_git_context_at(&repo_root)
+}
 
+/// Collect a [`GitContext`] for a specific workspace or repository path.
+///
+/// Returns `None` when `repo_root` is not inside a git repository.
+pub fn collect_git_context_at(repo_root: &Path) -> Option<GitContext> {
     let git_program = bin_override::git_program();
-    if !bin_override::is_repo_root(&repo_root, &git_program) {
+    if !bin_override::is_repo_root(repo_root, &git_program) {
         return None;
     }
 
     if env::var("SHIPPER_GIT_BIN").is_ok() {
-        let commit = bin_override::get_git_commit(&repo_root, &git_program);
-        let branch = bin_override::get_git_branch(&repo_root, &git_program);
-        let tag = bin_override::get_git_tag(&repo_root, &git_program);
-        let dirty = bin_override::get_git_dirty_status(&repo_root, &git_program);
+        let commit = bin_override::get_git_commit(repo_root, &git_program);
+        let branch = bin_override::get_git_branch(repo_root, &git_program);
+        let tag = bin_override::get_git_tag(repo_root, &git_program);
+        let dirty = bin_override::get_git_dirty_status(repo_root, &git_program);
         return Some(GitContext {
             commit,
             branch,
@@ -54,9 +61,9 @@ pub fn collect_git_context() -> Option<GitContext> {
         });
     }
 
-    if !context::is_git_repo(&repo_root) {
+    if !context::is_git_repo(repo_root) {
         return None;
     }
 
-    Some(context::get_git_context(&repo_root))
+    Some(context::get_git_context(repo_root))
 }


### PR DESCRIPTION
Summary:
- Make doctor inspect git state for the planned workspace root instead of the process CWD.
- Add a structured dirty-git Doctor finding with why/evidence/try-next remediation steps.
- Cover dirty workspace diagnostics with an end-to-end doctor test and update snapshots for non-git temp workspaces.

Validation:
- cargo test -p shipper-cli --test e2e_doctor doctor_reports_dirty_git_remediation --locked
- cargo test -p shipper-cli --test cli_e2e doctor --locked
- cargo test -p shipper-cli --test e2e_doctor --locked
- cargo test -p shipper-cli --test bdd_doctor --locked
- cargo test -p shipper-cli doctor --locked
- cargo check -p shipper-core -p shipper-cli --locked
- cargo fmt --all -- --check
- cargo clippy -p shipper-core -p shipper-cli --all-targets --locked -- -D warnings
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask policy-report
- git diff --check

Note: a broad local cargo test -p shipper-core git --lib --locked run hit existing parallel-test noise: the exact git phrasing test passed alone, and the other failure was an unrelated mock registry connect in a publish test.