### PR TITLE
feat(plan): surface plan evidence artifact

### DIFF
--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -1642,6 +1642,7 @@ struct PlanReport {
     skipped_count: usize,
     internal_dependency_edges: usize,
     publish_levels: usize,
+    artifacts: Vec<PlanArtifactReport>,
     packages: Vec<PlanPackageReport>,
     skipped: Vec<PlanSkippedPackageReport>,
 }
@@ -1670,6 +1671,13 @@ struct PlanSkippedPackageReport {
     name: String,
     version: String,
     reason: String,
+}
+
+#[derive(Debug, Serialize)]
+struct PlanArtifactReport {
+    kind: &'static str,
+    path: String,
+    description: &'static str,
 }
 
 #[derive(Debug, Serialize)]
@@ -1736,6 +1744,7 @@ fn print_plan(ws: &plan::PlannedWorkspace, verbose: bool, format: &str) {
         internal_dependency_edges(&ws.plan)
     );
     println!("  Publish levels: {}", ws.plan.group_by_levels().len());
+    println!("  Plan artifact: .shipper/plan.txt (`shipper plan --format json` capture)");
     println!();
 
     if !ws.skipped.is_empty() {
@@ -1816,8 +1825,17 @@ fn build_plan_report(ws: &plan::PlannedWorkspace) -> PlanReport {
         skipped_count: ws.skipped.len(),
         internal_dependency_edges: internal_dependency_edges(&ws.plan),
         publish_levels: levels.len(),
+        artifacts: vec![plan_artifact_report()],
         packages,
         skipped,
+    }
+}
+
+fn plan_artifact_report() -> PlanArtifactReport {
+    PlanArtifactReport {
+        kind: "plan_json_stdout",
+        path: ".shipper/plan.txt".to_string(),
+        description: "Recommended CI capture path for `shipper plan --format json`.",
     }
 }
 

