### PR TITLE
test(config): close coverage gap in runtime_options::registry and ::secrets

### DIFF
--- a/crates/shipper-config/src/runtime_options/registry.rs
+++ b/crates/shipper-config/src/runtime_options/registry.rs
@@ -67,7 +67,27 @@ fn is_safe_synthetic_registry_name(name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::default_registry_for_name;
+    use super::{default_registry_for_name, is_safe_synthetic_registry_name, resolve};
+    use crate::{CliOverrides, MultiRegistryConfig, RegistryConfig};
+
+    fn config_with(registries: Vec<RegistryConfig>) -> MultiRegistryConfig {
+        MultiRegistryConfig {
+            registries,
+            default_registries: vec![],
+        }
+    }
+
+    fn registry_config(name: &str) -> RegistryConfig {
+        RegistryConfig {
+            name: name.to_string(),
+            api_base: format!("https://{name}.example/api"),
+            index_base: Some(format!("https://{name}.example/index")),
+            token: None,
+            default: false,
+        }
+    }
+
+    // ── default_registry_for_name ───────────────────────────────────────────
 
     #[test]
     fn safe_unknown_registry_name_uses_synthetic_crates_io_subdomain() {
@@ -96,5 +116,193 @@ mod tests {
 
         assert_eq!(registry.name, "-custom");
         assert_eq!(registry.api_base, "https://crates.io");
+    }
+
+    #[test]
+    fn crates_io_name_returns_canonical_crates_io_registry() {
+        let registry = default_registry_for_name("crates-io");
+
+        assert_eq!(registry.name, "crates-io");
+        assert_eq!(registry.api_base, "https://crates.io");
+        assert_eq!(
+            registry.index_base.as_deref(),
+            Some("https://index.crates.io")
+        );
+    }
+
+    // ── is_safe_synthetic_registry_name ─────────────────────────────────────
+
+    #[test]
+    fn is_safe_synthetic_registry_name_rejects_empty() {
+        assert!(!is_safe_synthetic_registry_name(""));
+    }
+
+    #[test]
+    fn is_safe_synthetic_registry_name_accepts_simple_lowercase() {
+        assert!(is_safe_synthetic_registry_name("mirror"));
+        assert!(is_safe_synthetic_registry_name("kellnr"));
+    }
+
+    #[test]
+    fn is_safe_synthetic_registry_name_accepts_digits_and_internal_hyphens() {
+        assert!(is_safe_synthetic_registry_name("my-mirror-7"));
+        assert!(is_safe_synthetic_registry_name("mirror42"));
+    }
+
+    #[test]
+    fn is_safe_synthetic_registry_name_rejects_uppercase() {
+        assert!(!is_safe_synthetic_registry_name("Custom"));
+    }
+
+    #[test]
+    fn is_safe_synthetic_registry_name_rejects_special_chars() {
+        assert!(!is_safe_synthetic_registry_name("custom_mirror"));
+        assert!(!is_safe_synthetic_registry_name("custom.mirror"));
+        assert!(!is_safe_synthetic_registry_name("custom/mirror"));
+    }
+
+    #[test]
+    fn is_safe_synthetic_registry_name_rejects_leading_hyphen() {
+        assert!(!is_safe_synthetic_registry_name("-mirror"));
+    }
+
+    #[test]
+    fn is_safe_synthetic_registry_name_rejects_trailing_hyphen() {
+        assert!(!is_safe_synthetic_registry_name("mirror-"));
+    }
+
+    #[test]
+    fn is_safe_synthetic_registry_name_accepts_max_length_sixty_three() {
+        let max = "a".repeat(63);
+        assert!(is_safe_synthetic_registry_name(&max));
+    }
+
+    #[test]
+    fn is_safe_synthetic_registry_name_rejects_over_sixty_three() {
+        let oversize = "a".repeat(64);
+        assert!(!is_safe_synthetic_registry_name(&oversize));
+    }
+
+    // ── resolve ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn resolve_default_returns_empty_vec_so_plan_default_is_used() {
+        let config = MultiRegistryConfig::default();
+        let cli = CliOverrides::default();
+
+        let result = resolve(&config, &cli);
+
+        assert!(
+            result.is_empty(),
+            "no flag means use the plan's single default registry"
+        );
+    }
+
+    #[test]
+    fn resolve_all_registries_returns_every_configured_entry() {
+        let config = config_with(vec![registry_config("alpha"), registry_config("beta")]);
+        let cli = CliOverrides {
+            all_registries: true,
+            ..CliOverrides::default()
+        };
+
+        let result = resolve(&config, &cli);
+
+        let names: Vec<_> = result.iter().map(|r| r.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "beta"]);
+        assert_eq!(result[0].api_base, "https://alpha.example/api");
+        assert_eq!(
+            result[0].index_base.as_deref(),
+            Some("https://alpha.example/index")
+        );
+    }
+
+    #[test]
+    fn resolve_all_registries_falls_back_to_crates_io_when_unconfigured() {
+        let config = MultiRegistryConfig::default();
+        let cli = CliOverrides {
+            all_registries: true,
+            ..CliOverrides::default()
+        };
+
+        let result = resolve(&config, &cli);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "crates-io");
+    }
+
+    #[test]
+    fn resolve_named_registry_uses_configured_when_found() {
+        let config = config_with(vec![registry_config("alpha"), registry_config("beta")]);
+        let cli = CliOverrides {
+            registries: Some(vec!["beta".to_string()]),
+            ..CliOverrides::default()
+        };
+
+        let result = resolve(&config, &cli);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "beta");
+        assert_eq!(result[0].api_base, "https://beta.example/api");
+    }
+
+    #[test]
+    fn resolve_named_registry_falls_back_to_synthetic_default_when_unknown_safe() {
+        let config = MultiRegistryConfig::default();
+        let cli = CliOverrides {
+            registries: Some(vec!["my-mirror".to_string()]),
+            ..CliOverrides::default()
+        };
+
+        let result = resolve(&config, &cli);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "my-mirror");
+        assert_eq!(result[0].api_base, "https://my-mirror.crates.io");
+        assert!(result[0].index_base.is_none());
+    }
+
+    #[test]
+    fn resolve_named_registry_falls_back_to_crates_io_when_unknown_unsafe() {
+        let config = MultiRegistryConfig::default();
+        let cli = CliOverrides {
+            registries: Some(vec!["DANGER/registry".to_string()]),
+            ..CliOverrides::default()
+        };
+
+        let result = resolve(&config, &cli);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "DANGER/registry");
+        assert_eq!(result[0].api_base, "https://crates.io");
+    }
+
+    #[test]
+    fn resolve_named_registry_preserves_request_order() {
+        let config = config_with(vec![registry_config("alpha"), registry_config("beta")]);
+        let cli = CliOverrides {
+            registries: Some(vec!["beta".to_string(), "alpha".to_string()]),
+            ..CliOverrides::default()
+        };
+
+        let result = resolve(&config, &cli);
+
+        let names: Vec<_> = result.iter().map(|r| r.name.as_str()).collect();
+        assert_eq!(names, vec!["beta", "alpha"]);
+    }
+
+    #[test]
+    fn resolve_all_registries_takes_precedence_over_named() {
+        let config = config_with(vec![registry_config("alpha"), registry_config("beta")]);
+        let cli = CliOverrides {
+            all_registries: true,
+            registries: Some(vec!["beta".to_string()]),
+            ..CliOverrides::default()
+        };
+
+        let result = resolve(&config, &cli);
+
+        let names: Vec<_> = result.iter().map(|r| r.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "beta"]);
     }
 }