--- a/crates/shipper-cli/tests/bdd_workflow.rs
+++ b/crates/shipper-cli/tests/bdd_workflow.rs
@@ -3094,6 +3094,16 @@ mod plan_json_format {
         assert_eq!(json["skipped_count"].as_u64(), Some(0));
         assert_eq!(json["internal_dependency_edges"].as_u64(), Some(3));
         assert_eq!(json["publish_levels"].as_u64(), Some(3));
+        assert_eq!(
+            json.pointer("/artifacts/0/kind")
+                .and_then(serde_json::Value::as_str),
+            Some("plan_json_stdout")
+        );
+        assert_eq!(
+            json.pointer("/artifacts/0/path")
+                .and_then(serde_json::Value::as_str),
+            Some(".shipper/plan.txt")
+        );
 
         let packages = json["packages"].as_array().expect("packages array");
         assert_eq!(packages.len(), 3, "unexpected packages: {stdout}");

--- a/crates/shipper-cli/tests/cli_e2e.rs
+++ b/crates/shipper-cli/tests/cli_e2e.rs
@@ -191,6 +191,7 @@ fn plan_command_snapshot() {
       Skipped packages: 0
       Internal dependency edges: 0
       Publish levels: 1
+      Plan artifact: .shipper/plan.txt (`shipper plan --format json` capture)
 
       1. demo@0.1.0 (no workspace dependencies)
     "

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_all_publish_false.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_all_publish_false.snap
@@ -12,6 +12,7 @@ Plan summary:
   Skipped packages: 2
   Internal dependency edges: 0
   Publish levels: 0
+  Plan artifact: .shipper/plan.txt (`shipper plan --format json` capture)
 
 Skipped packages:
   - internal-a@0.1.0 (publish = false)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_deeply_nested_crate.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_deeply_nested_crate.snap
@@ -12,5 +12,6 @@ Plan summary:
   Skipped packages: 0
   Internal dependency edges: 0
   Publish levels: 1
+  Plan artifact: .shipper/plan.txt (`shipper plan --format json` capture)
 
   1. deep-crate@1.0.0 (no workspace dependencies)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_format_json_flag.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_format_json_flag.snap
@@ -13,6 +13,13 @@ expression: "normalize_tempdir_json_output(&stdout, td.path())"
   "skipped_count": 0,
   "internal_dependency_edges": 0,
   "publish_levels": 1,
+  "artifacts": [
+    {
+      "kind": "plan_json_stdout",
+      "path": ".shipper/plan.txt",
+      "description": "Recommended CI capture path for `shipper plan --format json`."
+    }
+  ],
   "packages": [
     {
       "order": 1,

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_format_json_multi_crate.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_format_json_multi_crate.snap
@@ -13,6 +13,13 @@ expression: "normalize_tempdir_json_output(&stdout, td.path())"
   "skipped_count": 0,
   "internal_dependency_edges": 2,
   "publish_levels": 3,
+  "artifacts": [
+    {
+      "kind": "plan_json_stdout",
+      "path": ".shipper/plan.txt",
+      "description": "Recommended CI capture path for `shipper plan --format json`."
+    }
+  ],
   "packages": [
     {
       "order": 1,

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_multi_crate.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_multi_crate.snap
@@ -12,6 +12,7 @@ Plan summary:
   Skipped packages: 0
   Internal dependency edges: 2
   Publish levels: 3
+  Plan artifact: .shipper/plan.txt (`shipper plan --format json` capture)
 
   1. core-lib@0.2.0 (no workspace dependencies)
   2. mid-lib@0.3.0 (depends on: core-lib@0.2.0)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_multiple_packages_filter.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_multiple_packages_filter.snap
@@ -12,6 +12,7 @@ Plan summary:
   Skipped packages: 0
   Internal dependency edges: 1
   Publish levels: 2
+  Plan artifact: .shipper/plan.txt (`shipper plan --format json` capture)
 
   1. core-lib@0.2.0 (no workspace dependencies)
   2. mid-lib@0.3.0 (depends on: core-lib@0.2.0)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_publish_false.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_publish_false.snap
@@ -12,6 +12,7 @@ Plan summary:
   Skipped packages: 1
   Internal dependency edges: 0
   Publish levels: 1
+  Plan artifact: .shipper/plan.txt (`shipper plan --format json` capture)
 
 Skipped packages:
   - beta-internal@0.0.1 (publish = false)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_quiet_mode.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_quiet_mode.snap
@@ -12,5 +12,6 @@ Plan summary:
   Skipped packages: 0
   Internal dependency edges: 0
   Publish levels: 1
+  Plan artifact: .shipper/plan.txt (`shipper plan --format json` capture)
 
   1. demo@0.1.0 (no workspace dependencies)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_retry_jitter_out_of_range.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_retry_jitter_out_of_range.snap
@@ -14,5 +14,6 @@ Plan summary:
   Skipped packages: 0
   Internal dependency edges: 0
   Publish levels: 1
+  Plan artifact: .shipper/plan.txt (`shipper plan --format json` capture)
 
   1. demo@0.1.0 (no workspace dependencies)--- stderr ---

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_single_crate.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_single_crate.snap
@@ -12,5 +12,6 @@ Plan summary:
   Skipped packages: 0
   Internal dependency edges: 0
   Publish levels: 1
+  Plan artifact: .shipper/plan.txt (`shipper plan --format json` capture)
 
   1. demo@0.1.0 (no workspace dependencies)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_single_package_filter.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_single_package_filter.snap
@@ -12,5 +12,6 @@ Plan summary:
   Skipped packages: 0
   Internal dependency edges: 0
   Publish levels: 1
+  Plan artifact: .shipper/plan.txt (`shipper plan --format json` capture)
 
   1. core-lib@0.2.0 (no workspace dependencies)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_verbose_multi_crate.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_verbose_multi_crate.snap
@@ -12,6 +12,7 @@ Plan summary:
   Skipped packages: 0
   Internal dependency edges: 2
   Publish levels: 3
+  Plan artifact: .shipper/plan.txt (`shipper plan --format json` capture)
 
 === Dependency Analysis ===
 

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_verbose_single_package_filter.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__plan_verbose_single_package_filter.snap
@@ -12,6 +12,7 @@ Plan summary:
   Skipped packages: 0
   Internal dependency edges: 0
   Publish levels: 1
+  Plan artifact: .shipper/plan.txt (`shipper plan --format json` capture)
 
 === Dependency Analysis ===
 

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__verbose_single_crate_plan.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__verbose_single_crate_plan.snap
@@ -12,6 +12,7 @@ Plan summary:
   Skipped packages: 0
   Internal dependency edges: 0
   Publish levels: 1
+  Plan artifact: .shipper/plan.txt (`shipper plan --format json` capture)
 
 === Dependency Analysis ===
 


### PR DESCRIPTION
## Summary
- add a plan artifact descriptor to `shipper plan --format json`
- print the recommended `.shipper/plan.txt` capture path in human plan output
- update plan snapshots and JSON contract coverage

## Validation
- `cargo test -p shipper-cli --test cli_e2e plan_command_snapshot --locked`
- `cargo test -p shipper-cli --test bdd_workflow plan_json_format --locked`
- `cargo test -p shipper-cli --test e2e_expanded plan --locked`
- `cargo fmt --all -- --check`
- `cargo xtask package-surface`
- `cargo xtask check-file-policy --mode blocking-allowlist`
- `cargo xtask check-doc-contracts --mode advisory`
- `cargo xtask policy-report`
- `cargo clippy -p shipper-cli --all-targets --locked -- -D warnings`
- `git diff --check`