--- a/crates/shipper-config/src/runtime_options/secrets.rs
+++ b/crates/shipper-config/src/runtime_options/secrets.rs
@@ -42,3 +42,257 @@ fn default_env_var(config: &EncryptionSettings) -> Option<String> {
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shipper_webhook::WebhookType;
+
+    use crate::CliOverrides;
+
+    fn empty_cli() -> CliOverrides {
+        CliOverrides::default()
+    }
+
+    fn cfg_webhook(url: &str) -> WebhookConfig {
+        WebhookConfig {
+            url: url.to_string(),
+            webhook_type: WebhookType::Generic,
+            secret: Some("config-secret".to_string()),
+            timeout_secs: 30,
+        }
+    }
+
+    // ── resolve_webhook ────────────────────────────────────────────────────
+
+    #[test]
+    fn resolve_webhook_returns_config_when_no_overrides() {
+        let config = cfg_webhook("https://config.example/hook");
+        let cli = empty_cli();
+
+        let resolved = resolve_webhook(&config, &cli);
+
+        assert_eq!(resolved.url, "https://config.example/hook");
+        assert_eq!(resolved.secret.as_deref(), Some("config-secret"));
+    }
+
+    #[test]
+    fn resolve_webhook_url_override_replaces_config_url() {
+        let config = cfg_webhook("https://config.example/hook");
+        let cli = CliOverrides {
+            webhook_url: Some("https://cli.example/hook".to_string()),
+            ..empty_cli()
+        };
+
+        let resolved = resolve_webhook(&config, &cli);
+
+        assert_eq!(resolved.url, "https://cli.example/hook");
+        assert_eq!(
+            resolved.secret.as_deref(),
+            Some("config-secret"),
+            "url override must not touch secret"
+        );
+    }
+
+    #[test]
+    fn resolve_webhook_secret_override_replaces_config_secret() {
+        let config = cfg_webhook("https://config.example/hook");
+        let cli = CliOverrides {
+            webhook_secret: Some("cli-secret".to_string()),
+            ..empty_cli()
+        };
+
+        let resolved = resolve_webhook(&config, &cli);
+
+        assert_eq!(resolved.url, "https://config.example/hook");
+        assert_eq!(resolved.secret.as_deref(), Some("cli-secret"));
+    }
+
+    #[test]
+    fn resolve_webhook_both_overrides_apply_together() {
+        let config = cfg_webhook("https://config.example/hook");
+        let cli = CliOverrides {
+            webhook_url: Some("https://cli.example/hook".to_string()),
+            webhook_secret: Some("cli-secret".to_string()),
+            ..empty_cli()
+        };
+
+        let resolved = resolve_webhook(&config, &cli);
+
+        assert_eq!(resolved.url, "https://cli.example/hook");
+        assert_eq!(resolved.secret.as_deref(), Some("cli-secret"));
+    }
+
+    #[test]
+    fn resolve_webhook_preserves_webhook_type_and_timeout() {
+        let config = WebhookConfig {
+            url: "https://config.example/hook".to_string(),
+            webhook_type: WebhookType::Slack,
+            secret: None,
+            timeout_secs: 7,
+        };
+        let cli = CliOverrides {
+            webhook_url: Some("https://cli.example/hook".to_string()),
+            ..empty_cli()
+        };
+
+        let resolved = resolve_webhook(&config, &cli);
+
+        assert_eq!(resolved.webhook_type, WebhookType::Slack);
+        assert_eq!(resolved.timeout_secs, 7);
+    }
+
+    // ── resolve_encryption ─────────────────────────────────────────────────
+
+    #[test]
+    fn resolve_encryption_disabled_when_nothing_set() {
+        let config = EncryptionConfigInner::default();
+        let cli = empty_cli();
+
+        let resolved = resolve_encryption(&config, &cli);
+
+        assert!(!resolved.enabled);
+        assert!(resolved.passphrase.is_none());
+        assert!(
+            resolved.env_var.is_none(),
+            "env_var must not default when encryption is disabled"
+        );
+    }
+
+    #[test]
+    fn resolve_encryption_cli_flag_enables_and_implies_default_env_var() {
+        let config = EncryptionConfigInner::default();
+        let cli = CliOverrides {
+            encrypt: true,
+            ..empty_cli()
+        };
+
+        let resolved = resolve_encryption(&config, &cli);
+
+        assert!(resolved.enabled);
+        assert!(resolved.passphrase.is_none());
+        assert_eq!(resolved.env_var.as_deref(), Some("SHIPPER_ENCRYPT_KEY"));
+    }
+
+    #[test]
+    fn resolve_encryption_config_enable_alone_implies_default_env_var() {
+        let config = EncryptionConfigInner {
+            enabled: true,
+            passphrase: None,
+            env_key: None,
+        };
+        let cli = empty_cli();
+
+        let resolved = resolve_encryption(&config, &cli);
+
+        assert!(resolved.enabled);
+        assert!(resolved.passphrase.is_none());
+        assert_eq!(resolved.env_var.as_deref(), Some("SHIPPER_ENCRYPT_KEY"));
+    }
+
+    #[test]
+    fn resolve_encryption_cli_passphrase_overrides_config_passphrase() {
+        let config = EncryptionConfigInner {
+            enabled: true,
+            passphrase: Some("config-pass".to_string()),
+            env_key: None,
+        };
+        let cli = CliOverrides {
+            encrypt: true,
+            encrypt_passphrase: Some("cli-pass".to_string()),
+            ..empty_cli()
+        };
+
+        let resolved = resolve_encryption(&config, &cli);
+
+        assert!(resolved.enabled);
+        assert_eq!(resolved.passphrase.as_deref(), Some("cli-pass"));
+        assert!(
+            resolved.env_var.is_none(),
+            "explicit passphrase suppresses default env var"
+        );
+    }
+
+    #[test]
+    fn resolve_encryption_falls_back_to_config_passphrase_when_cli_absent() {
+        let config = EncryptionConfigInner {
+            enabled: true,
+            passphrase: Some("config-pass".to_string()),
+            env_key: None,
+        };
+        let cli = empty_cli();
+
+        let resolved = resolve_encryption(&config, &cli);
+
+        assert!(resolved.enabled);
+        assert_eq!(resolved.passphrase.as_deref(), Some("config-pass"));
+        assert!(resolved.env_var.is_none());
+    }
+
+    #[test]
+    fn resolve_encryption_config_env_key_preserved_over_default() {
+        let config = EncryptionConfigInner {
+            enabled: true,
+            passphrase: None,
+            env_key: Some("MY_CUSTOM_KEY".to_string()),
+        };
+        let cli = empty_cli();
+
+        let resolved = resolve_encryption(&config, &cli);
+
+        assert!(resolved.enabled);
+        assert_eq!(resolved.env_var.as_deref(), Some("MY_CUSTOM_KEY"));
+    }
+
+    #[test]
+    fn resolve_encryption_cli_flag_is_or_with_config_enable() {
+        let config = EncryptionConfigInner {
+            enabled: true,
+            passphrase: None,
+            env_key: None,
+        };
+        let cli = CliOverrides {
+            encrypt: false,
+            ..empty_cli()
+        };
+
+        let resolved = resolve_encryption(&config, &cli);
+
+        assert!(resolved.enabled, "config-only enable must turn it on");
+    }
+
+    // ── default_env_var (private) ──────────────────────────────────────────
+
+    #[test]
+    fn default_env_var_none_when_disabled() {
+        let cfg = EncryptionSettings {
+            enabled: false,
+            passphrase: None,
+            env_var: None,
+        };
+        assert!(default_env_var(&cfg).is_none());
+    }
+
+    #[test]
+    fn default_env_var_none_when_passphrase_set() {
+        let cfg = EncryptionSettings {
+            enabled: true,
+            passphrase: Some("p".to_string()),
+            env_var: None,
+        };
+        assert!(default_env_var(&cfg).is_none());
+    }
+
+    #[test]
+    fn default_env_var_default_key_when_enabled_without_passphrase() {
+        let cfg = EncryptionSettings {
+            enabled: true,
+            passphrase: None,
+            env_var: None,
+        };
+        assert_eq!(
+            default_env_var(&cfg).as_deref(),
+            Some("SHIPPER_ENCRYPT_KEY")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes the two lowest-coverage files in `shipper-config` by adding inline unit tests covering CLI/config merge semantics for registry and secrets resolution.

| File | Region cov before | After |
| --- | ---: | ---: |
| `crates/shipper-config/src/runtime_options/registry.rs` | 70.45% | 100% |
| `crates/shipper-config/src/runtime_options/secrets.rs` | 85.71% | 100% |
| Crate total | ~98% | 99.72% |

## What the new tests exercise

**`registry::resolve`**
- Default returns empty (so the plan default is used).
- `all_registries` enumerates every configured entry, and falls back to crates-io when nothing is configured.
- Named-registry resolution uses the configured entry when found, falls back to a synthetic `<name>.crates.io` host only for **safe** names, and to canonical crates.io for **unsafe** names.
- Named order is preserved.
- `all_registries` takes precedence over `registries`.

**`registry::is_safe_synthetic_registry_name`**
- Full grammar coverage including empty, uppercase, special chars (`_`, `.`, `/`), leading/trailing hyphens, and the 63-byte length boundary.

**`registry::default_registry_for_name`**
- `crates-io` returns the canonical registry (previously only synthetic & unsafe were tested).

**`secrets::resolve_webhook`**
- No overrides preserves config.
- `webhook_url` and `webhook_secret` overrides apply independently and together.
- `webhook_type` and `timeout_secs` are preserved through overrides.

**`secrets::resolve_encryption`**
- Disabled by default; CLI flag or config enable each turns it on (OR semantics).
- CLI passphrase overrides config passphrase.
- Explicit passphrase suppresses the default env var.
- Configured `env_key` is preserved over the default.

**`secrets::default_env_var`** — direct unit tests for all three branches.

## Notes

- No production behavior changes; only `#[cfg(test)]` additions in two files.

## Test plan

- [x] `cargo test -p shipper-config --lib runtime_options` — all 45 tests pass (28 new + 17 pre-existing).
- [x] `cargo clippy -p shipper-config --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo llvm-cov --lib -p shipper-config` — region coverage 99.72%.


---
_Generated by [Claude Code](https://claude.ai/code/session_015Ke4gUF1gD7Q3jf33XpjEY)_