### PR TITLE
feat(state): record publish attempt history

### DIFF
--- a/crates/shipper-core/src/engine/mod.rs
+++ b/crates/shipper-core/src/engine/mod.rs
@@ -14,17 +14,17 @@ use crate::runtime::environment;
 #[cfg(test)]
 use crate::runtime::execution::short_state;
 use crate::runtime::execution::{
-    backoff_delay, classify_cargo_failure, pkg_key, registry_aware_backoff, resolve_state_dir,
-    update_state,
+    backoff_delay, classify_cargo_failure, pkg_key, record_attempt_detail, registry_aware_backoff,
+    resolve_state_dir, retry_next_attempt_at, update_state,
 };
 use crate::state::events;
 use crate::state::execution_state as state;
 #[cfg(test)]
 use crate::types::ExecutionResult;
 use crate::types::{
-    AttemptEvidence, ErrorClass, EventType, ExecutionState, PackageProgress, PackageReceipt,
-    PackageState, PreflightReport, PublishEvent, PublishRegime, ReadinessEvidence, Receipt,
-    ReconciliationOutcome, Registry, RuntimeOptions,
+    AttemptDetail, AttemptEvidence, ErrorClass, EventType, ExecutionState, PackageProgress,
+    PackageReceipt, PackageState, PreflightReport, PublishEvent, PublishRegime, ReadinessEvidence,
+    Receipt, ReconciliationOutcome, Registry, RuntimeOptions,
 };
 #[cfg(test)]
 use crate::types::{Finishability, PreflightPackage};
@@ -601,8 +601,9 @@ pub fn run_publish(
 
             if !cargo_succeeded {
                 // Event: PackageAttempted
+                let attempt_started_at = Utc::now();
                 event_log.record(PublishEvent {
-                    timestamp: Utc::now(),
+                    timestamp: attempt_started_at,
                     event_type: EventType::PackageAttempted {
                         attempt,
                         command: command.clone(),
@@ -619,6 +620,7 @@ pub fn run_publish(
                     opts.output_lines,
                     None, // sequential mode: no per-package timeout
                 )?;
+                let attempt_ended_at = Utc::now();
 
                 // Collect attempt evidence
                 attempt_evidence.push(AttemptEvidence {
@@ -627,7 +629,7 @@ pub fn run_publish(
                     exit_code: out.exit_code,
                     stdout_tail: out.stdout_tail.clone(),
                     stderr_tail: out.stderr_tail.clone(),
-                    timestamp: Utc::now(),
+                    timestamp: attempt_ended_at,
                     duration: out.duration,
                 });
 
@@ -640,8 +642,25 @@ pub fn run_publish(
                     },
                     package: pkg_label.clone(),
                 });
+                event_log.write_to_file(&events_path)?;
+                event_log.clear();
 
                 if out.exit_code == 0 {
+                    record_attempt_detail(
+                        &mut st,
+                        &state_dir,
+                        AttemptDetail {
+                            package: p.name.clone(),
+                            version: p.version.clone(),
+                            attempt,
+                            max_attempts: opts.max_attempts,
+                            started_at: attempt_started_at,
+                            ended_at: attempt_ended_at,
+                            error_class: None,
+                            next_attempt_at: None,
+                            redacted_message: None,
+                        },
+                    )?;
                     cargo_succeeded = true;
                     // Persist Uploaded state so resume skips cargo publish
                     update_state(&mut st, &state_dir, &key, PackageState::Uploaded)?;
@@ -649,6 +668,17 @@ pub fn run_publish(
                     let failure_output = format!("{}\n{}", out.stderr_tail, out.stdout_tail);
                     let (class, msg) = classify_cargo_failure(&out.stderr_tail, &out.stdout_tail);
                     last_err = Some((class.clone(), msg.clone()));
+                    let mut attempt_detail = AttemptDetail {
+                        package: p.name.clone(),
+                        version: p.version.clone(),
+                        attempt,
+                        max_attempts: opts.max_attempts,
+                        started_at: attempt_started_at,
+                        ended_at: attempt_ended_at,
+                        error_class: Some(class.clone()),
+                        next_attempt_at: None,
+                        redacted_message: Some(msg.clone()),
+                    };
 
                     if class == ErrorClass::Ambiguous {
                         event_log.record(PublishEvent {
@@ -697,6 +727,7 @@ pub fn run_publish(
 
                         match outcome {
                             ReconciliationOutcome::Published { .. } => {
+                                record_attempt_detail(&mut st, &state_dir, attempt_detail)?;
                                 reporter.info(&format!(
                                     "{}@{}: reconciliation outcome: Published; registry shows version present; action: mark published and continue without retry (evidence: {})",
                                     p.name,
@@ -727,6 +758,7 @@ pub fn run_publish(
                                 readiness_evidence = reconcile_evidence;
                             }
                             ReconciliationOutcome::StillUnknown { reason, .. } => {
+                                record_attempt_detail(&mut st, &state_dir, attempt_detail)?;
                                 let ambiguous_state = PackageState::Ambiguous {
                                     message: reason.clone(),
                                 };
@@ -770,6 +802,7 @@ pub fn run_publish(
                                 "{}@{}: version is present on registry; treating as published",
                                 p.name, p.version
                             ));
+                            record_attempt_detail(&mut st, &state_dir, attempt_detail)?;
                             update_state(&mut st, &state_dir, &key, PackageState::Published)?;
                             last_err = None;
                             break;
@@ -778,6 +811,7 @@ pub fn run_publish(
 
                     match class {
                         ErrorClass::Permanent => {
+                            record_attempt_detail(&mut st, &state_dir, attempt_detail)?;
                             let failed = PackageState::Failed {
                                 class: class.clone(),
                                 message: msg.clone(),
@@ -813,28 +847,43 @@ pub fn run_publish(
                             } else {
                                 false
                             };
-                            let delay = registry_aware_backoff(
-                                opts.base_delay,
-                                opts.max_delay,
-                                attempt,
-                                opts.retry_strategy,
-                                opts.retry_jitter,
-                                is_new_crate,
-                                &failure_output,
-                            );
-                            emit_retry_backoff_event(
-                                &mut event_log,
-                                &events_path,
-                                reporter,
-                                &pkg_label,
-                                &p.name,
-                                &p.version,
-                                attempt,
-                                opts.max_attempts,
-                                delay,
-                                class.clone(),
-                                &msg,
-                            )?;
+                            if attempt < opts.max_attempts {
+                                let delay = registry_aware_backoff(
+                                    opts.base_delay,
+                                    opts.max_delay,
+                                    attempt,
+                                    opts.retry_strategy,
+                                    opts.retry_jitter,
+                                    is_new_crate,
+                                    &failure_output,
+                                );
+                                let next_attempt_at = retry_next_attempt_at(delay);
+                                attempt_detail.next_attempt_at = Some(next_attempt_at);
+                                record_retry_backoff_event(
+                                    &mut event_log,
+                                    &events_path,
+                                    &pkg_label,
+                                    attempt,
+                                    opts.max_attempts,
+                                    delay,
+                                    next_attempt_at,
+                                    &class,
+                                    &msg,
+                                )?;
+                                record_attempt_detail(&mut st, &state_dir, attempt_detail)?;
+                                wait_after_retry(
+                                    reporter,
+                                    &p.name,
+                                    &p.version,
+                                    attempt,
+                                    opts.max_attempts,
+                                    delay,
+                                    class.clone(),
+                                    &msg,
+                                );
+                            } else {
+                                record_attempt_detail(&mut st, &state_dir, attempt_detail)?;
+                            }
                         }
                     }
                     continue;
@@ -891,6 +940,7 @@ pub fn run_publish(
                     opts.retry_strategy,
                     opts.retry_jitter,
                 );
+                let next_attempt_at = retry_next_attempt_at(delay);
                 emit_retry_backoff_event(
                     &mut event_log,
                     &events_path,
@@ -901,6 +951,7 @@ pub fn run_publish(
                     attempt,
                     opts.max_attempts,
                     delay,
+                    next_attempt_at,
                     ErrorClass::Ambiguous,
                     message,
                 )?;
@@ -1452,6 +1503,7 @@ pub(crate) fn init_state(ws: &PlannedWorkspace, state_dir: &Path) -> Result<Exec
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     };
 
@@ -1520,12 +1572,46 @@ fn emit_retry_backoff_event(
     attempt: u32,
     max_attempts: u32,
     delay: std::time::Duration,
+    next_attempt_at: chrono::DateTime<Utc>,
     reason: ErrorClass,
     message: &str,
 ) -> Result<()> {
-    let next_attempt_at =
-        Utc::now() + chrono::Duration::from_std(delay).unwrap_or_else(|_| chrono::Duration::zero());
+    record_retry_backoff_event(
+        event_log,
+        events_path,
+        pkg_label,
+        attempt,
+        max_attempts,
+        delay,
+        next_attempt_at,
+        &reason,
+        message,
+    )?;
+    wait_after_retry(
+        reporter,
+        pkg_name,
+        pkg_version,
+        attempt,
+        max_attempts,
+        delay,
+        reason,
+        message,
+    );
+    Ok(())
+}
 
+#[allow(clippy::too_many_arguments)]
+fn record_retry_backoff_event(
+    event_log: &mut events::EventLog,
+    events_path: &Path,
+    pkg_label: &str,
+    attempt: u32,
+    max_attempts: u32,
+    delay: std::time::Duration,
+    next_attempt_at: chrono::DateTime<Utc>,
+    reason: &ErrorClass,
+    message: &str,
+) -> Result<()> {
     event_log.record(PublishEvent {
         timestamp: Utc::now(),
         event_type: EventType::RetryBackoffStarted {
@@ -1540,7 +1626,20 @@ fn emit_retry_backoff_event(
     });
     event_log.write_to_file(events_path)?;
     event_log.clear();
+    Ok(())
+}
 
+#[allow(clippy::too_many_arguments)]
+fn wait_after_retry(
+    reporter: &mut dyn Reporter,
+    pkg_name: &str,
+    pkg_version: &str,
+    attempt: u32,
+    max_attempts: u32,
+    delay: std::time::Duration,
+    reason: ErrorClass,
+    message: &str,
+) {
     // Delegate the human-facing narration AND the backoff sleep to the
     // Reporter so TTY-capable UIs can render a live countdown during the
     // wait. The default `Reporter::retry_wait` impl preserves the pre-#103
@@ -1555,7 +1654,6 @@ fn emit_retry_backoff_event(
         reason,
         message,
     );
-    Ok(())
 }
 
 fn verify_published(
@@ -2881,6 +2979,7 @@ mod tests {
                 registry: ws.plan.registry.clone(),
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
+                attempt_history: Vec::new(),
                 packages,
             };
             state::save_state(&state_dir, &seeded).expect("seed state");
@@ -2950,6 +3049,7 @@ mod tests {
                 registry: ws.plan.registry.clone(),
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
+                attempt_history: Vec::new(),
                 packages,
             };
             state::save_state(&state_dir, &seeded).expect("seed state");
@@ -3250,6 +3350,7 @@ mod tests {
                 registry: ws.plan.registry.clone(),
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
+                attempt_history: Vec::new(),
                 packages: BTreeMap::new(),
             };
             state::save_state(&state_dir, &existing).expect("save");
@@ -3583,6 +3684,7 @@ mod tests {
             registry: ws.plan.registry.clone(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            attempt_history: Vec::new(),
             packages,
         };
         state::save_state(&state_dir, &st).expect("save");
@@ -3616,6 +3718,7 @@ mod tests {
             registry: ws.plan.registry.clone(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            attempt_history: Vec::new(),
             packages,
         };
         state::save_state(&state_dir, &st).expect("save");
@@ -3668,6 +3771,7 @@ mod tests {
             registry: ws.plan.registry.clone(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            attempt_history: Vec::new(),
             packages,
         };
         state::save_state(&state_dir, &st).expect("save");
@@ -4394,6 +4498,7 @@ mod tests {
                 registry: ws.plan.registry.clone(),
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
+                attempt_history: Vec::new(),
                 packages,
             };
             state::save_state(&state_dir, &st).expect("save");
@@ -4677,6 +4782,16 @@ mod tests {
             assert!(!receipt.packages[0].evidence.attempts.is_empty());
             assert_eq!(receipt.packages[0].evidence.attempts[0].attempt_number, 1);
             assert_eq!(receipt.packages[0].evidence.attempts[0].exit_code, 0);
+            let state = state::load_state(&td.path().join(".shipper"))
+                .expect("load state")
+                .expect("state exists");
+            assert_eq!(state.attempt_history.len(), 1);
+            assert_eq!(state.attempt_history[0].package, "demo");
+            assert_eq!(state.attempt_history[0].version, "0.1.0");
+            assert_eq!(state.attempt_history[0].attempt, 1);
+            assert_eq!(state.attempt_history[0].max_attempts, opts.max_attempts);
+            assert!(state.attempt_history[0].error_class.is_none());
+            assert!(state.attempt_history[0].next_attempt_at.is_none());
             server.join();
         });
     }
@@ -4780,6 +4895,19 @@ mod tests {
                     .expect("exists");
                 let pkg = st.packages.get("demo@0.1.0").expect("pkg");
                 assert_eq!(pkg.attempts, 2, "expected 2 attempts");
+                assert_eq!(st.attempt_history.len(), 2);
+                assert_eq!(st.attempt_history[0].attempt, 1);
+                assert_eq!(
+                    st.attempt_history[0].error_class,
+                    Some(ErrorClass::Retryable)
+                );
+                assert!(st.attempt_history[0].next_attempt_at.is_some());
+                assert_eq!(st.attempt_history[1].attempt, 2);
+                assert_eq!(
+                    st.attempt_history[1].error_class,
+                    Some(ErrorClass::Retryable)
+                );
+                assert!(st.attempt_history[1].next_attempt_at.is_none());
                 server.join();
             },
         );
@@ -5143,6 +5271,7 @@ mod tests {
             registry: ws.plan.registry.clone(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            attempt_history: Vec::new(),
             packages,
         };
         state::save_state(&state_dir, &st).expect("save");
@@ -5268,6 +5397,7 @@ mod tests {
                 registry: ws.plan.registry.clone(),
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
+                attempt_history: Vec::new(),
                 packages,
             };
             state::save_state(&state_dir, &st).expect("save");
@@ -5481,6 +5611,7 @@ mod tests {
             },
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            attempt_history: Vec::new(),
             packages,
         };
 
@@ -6211,6 +6342,7 @@ mod tests {
                     registry: ws.plan.registry.clone(),
                     created_at: Utc::now(),
                     updated_at: Utc::now(),
+                    attempt_history: Vec::new(),
                     packages,
                 };
                 state::save_state(&state_dir, &st).expect("save");
@@ -6273,6 +6405,7 @@ mod tests {
             registry: ws.plan.registry.clone(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            attempt_history: Vec::new(),
             packages,
         };
         state::save_state(&state_dir, &st).expect("save");
@@ -6573,6 +6706,7 @@ mod tests {
                     registry: ws.plan.registry.clone(),
                     created_at: Utc::now(),
                     updated_at: Utc::now(),
+                    attempt_history: Vec::new(),
                     packages,
                 };
                 state::save_state(&state_dir, &st).expect("save");
@@ -6834,6 +6968,7 @@ mod tests {
             registry: ws.plan.registry.clone(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            attempt_history: Vec::new(),
             packages,
         };
         state::save_state(&state_dir, &st).expect("save");
@@ -7129,6 +7264,7 @@ mod tests {
                     },
                     created_at: Utc::now(),
                     updated_at: Utc::now(),
+                    attempt_history: Vec::new(),
                     packages,
                 };
 

--- a/crates/shipper-core/src/engine/parallel/publish.rs
+++ b/crates/shipper-core/src/engine/parallel/publish.rs
@@ -11,20 +11,21 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use anyhow::{Result, bail};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 
 use crate::ops::cargo;
 use crate::plan::PlannedWorkspace;
 use crate::runtime::execution::{
-    backoff_delay, classify_cargo_failure, pkg_key, registry_aware_backoff, update_state_locked,
+    append_attempt_detail, backoff_delay, classify_cargo_failure, pkg_key, registry_aware_backoff,
+    retry_next_attempt_at, update_state_locked,
 };
 use crate::state::events;
 use crate::state::execution_state as state;
 use shipper_registry::HttpRegistryClient as RegistryClient;
 use shipper_types::{
-    AttemptEvidence, ErrorClass, EventType, ExecutionState, PackageEvidence, PackageReceipt,
-    PackageState, PlannedPackage, PublishEvent, PublishLevel, PublishRegime, ReadinessConfig,
-    ReadinessEvidence, ReconciliationOutcome, RuntimeOptions,
+    AttemptDetail, AttemptEvidence, ErrorClass, EventType, ExecutionState, PackageEvidence,
+    PackageReceipt, PackageState, PlannedPackage, PublishEvent, PublishLevel, PublishRegime,
+    ReadinessConfig, ReadinessEvidence, ReconciliationOutcome, RuntimeOptions,
 };
 
 use super::policy::policy_effects;
@@ -39,6 +40,18 @@ use crate::plan::chunking::chunk_by_max_concurrent;
 #[derive(Debug)]
 pub(super) struct PackagePublishResult {
     pub(super) result: anyhow::Result<PackageReceipt>,
+}
+
+fn record_attempt_detail(
+    st: &Arc<Mutex<ExecutionState>>,
+    state_dir: &Path,
+    detail: AttemptDetail,
+) -> Result<()> {
+    let mut state = st.lock().map_err(|_| {
+        anyhow::anyhow!("execution state lock poisoned while recording attempt detail")
+    })?;
+    append_attempt_detail(&mut state, detail);
+    state::save_state(state_dir, &state)
 }
 
 /// Emit a [`EventType::RetryBackoffStarted`] event + a human-readable warn
@@ -56,31 +69,73 @@ pub(super) fn emit_retry_backoff(
     attempt: u32,
     max_attempts: u32,
     delay: std::time::Duration,
+    next_attempt_at: DateTime<Utc>,
     reason: ErrorClass,
     message: &str,
 ) {
-    let next_attempt_at =
-        Utc::now() + chrono::Duration::from_std(delay).unwrap_or_else(|_| chrono::Duration::zero());
+    record_retry_backoff(
+        event_log,
+        events_path,
+        pkg_label,
+        attempt,
+        max_attempts,
+        delay,
+        next_attempt_at,
+        &reason,
+        message,
+    );
+    wait_after_retry(
+        reporter,
+        pkg_name,
+        pkg_version,
+        attempt,
+        max_attempts,
+        delay,
+        reason,
+        message,
+    );
+}
 
-    // Record the event (flushed with the next batch of events)
-    {
-        let mut log = event_log.lock().unwrap();
-        log.record(PublishEvent {
-            timestamp: Utc::now(),
-            event_type: EventType::RetryBackoffStarted {
-                attempt,
-                max_attempts,
-                delay_ms: delay.as_millis() as u64,
-                next_attempt_at,
-                reason: reason.clone(),
-                message: message.to_string(),
-            },
-            package: pkg_label.to_string(),
-        });
-        let _ = log.write_to_file(events_path);
-        log.clear();
-    }
+#[allow(clippy::too_many_arguments)]
+fn record_retry_backoff(
+    event_log: &Arc<Mutex<events::EventLog>>,
+    events_path: &Path,
+    pkg_label: &str,
+    attempt: u32,
+    max_attempts: u32,
+    delay: std::time::Duration,
+    next_attempt_at: DateTime<Utc>,
+    reason: &ErrorClass,
+    message: &str,
+) {
+    let mut log = event_log.lock().unwrap();
+    log.record(PublishEvent {
+        timestamp: Utc::now(),
+        event_type: EventType::RetryBackoffStarted {
+            attempt,
+            max_attempts,
+            delay_ms: delay.as_millis() as u64,
+            next_attempt_at,
+            reason: reason.clone(),
+            message: message.to_string(),
+        },
+        package: pkg_label.to_string(),
+    });
+    let _ = log.write_to_file(events_path);
+    log.clear();
+}
 
+#[allow(clippy::too_many_arguments)]
+fn wait_after_retry(
+    reporter: &Arc<SendReporter>,
+    pkg_name: &str,
+    pkg_version: &str,
+    attempt: u32,
+    max_attempts: u32,
+    delay: std::time::Duration,
+    reason: ErrorClass,
+    message: &str,
+) {
     reporter.retry_wait(
         pkg_name,
         pkg_version,
@@ -375,10 +430,11 @@ pub(super) fn publish_package(
 
         if !cargo_succeeded {
             // Event: PackageAttempted
+            let attempt_started_at = Utc::now();
             {
                 let mut log = event_log.lock().unwrap();
                 log.record(PublishEvent {
-                    timestamp: Utc::now(),
+                    timestamp: attempt_started_at,
                     event_type: EventType::PackageAttempted {
                         attempt,
                         command: command.clone(),
@@ -405,6 +461,7 @@ pub(super) fn publish_package(
                     return PackagePublishResult { result: Err(e) };
                 }
             };
+            let attempt_ended_at = Utc::now();
 
             // Collect attempt evidence
             attempt_evidence.push(AttemptEvidence {
@@ -413,7 +470,7 @@ pub(super) fn publish_package(
                 exit_code: out.exit_code,
                 stdout_tail: out.stdout_tail.clone(),
                 stderr_tail: out.stderr_tail.clone(),
-                timestamp: Utc::now(),
+                timestamp: attempt_ended_at,
                 duration: out.duration,
             });
 
@@ -428,9 +485,28 @@ pub(super) fn publish_package(
                     },
                     package: pkg_label.clone(),
                 });
+                let _ = log.write_to_file(events_path);
+                log.clear();
             }
 
             if out.exit_code == 0 && !out.timed_out {
+                if let Err(e) = record_attempt_detail(
+                    st,
+                    state_dir,
+                    AttemptDetail {
+                        package: p.name.clone(),
+                        version: p.version.clone(),
+                        attempt,
+                        max_attempts: opts.max_attempts,
+                        started_at: attempt_started_at,
+                        ended_at: attempt_ended_at,
+                        error_class: None,
+                        next_attempt_at: None,
+                        redacted_message: None,
+                    },
+                ) {
+                    return PackagePublishResult { result: Err(e) };
+                }
                 cargo_succeeded = true;
                 // Persist Uploaded state so resume skips cargo publish
                 {
@@ -445,12 +521,30 @@ pub(super) fn publish_package(
                     p.name, p.version, out.exit_code
                 ));
 
+                let failure_output = format!("{}\n{}", out.stderr_tail, out.stdout_tail);
+                let (class, msg) = classify_cargo_failure(&out.stderr_tail, &out.stdout_tail);
+                last_err = Some((class.clone(), msg.clone()));
+                let mut attempt_detail = AttemptDetail {
+                    package: p.name.clone(),
+                    version: p.version.clone(),
+                    attempt,
+                    max_attempts: opts.max_attempts,
+                    started_at: attempt_started_at,
+                    ended_at: attempt_ended_at,
+                    error_class: Some(class.clone()),
+                    next_attempt_at: None,
+                    redacted_message: Some(msg.clone()),
+                };
+
                 if reg.version_exists(&p.name, &p.version).unwrap_or(false) {
                     reporter.info(&format!(
                         "{}@{}: version is present on registry; treating as published",
                         p.name, p.version
                     ));
 
+                    if let Err(e) = record_attempt_detail(st, state_dir, attempt_detail) {
+                        return PackagePublishResult { result: Err(e) };
+                    }
                     {
                         let mut state = st.lock().unwrap();
                         update_state_locked(&mut state, &key, PackageState::Published);
@@ -459,10 +553,6 @@ pub(super) fn publish_package(
                     last_err = None;
                     break;
                 }
-
-                let failure_output = format!("{}\n{}", out.stderr_tail, out.stdout_tail);
-                let (class, msg) = classify_cargo_failure(&out.stderr_tail, &out.stdout_tail);
-                last_err = Some((class.clone(), msg.clone()));
 
                 // Event: PackageFailed
                 {
@@ -515,6 +605,11 @@ pub(super) fn publish_package(
 
                     match outcome {
                         ReconciliationOutcome::Published { .. } => {
+                            if let Err(e) =
+                                record_attempt_detail(st, state_dir, attempt_detail.clone())
+                            {
+                                return PackagePublishResult { result: Err(e) };
+                            }
                             reporter.info(&format!(
                                 "{}@{}: reconciliation outcome: Published; registry shows version present; action: mark published and continue without retry (evidence: {})",
                                 p.name,
@@ -559,6 +654,11 @@ pub(super) fn publish_package(
                             readiness_evidence = reconcile_evidence;
                         }
                         ReconciliationOutcome::StillUnknown { reason, .. } => {
+                            if let Err(e) =
+                                record_attempt_detail(st, state_dir, attempt_detail.clone())
+                            {
+                                return PackagePublishResult { result: Err(e) };
+                            }
                             let ambiguous_state = PackageState::Ambiguous {
                                 message: reason.clone(),
                             };
@@ -607,6 +707,9 @@ pub(super) fn publish_package(
 
                 match class {
                     ErrorClass::Permanent => {
+                        if let Err(e) = record_attempt_detail(st, state_dir, attempt_detail) {
+                            return PackagePublishResult { result: Err(e) };
+                        }
                         let failed = PackageState::Failed {
                             class: class.clone(),
                             message: msg.clone(),
@@ -658,28 +761,46 @@ pub(super) fn publish_package(
                             } else {
                                 false
                             };
-                        let delay = registry_aware_backoff(
-                            opts.base_delay,
-                            opts.max_delay,
-                            attempt,
-                            opts.retry_strategy,
-                            opts.retry_jitter,
-                            is_new_crate,
-                            &failure_output,
-                        );
-                        emit_retry_backoff(
-                            event_log,
-                            events_path,
-                            reporter,
-                            &pkg_label,
-                            &p.name,
-                            &p.version,
-                            attempt,
-                            opts.max_attempts,
-                            delay,
-                            class.clone(),
-                            &msg,
-                        );
+                        if attempt < opts.max_attempts {
+                            let delay = registry_aware_backoff(
+                                opts.base_delay,
+                                opts.max_delay,
+                                attempt,
+                                opts.retry_strategy,
+                                opts.retry_jitter,
+                                is_new_crate,
+                                &failure_output,
+                            );
+                            let next_attempt_at = retry_next_attempt_at(delay);
+                            attempt_detail.next_attempt_at = Some(next_attempt_at);
+                            record_retry_backoff(
+                                event_log,
+                                events_path,
+                                &pkg_label,
+                                attempt,
+                                opts.max_attempts,
+                                delay,
+                                next_attempt_at,
+                                &class,
+                                &msg,
+                            );
+                            if let Err(e) = record_attempt_detail(st, state_dir, attempt_detail) {
+                                return PackagePublishResult { result: Err(e) };
+                            }
+                            wait_after_retry(
+                                reporter,
+                                &p.name,
+                                &p.version,
+                                attempt,
+                                opts.max_attempts,
+                                delay,
+                                class.clone(),
+                                &msg,
+                            );
+                        } else if let Err(e) = record_attempt_detail(st, state_dir, attempt_detail)
+                        {
+                            return PackagePublishResult { result: Err(e) };
+                        }
                     }
                 }
                 continue;
@@ -743,6 +864,7 @@ pub(super) fn publish_package(
                         opts.retry_strategy,
                         opts.retry_jitter,
                     );
+                    let next_attempt_at = retry_next_attempt_at(delay);
                     emit_retry_backoff(
                         event_log,
                         events_path,
@@ -753,6 +875,7 @@ pub(super) fn publish_package(
                         attempt,
                         opts.max_attempts,
                         delay,
+                        next_attempt_at,
                         ErrorClass::Ambiguous,
                         message,
                     );
@@ -768,6 +891,7 @@ pub(super) fn publish_package(
                     opts.retry_strategy,
                     opts.retry_jitter,
                 );
+                let next_attempt_at = retry_next_attempt_at(delay);
                 emit_retry_backoff(
                     event_log,
                     events_path,
@@ -778,6 +902,7 @@ pub(super) fn publish_package(
                     attempt,
                     opts.max_attempts,
                     delay,
+                    next_attempt_at,
                     ErrorClass::Ambiguous,
                     message,
                 );

--- a/crates/shipper-core/src/engine/parallel/tests.rs
+++ b/crates/shipper-core/src/engine/parallel/tests.rs
@@ -74,6 +74,7 @@ fn emit_retry_backoff_does_not_block_other_reporter_calls_during_sleep() {
             1,
             3,
             delay,
+            chrono::Utc::now() + chrono::Duration::milliseconds(250),
             ErrorClass::Retryable,
             "rate limited",
         );
@@ -347,6 +348,7 @@ fn init_state_for_package(
         registry: registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     }
 }
@@ -680,6 +682,7 @@ fn test_run_publish_level_processes_packages() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     }));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
@@ -727,6 +730,7 @@ fn test_update_state_locked_sets_state() {
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: BTreeMap::from([(
             "demo@0.1.0".to_string(),
             PackageProgress {
@@ -871,6 +875,7 @@ fn test_run_publish_parallel_multiple_levels() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     };
     let mut reporter = CollectingReporter::default();
@@ -949,6 +954,7 @@ fn test_publish_package_handles_uploaded_resume() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     }));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
@@ -1151,6 +1157,7 @@ fn test_run_publish_level_respects_max_concurrent() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: state_packages,
     }));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
@@ -1300,6 +1307,7 @@ fn test_levels_execute_in_dependency_order() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     };
     let mut reporter = CollectingReporter::default();
@@ -1408,6 +1416,7 @@ fn test_failed_level_stops_subsequent_levels() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     };
     let mut reporter = CollectingReporter::default();
@@ -1528,6 +1537,7 @@ fn test_partial_success_within_level() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: state_packages,
     }));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
@@ -1752,6 +1762,7 @@ fn test_resume_from_skips_earlier_levels() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     };
     let mut reporter = CollectingReporter::default();
@@ -1888,6 +1899,7 @@ fn test_all_packages_already_published() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     };
     let mut reporter = CollectingReporter::default();
@@ -2011,6 +2023,7 @@ fn test_max_concurrency_one_serializes_execution() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: state_packages,
     }));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
@@ -2903,6 +2916,7 @@ fn test_error_in_first_level_prevents_all_subsequent() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     };
     let mut reporter = CollectingReporter::default();
@@ -2977,6 +2991,7 @@ fn test_empty_plan_produces_no_receipts() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: BTreeMap::new(),
     };
     let mut reporter = CollectingReporter::default();
@@ -3180,6 +3195,7 @@ fn test_max_concurrent_exceeds_package_count() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: state_packages,
     }));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
@@ -3293,6 +3309,7 @@ fn test_independent_failures_both_reported() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: state_packages,
     }));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
@@ -3408,6 +3425,7 @@ fn test_concurrent_state_updates_consistent() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: state_packages,
     }));
     let event_log = Arc::new(Mutex::new(events::EventLog::new()));
@@ -3715,6 +3733,7 @@ fn test_level_message_includes_max_concurrent() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: state_packages,
     };
     let mut reporter = CollectingReporter::default();

--- a/crates/shipper-core/src/runtime/execution/mod.rs
+++ b/crates/shipper-core/src/runtime/execution/mod.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 
 use shipper_retry::{RetryStrategyConfig, RetryStrategyType, calculate_delay};
-use shipper_types::{ErrorClass, ExecutionState, PackageState, PublishRegime};
+use shipper_types::{AttemptDetail, ErrorClass, ExecutionState, PackageState, PublishRegime};
 
 /// Update a package state and persist the entire execution state to disk.
 pub fn update_state(
@@ -29,6 +29,27 @@ pub fn update_state(
     pr.last_updated_at = Utc::now();
     st.updated_at = Utc::now();
     crate::state::execution_state::save_state(state_dir, st)
+}
+
+/// Append an attempt detail to an in-memory state and refresh its timestamp.
+pub fn append_attempt_detail(st: &mut ExecutionState, detail: AttemptDetail) {
+    st.attempt_history.push(detail);
+    st.updated_at = Utc::now();
+}
+
+/// Append an attempt detail and persist the execution state.
+pub fn record_attempt_detail(
+    st: &mut ExecutionState,
+    state_dir: &Path,
+    detail: AttemptDetail,
+) -> Result<()> {
+    append_attempt_detail(st, detail);
+    crate::state::execution_state::save_state(state_dir, st)
+}
+
+/// Calculate the wall-clock time for a scheduled retry.
+pub fn retry_next_attempt_at(delay: Duration) -> DateTime<Utc> {
+    Utc::now() + chrono::Duration::from_std(delay).unwrap_or_else(|_| chrono::Duration::zero())
 }
 
 /// Resolve the effective state directory from a workspace root and user option.
@@ -586,6 +607,7 @@ mod tests {
             registry: shipper_types::Registry::crates_io(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            attempt_history: Vec::new(),
             packages: BTreeMap::from([(key.to_string(), make_progress("demo", "0.1.0", state))]),
         }
     }
@@ -836,6 +858,7 @@ mod tests {
             registry: shipper_types::Registry::crates_io(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            attempt_history: Vec::new(),
             packages: BTreeMap::new(),
         };
         let td = tempdir().expect("tempdir");
@@ -850,6 +873,7 @@ mod tests {
             registry: shipper_types::Registry::crates_io(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            attempt_history: Vec::new(),
             packages: BTreeMap::new(),
         };
         // Should not panic
@@ -873,6 +897,7 @@ mod tests {
             registry: shipper_types::Registry::crates_io(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            attempt_history: Vec::new(),
             packages,
         }
     }
@@ -1673,6 +1698,7 @@ mod tests {
                 registry: shipper_types::Registry::crates_io(),
                 created_at: fixed_time(),
                 updated_at: fixed_time(),
+                attempt_history: Vec::new(),
                 packages,
             }
         }

--- a/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_execution_state_empty_packages.snap
+++ b/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_execution_state_empty_packages.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper/src/runtime/execution/mod.rs
+source: crates/shipper-core/src/runtime/execution/mod.rs
 expression: st
 ---
 ExecutionState {
@@ -14,5 +14,6 @@ ExecutionState {
     },
     created_at: 2025-01-15T12:00:00Z,
     updated_at: 2025-01-15T12:00:00Z,
+    attempt_history: [],
     packages: {},
 }

--- a/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_execution_state_single_ambiguous.snap
+++ b/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_execution_state_single_ambiguous.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper/src/runtime/execution/mod.rs
+source: crates/shipper-core/src/runtime/execution/mod.rs
 expression: st
 ---
 ExecutionState {
@@ -14,6 +14,7 @@ ExecutionState {
     },
     created_at: 2025-01-15T12:00:00Z,
     updated_at: 2025-01-15T12:00:00Z,
+    attempt_history: [],
     packages: {
         "a@1.0.0": PackageProgress {
             name: "a",

--- a/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_execution_state_single_failed.snap
+++ b/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_execution_state_single_failed.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper/src/runtime/execution/mod.rs
+source: crates/shipper-core/src/runtime/execution/mod.rs
 expression: st
 ---
 ExecutionState {
@@ -14,6 +14,7 @@ ExecutionState {
     },
     created_at: 2025-01-15T12:00:00Z,
     updated_at: 2025-01-15T12:00:00Z,
+    attempt_history: [],
     packages: {
         "a@1.0.0": PackageProgress {
             name: "a",

--- a/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_execution_state_single_pending.snap
+++ b/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_execution_state_single_pending.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper/src/runtime/execution/mod.rs
+source: crates/shipper-core/src/runtime/execution/mod.rs
 expression: st
 ---
 ExecutionState {
@@ -14,6 +14,7 @@ ExecutionState {
     },
     created_at: 2025-01-15T12:00:00Z,
     updated_at: 2025-01-15T12:00:00Z,
+    attempt_history: [],
     packages: {
         "a@1.0.0": PackageProgress {
             name: "a",

--- a/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_execution_state_single_published.snap
+++ b/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_execution_state_single_published.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper/src/runtime/execution/mod.rs
+source: crates/shipper-core/src/runtime/execution/mod.rs
 expression: st
 ---
 ExecutionState {
@@ -14,6 +14,7 @@ ExecutionState {
     },
     created_at: 2025-01-15T12:00:00Z,
     updated_at: 2025-01-15T12:00:00Z,
+    attempt_history: [],
     packages: {
         "a@1.0.0": PackageProgress {
             name: "a",

--- a/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_execution_state_single_skipped.snap
+++ b/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_execution_state_single_skipped.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper/src/runtime/execution/mod.rs
+source: crates/shipper-core/src/runtime/execution/mod.rs
 expression: st
 ---
 ExecutionState {
@@ -14,6 +14,7 @@ ExecutionState {
     },
     created_at: 2025-01-15T12:00:00Z,
     updated_at: 2025-01-15T12:00:00Z,
+    attempt_history: [],
     packages: {
         "a@1.0.0": PackageProgress {
             name: "a",

--- a/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_execution_state_single_uploaded.snap
+++ b/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_execution_state_single_uploaded.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper/src/runtime/execution/mod.rs
+source: crates/shipper-core/src/runtime/execution/mod.rs
 expression: st
 ---
 ExecutionState {
@@ -14,6 +14,7 @@ ExecutionState {
     },
     created_at: 2025-01-15T12:00:00Z,
     updated_at: 2025-01-15T12:00:00Z,
+    attempt_history: [],
     packages: {
         "a@1.0.0": PackageProgress {
             name: "a",

--- a/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_state_ambiguous_resolved.snap
+++ b/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_state_ambiguous_resolved.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper/src/runtime/execution/mod.rs
+source: crates/shipper-core/src/runtime/execution/mod.rs
 expression: st
 ---
 state_version: shipper.state.v1
@@ -10,6 +10,7 @@ registry:
   index_base: "https://index.crates.io"
 created_at: "2025-01-15T12:00:00Z"
 updated_at: "2025-01-15T12:00:00Z"
+attempt_history: []
 packages:
   demo@1.0.0:
     name: demo

--- a/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_state_failure_flow.snap
+++ b/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_state_failure_flow.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper/src/runtime/execution/mod.rs
+source: crates/shipper-core/src/runtime/execution/mod.rs
 expression: st
 ---
 state_version: shipper.state.v1
@@ -10,6 +10,7 @@ registry:
   index_base: "https://index.crates.io"
 created_at: "2025-01-15T12:00:00Z"
 updated_at: "2025-01-15T12:00:00Z"
+attempt_history: []
 packages:
   demo@1.0.0:
     name: demo

--- a/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_state_multi_package_mixed_outcomes.snap
+++ b/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_state_multi_package_mixed_outcomes.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper/src/runtime/execution/mod.rs
+source: crates/shipper-core/src/runtime/execution/mod.rs
 expression: st
 ---
 state_version: shipper.state.v1
@@ -10,6 +10,7 @@ registry:
   index_base: "https://index.crates.io"
 created_at: "2025-01-15T12:00:00Z"
 updated_at: "2025-01-15T12:00:00Z"
+attempt_history: []
 packages:
   cli@1.0.0:
     name: cli

--- a/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_state_skip_flow.snap
+++ b/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_state_skip_flow.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper/src/runtime/execution/mod.rs
+source: crates/shipper-core/src/runtime/execution/mod.rs
 expression: st
 ---
 state_version: shipper.state.v1
@@ -10,6 +10,7 @@ registry:
   index_base: "https://index.crates.io"
 created_at: "2025-01-15T12:00:00Z"
 updated_at: "2025-01-15T12:00:00Z"
+attempt_history: []
 packages:
   demo@1.0.0:
     name: demo

--- a/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_state_success_flow.snap
+++ b/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_state_success_flow.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper/src/runtime/execution/mod.rs
+source: crates/shipper-core/src/runtime/execution/mod.rs
 expression: st
 ---
 state_version: shipper.state.v1
@@ -10,6 +10,7 @@ registry:
   index_base: "https://index.crates.io"
 created_at: "2025-01-15T12:00:00Z"
 updated_at: "2025-01-15T12:00:00Z"
+attempt_history: []
 packages:
   demo@1.0.0:
     name: demo

--- a/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_transition_all_skipped_plan.snap
+++ b/crates/shipper-core/src/runtime/execution/snapshots/shipper_core__runtime__execution__tests__snapshots__snapshot_transition_all_skipped_plan.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper/src/runtime/execution/mod.rs
+source: crates/shipper-core/src/runtime/execution/mod.rs
 expression: st
 ---
 ExecutionState {
@@ -14,6 +14,7 @@ ExecutionState {
     },
     created_at: 2025-01-15T12:00:00Z,
     updated_at: 2025-01-15T12:00:00Z,
+    attempt_history: [],
     packages: {
         "a@1.0.0": PackageProgress {
             name: "a",

--- a/crates/shipper-core/src/state/consistency.rs
+++ b/crates/shipper-core/src/state/consistency.rs
@@ -133,6 +133,7 @@ mod tests {
                 api_base: "https://crates.io".to_string(),
                 index_base: None,
             },
+            attempt_history: Vec::new(),
             packages: packages.into_iter().collect::<BTreeMap<_, _>>(),
             created_at: Utc::now(),
             updated_at: Utc::now(),

--- a/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__state_all_lifecycle_variants.snap
+++ b/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__state_all_lifecycle_variants.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-state/src/lib.rs
+source: crates/shipper-core/src/state/execution_state/tests.rs
 expression: json
 ---
 {
@@ -12,6 +12,7 @@ expression: json
   },
   "created_at": "2025-01-15T12:00:00Z",
   "updated_at": "2025-01-15T12:00:00Z",
+  "attempt_history": [],
   "packages": {
     "crate-a@1.0.0": {
       "name": "crate-a",

--- a/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__state_empty_packages.snap
+++ b/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__state_empty_packages.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/shipper-state/src/lib.rs
-assertion_line: 2490
+source: crates/shipper-core/src/state/execution_state/tests.rs
 expression: json
 ---
 {
@@ -13,5 +12,6 @@ expression: json
   },
   "created_at": "2025-01-15T12:00:00Z",
   "updated_at": "2025-01-15T12:00:00Z",
+  "attempt_history": [],
   "packages": {}
 }

--- a/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__state_json_format.snap
+++ b/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__state_json_format.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-state/src/lib.rs
+source: crates/shipper-core/src/state/execution_state/tests.rs
 expression: json
 ---
 {
@@ -12,6 +12,7 @@ expression: json
   },
   "created_at": "2025-01-15T12:00:00Z",
   "updated_at": "2025-01-15T12:00:00Z",
+  "attempt_history": [],
   "packages": {
     "alpha@0.1.0": {
       "name": "alpha",

--- a/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__state_transition_pending_to_failed.snap
+++ b/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__state_transition_pending_to_failed.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-state/src/lib.rs
+source: crates/shipper-core/src/state/execution_state/tests.rs
 expression: json
 ---
 {
@@ -12,6 +12,7 @@ expression: json
   },
   "created_at": "2025-01-15T12:00:00Z",
   "updated_at": "2025-01-15T12:00:00Z",
+  "attempt_history": [],
   "packages": {
     "alpha@0.1.0": {
       "name": "alpha",

--- a/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__state_transition_pending_to_published.snap
+++ b/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__state_transition_pending_to_published.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-state/src/lib.rs
+source: crates/shipper-core/src/state/execution_state/tests.rs
 expression: json
 ---
 {
@@ -12,6 +12,7 @@ expression: json
   },
   "created_at": "2025-01-15T12:00:00Z",
   "updated_at": "2025-01-15T12:00:00Z",
+  "attempt_history": [],
   "packages": {
     "alpha@0.1.0": {
       "name": "alpha",

--- a/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__state_transition_pending_to_skipped.snap
+++ b/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__state_transition_pending_to_skipped.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-state/src/lib.rs
+source: crates/shipper-core/src/state/execution_state/tests.rs
 expression: json
 ---
 {
@@ -12,6 +12,7 @@ expression: json
   },
   "created_at": "2025-01-15T12:00:00Z",
   "updated_at": "2025-01-15T12:00:00Z",
+  "attempt_history": [],
   "packages": {
     "alpha@0.1.0": {
       "name": "alpha",

--- a/crates/shipper-core/src/state/execution_state/tests.rs
+++ b/crates/shipper-core/src/state/execution_state/tests.rs
@@ -32,6 +32,7 @@ fn sample_state() -> ExecutionState {
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     }
 }
@@ -544,6 +545,43 @@ fn state_double_save_produces_identical_json() {
 }
 
 #[test]
+fn load_state_defaults_missing_attempt_history_for_old_state_json() {
+    let td = tempdir().expect("tempdir");
+    let dir = td.path().join("old-state");
+    fs::create_dir_all(&dir).expect("mkdir");
+    fs::write(
+        state_path(&dir),
+        r#"{
+  "state_version": "shipper.state.v1",
+  "plan_id": "old-plan",
+  "registry": {
+    "name": "crates-io",
+    "api_base": "https://crates.io",
+    "index_base": null
+  },
+  "created_at": "2025-01-15T12:00:00Z",
+  "updated_at": "2025-01-15T12:00:00Z",
+  "packages": {
+    "demo@0.1.0": {
+      "name": "demo",
+      "version": "0.1.0",
+      "attempts": 1,
+      "state": { "state": "pending" },
+      "last_updated_at": "2025-01-15T12:00:00Z"
+    }
+  }
+}"#,
+    )
+    .expect("write old state");
+
+    let loaded = load_state(&dir).expect("load").expect("exists");
+
+    assert_eq!(loaded.plan_id, "old-plan");
+    assert!(loaded.attempt_history.is_empty());
+    assert_eq!(loaded.packages["demo@0.1.0"].attempts, 1);
+}
+
+#[test]
 fn receipt_double_save_produces_identical_json() {
     let td = tempdir().expect("tempdir");
     let dir1 = td.path().join("first");
@@ -584,6 +622,7 @@ fn state_lifecycle_pending_uploaded_published() {
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     };
 
@@ -649,6 +688,7 @@ fn state_all_error_classes_persist() {
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     };
 
@@ -689,6 +729,7 @@ fn state_empty_packages_roundtrip() {
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: BTreeMap::new(),
     };
 
@@ -740,6 +781,7 @@ fn state_overwrite_replaces_all_data() {
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: BTreeMap::new(),
     };
     save_state(&dir, &st1).expect("save v1");
@@ -761,6 +803,7 @@ fn state_overwrite_replaces_all_data() {
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     };
     save_state(&dir, &st2).expect("save v2");
@@ -808,6 +851,7 @@ fn state_with_special_chars_in_plan_id() {
             registry: Registry::crates_io(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            attempt_history: Vec::new(),
             packages: BTreeMap::new(),
         };
 
@@ -828,6 +872,7 @@ fn state_plan_id_mismatch_detection() {
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: BTreeMap::new(),
     };
     save_state(&dir, &state).expect("save");
@@ -904,6 +949,7 @@ fn deterministic_state() -> ExecutionState {
         registry: Registry::crates_io(),
         created_at: fixed,
         updated_at: fixed,
+        attempt_history: Vec::new(),
         packages,
     }
 }
@@ -1124,6 +1170,7 @@ fn snapshot_state_all_lifecycle_variants() {
         registry: Registry::crates_io(),
         created_at: fixed,
         updated_at: fixed,
+        attempt_history: Vec::new(),
         packages,
     };
 
@@ -1279,6 +1326,7 @@ mod proptests {
                     registry,
                     created_at: created,
                     updated_at: updated,
+                    attempt_history: Vec::new(),
                     packages,
                 },
             )
@@ -1384,6 +1432,7 @@ mod proptests {
                 registry: Registry::crates_io(),
                 created_at: fixed,
                 updated_at: fixed,
+                attempt_history: Vec::new(),
                 packages: BTreeMap::new(),
             };
             let json = serde_json::to_string(&state).expect("serialize");
@@ -1419,6 +1468,7 @@ mod proptests {
                 registry: Registry::crates_io(),
                 created_at: fixed,
                 updated_at: fixed,
+                attempt_history: Vec::new(),
                 packages,
             };
 
@@ -1571,6 +1621,7 @@ fn atomic_write_no_partial_state_on_serialization_error_path() {
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: BTreeMap::new(),
     };
     save_state(&dir, &st1).expect("save original");
@@ -1906,6 +1957,7 @@ fn concurrent_readers_all_see_consistent_state() {
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: pkgs,
     };
     save_state(&dir, &state).expect("save");
@@ -1955,6 +2007,7 @@ fn sequential_writer_reader_pattern() {
             registry: Registry::crates_io(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            attempt_history: Vec::new(),
             packages: pkgs,
         };
         save_state(&dir, &state).expect("save");
@@ -1981,6 +2034,7 @@ fn concurrent_writer_then_readers() {
                 registry: Registry::crates_io(),
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
+                attempt_history: Vec::new(),
                 packages: BTreeMap::new(),
             };
             save_state(&wd, &state).expect("save");
@@ -2068,6 +2122,7 @@ fn each_package_state_variant_disk_roundtrip() {
             registry: Registry::crates_io(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            attempt_history: Vec::new(),
             packages: pkgs,
         };
         save_state(&dir, &state).expect("save");
@@ -2204,6 +2259,7 @@ fn snapshot_state_empty_packages() {
         registry: Registry::crates_io(),
         created_at: fixed,
         updated_at: fixed,
+        attempt_history: Vec::new(),
         packages: BTreeMap::new(),
     };
     let json = serde_json::to_string_pretty(&state).expect("serialize");
@@ -2343,6 +2399,7 @@ mod proptests_extended {
                     .unwrap_or_default(),
                 updated_at: chrono::DateTime::from_timestamp(1_700_000_000, 0)
                     .unwrap_or_default(),
+                attempt_history: Vec::new(),
                 packages: pkgs,
             };
 

--- a/crates/shipper-core/src/state/store/path_edge_case_tests.rs
+++ b/crates/shipper-core/src/state/store/path_edge_case_tests.rs
@@ -26,6 +26,7 @@ fn sample_state() -> ExecutionState {
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     }
 }

--- a/crates/shipper-core/src/state/store/snapshot_tests.rs
+++ b/crates/shipper-core/src/state/store/snapshot_tests.rs
@@ -42,6 +42,7 @@ fn snapshot_execution_state_single_pending() {
         registry: Registry::crates_io(),
         created_at: t,
         updated_at: t,
+        attempt_history: Vec::new(),
         packages,
     };
 
@@ -128,6 +129,7 @@ fn snapshot_execution_state_all_package_states() {
         registry: Registry::crates_io(),
         created_at: t,
         updated_at: t,
+        attempt_history: Vec::new(),
         packages,
     };
 
@@ -144,6 +146,7 @@ fn snapshot_execution_state_empty_packages() {
         registry: Registry::crates_io(),
         created_at: t,
         updated_at: t,
+        attempt_history: Vec::new(),
         packages: BTreeMap::new(),
     };
 
@@ -353,6 +356,7 @@ fn snapshot_state_persisted_json() {
         registry: Registry::crates_io(),
         created_at: t,
         updated_at: t,
+        attempt_history: Vec::new(),
         packages,
     };
 
@@ -642,6 +646,7 @@ fn snapshot_state_retry_cycle() {
         registry: Registry::crates_io(),
         created_at: t,
         updated_at: t,
+        attempt_history: Vec::new(),
         packages,
     };
 
@@ -797,6 +802,7 @@ fn snapshot_directory_layout_after_full_save() {
         registry: Registry::crates_io(),
         created_at: t,
         updated_at: t,
+        attempt_history: Vec::new(),
         packages,
     };
     store.save_state(&state).expect("save state");
@@ -885,6 +891,7 @@ fn snapshot_state_with_custom_registry() {
         },
         created_at: t,
         updated_at: t,
+        attempt_history: Vec::new(),
         packages,
     };
 

--- a/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__execution_state_all_package_states.snap
+++ b/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__execution_state_all_package_states.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-store/src/lib.rs
+source: crates/shipper-core/src/state/store/snapshot_tests.rs
 expression: json
 ---
 {
@@ -12,6 +12,7 @@ expression: json
   },
   "created_at": "2025-01-15T12:00:00Z",
   "updated_at": "2025-01-15T12:00:00Z",
+  "attempt_history": [],
   "packages": {
     "a@1.0.0": {
       "name": "a",

--- a/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__execution_state_empty_packages.snap
+++ b/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__execution_state_empty_packages.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-store/src/lib.rs
+source: crates/shipper-core/src/state/store/snapshot_tests.rs
 expression: json
 ---
 {
@@ -12,5 +12,6 @@ expression: json
   },
   "created_at": "2025-01-15T12:00:00Z",
   "updated_at": "2025-01-15T12:00:00Z",
+  "attempt_history": [],
   "packages": {}
 }

--- a/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__execution_state_single_pending.snap
+++ b/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__execution_state_single_pending.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-store/src/lib.rs
+source: crates/shipper-core/src/state/store/snapshot_tests.rs
 expression: json
 ---
 {
@@ -12,6 +12,7 @@ expression: json
   },
   "created_at": "2025-01-15T12:00:00Z",
   "updated_at": "2025-01-15T12:00:00Z",
+  "attempt_history": [],
   "packages": {
     "demo@0.1.0": {
       "name": "demo",

--- a/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__state_persisted_json.snap
+++ b/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__state_persisted_json.snap
@@ -1,8 +1,9 @@
 ---
-source: crates/shipper-store/src/lib.rs
+source: crates/shipper-core/src/state/store/snapshot_tests.rs
 expression: pretty
 ---
 {
+  "attempt_history": [],
   "created_at": "2025-01-15T12:00:00Z",
   "packages": {
     "alpha@0.1.0": {

--- a/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__state_retry_cycle.snap
+++ b/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__state_retry_cycle.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-store/src/lib.rs
+source: crates/shipper-core/src/state/store/snapshot_tests.rs
 expression: json
 ---
 {
@@ -12,6 +12,7 @@ expression: json
   },
   "created_at": "2025-01-15T12:00:00Z",
   "updated_at": "2025-01-15T12:00:00Z",
+  "attempt_history": [],
   "packages": {
     "retried@1.0.0": {
       "name": "retried",

--- a/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__state_with_custom_registry.snap
+++ b/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__state_with_custom_registry.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-store/src/lib.rs
+source: crates/shipper-core/src/state/store/snapshot_tests.rs
 expression: json
 ---
 {
@@ -12,6 +12,7 @@ expression: json
   },
   "created_at": "2025-01-15T12:00:00Z",
   "updated_at": "2025-01-15T12:00:00Z",
+  "attempt_history": [],
   "packages": {
     "my-lib@0.1.0": {
       "name": "my-lib",

--- a/crates/shipper-core/src/state/store/tests.rs
+++ b/crates/shipper-core/src/state/store/tests.rs
@@ -28,6 +28,7 @@ fn sample_state() -> ExecutionState {
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     }
 }
@@ -379,6 +380,7 @@ fn file_store_state_with_all_package_states() {
         registry: Registry::crates_io(),
         created_at: now,
         updated_at: now,
+        attempt_history: Vec::new(),
         packages,
     };
 
@@ -746,6 +748,7 @@ fn file_store_state_with_empty_packages() {
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: BTreeMap::new(),
     };
 
@@ -1115,6 +1118,7 @@ fn file_store_state_very_long_package_name() {
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     };
 
@@ -1137,6 +1141,7 @@ fn file_store_state_empty_plan_id() {
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: BTreeMap::new(),
     };
 
@@ -1461,6 +1466,7 @@ fn file_store_concurrent_writers_last_write_readable() {
                     registry: Registry::crates_io(),
                     created_at: Utc::now(),
                     updated_at: Utc::now(),
+                    attempt_history: Vec::new(),
                     packages: BTreeMap::new(),
                 };
                 state.packages.insert(
@@ -1523,6 +1529,7 @@ fn file_store_state_with_many_packages() {
         registry: Registry::crates_io(),
         created_at: now,
         updated_at: now,
+        attempt_history: Vec::new(),
         packages,
     };
 
@@ -1731,6 +1738,7 @@ mod proptests_hardened {
                 registry: Registry::crates_io(),
                 created_at: now,
                 updated_at: now,
+                attempt_history: Vec::new(),
                 packages,
             };
 

--- a/crates/shipper-core/src/stress_tests.rs
+++ b/crates/shipper-core/src/stress_tests.rs
@@ -46,6 +46,7 @@ mod tests {
             registry: Registry::crates_io(),
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
+            attempt_history: Vec::new(),
             packages: pkg_map,
         }
     }

--- a/crates/shipper-types/src/lib.rs
+++ b/crates/shipper-types/src/lib.rs
@@ -1191,6 +1191,27 @@ pub struct PackageProgress {
     pub last_updated_at: DateTime<Utc>,
 }
 
+/// Durable state record for one `cargo publish` attempt.
+///
+/// `PackageProgress::attempts` is the fast counter used by resume. This
+/// detail log preserves operator-facing facts needed by `status`, resume
+/// explainers, and release evidence before the final receipt exists.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AttemptDetail {
+    pub package: String,
+    pub version: String,
+    pub attempt: u32,
+    pub max_attempts: u32,
+    pub started_at: DateTime<Utc>,
+    pub ended_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_class: Option<ErrorClass>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_attempt_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redacted_message: Option<String>,
+}
+
 /// The complete state of an in-progress publish operation.
 ///
 /// This is the root structure persisted to disk during publishing.
@@ -1208,6 +1229,7 @@ pub struct PackageProgress {
 ///     registry: Registry::crates_io(),
 ///     created_at: Utc::now(),
 ///     updated_at: Utc::now(),
+///     attempt_history: Vec::new(),
 ///     packages: std::collections::BTreeMap::new(),
 /// };
 ///
@@ -1227,6 +1249,10 @@ pub struct ExecutionState {
     pub registry: Registry,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// Per-attempt timeline written during publish, before final receipt
+    /// construction. Defaults empty so older state files remain readable.
+    #[serde(default)]
+    pub attempt_history: Vec<AttemptDetail>,
     pub packages: BTreeMap<String, PackageProgress>,
 }
 
@@ -2009,6 +2035,7 @@ mod tests {
             registry: Registry::crates_io(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            attempt_history: Vec::new(),
             packages,
         };
 
@@ -3285,6 +3312,7 @@ mod tests {
                 registry: Registry::crates_io(),
                 created_at: t,
                 updated_at: t,
+                attempt_history: Vec::new(),
                 packages,
             };
             insta::assert_yaml_snapshot!(state);
@@ -3685,6 +3713,7 @@ mod tests {
                 registry: Registry::crates_io(),
                 created_at: t,
                 updated_at: t,
+                attempt_history: Vec::new(),
                 packages,
             };
             insta::assert_yaml_snapshot!(state);
@@ -3712,6 +3741,7 @@ mod tests {
                 registry: Registry::crates_io(),
                 created_at: t,
                 updated_at: t,
+                attempt_history: Vec::new(),
                 packages,
             };
             insta::assert_yaml_snapshot!(state);
@@ -3774,6 +3804,7 @@ mod tests {
                 registry: Registry::crates_io(),
                 created_at: t,
                 updated_at: t,
+                attempt_history: Vec::new(),
                 packages,
             };
             insta::assert_yaml_snapshot!(state);
@@ -4547,6 +4578,7 @@ mod tests {
                     registry: Registry::crates_io(),
                     created_at: Utc::now(),
                     updated_at: Utc::now(),
+                    attempt_history: Vec::new(),
                     packages,
                 };
                 let json = serde_json::to_string(&state).unwrap();
@@ -5025,6 +5057,7 @@ mod tests {
                     registry: Registry::crates_io(),
                     created_at: Utc::now(),
                     updated_at: Utc::now(),
+                    attempt_history: Vec::new(),
                     packages,
                 };
 
@@ -5066,6 +5099,7 @@ mod tests {
                     registry: Registry::crates_io(),
                     created_at: Utc::now(),
                     updated_at: Utc::now(),
+                    attempt_history: Vec::new(),
                     packages,
                 };
 
@@ -5405,6 +5439,7 @@ mod tests {
                     registry: Registry::crates_io(),
                     created_at: Utc::now(),
                     updated_at: Utc::now(),
+                    attempt_history: Vec::new(),
                     packages: packages.clone(),
                 };
                 let json = serde_json::to_string(&exec_state).unwrap();

--- a/crates/shipper-types/src/snapshots/shipper_types__tests__snapshots__execution_state_all_pending.snap
+++ b/crates/shipper-types/src/snapshots/shipper_types__tests__snapshots__execution_state_all_pending.snap
@@ -10,6 +10,7 @@ registry:
   index_base: "https://index.crates.io"
 created_at: "2025-01-15T12:00:00Z"
 updated_at: "2025-01-15T12:00:00Z"
+attempt_history: []
 packages:
   alpha@0.1.0:
     name: alpha

--- a/crates/shipper-types/src/snapshots/shipper_types__tests__snapshots__execution_state_completed.snap
+++ b/crates/shipper-types/src/snapshots/shipper_types__tests__snapshots__execution_state_completed.snap
@@ -10,6 +10,7 @@ registry:
   index_base: "https://index.crates.io"
 created_at: "2025-01-15T12:00:00Z"
 updated_at: "2025-01-15T12:00:00Z"
+attempt_history: []
 packages:
   alpha@0.1.0:
     name: alpha

--- a/crates/shipper-types/src/snapshots/shipper_types__tests__snapshots__execution_state_mixed_with_failures.snap
+++ b/crates/shipper-types/src/snapshots/shipper_types__tests__snapshots__execution_state_mixed_with_failures.snap
@@ -10,6 +10,7 @@ registry:
   index_base: "https://index.crates.io"
 created_at: "2025-01-15T12:00:00Z"
 updated_at: "2025-01-15T12:00:00Z"
+attempt_history: []
 packages:
   cli@0.3.0:
     name: cli

--- a/crates/shipper-types/src/snapshots/shipper_types__tests__snapshots__execution_state_snapshot.snap
+++ b/crates/shipper-types/src/snapshots/shipper_types__tests__snapshots__execution_state_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/shipper-types/src/lib.rs
-assertion_line: 1643
 expression: state
 ---
 state_version: shipper.state.v1
@@ -11,6 +10,7 @@ registry:
   index_base: "https://index.crates.io"
 created_at: "2025-01-15T12:00:00Z"
 updated_at: "2025-01-15T12:00:00Z"
+attempt_history: []
 packages:
   core-lib@0.1.0:
     name: core-lib

--- a/crates/shipper/tests/cross_crate_integration.rs
+++ b/crates/shipper/tests/cross_crate_integration.rs
@@ -98,6 +98,7 @@ fn sample_state(plan_id: &str) -> ExecutionState {
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     }
 }
@@ -215,6 +216,7 @@ fn plan_build_then_persist_state() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     };
 
@@ -1065,6 +1067,7 @@ fn state_roundtrip_preserves_all_package_state_variants() {
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     };
 
@@ -1183,6 +1186,7 @@ fn resume_skips_published_and_retries_failed() {
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     };
 

--- a/crates/shipper/tests/execution_bdd.rs
+++ b/crates/shipper/tests/execution_bdd.rs
@@ -16,6 +16,7 @@ fn bdd_given_existing_pending_package_when_state_is_updated_and_persisted_then_s
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: BTreeMap::from([(
             key.clone(),
             PackageProgress {
@@ -51,6 +52,7 @@ fn bdd_given_in_memory_update_then_state_uses_key_lookup_contract() {
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: BTreeMap::from([(
             key.clone(),
             PackageProgress {

--- a/crates/shipper/tests/facade_integration.rs
+++ b/crates/shipper/tests/facade_integration.rs
@@ -164,6 +164,7 @@ fn sample_state(plan_id: &str, packages: &[(&str, &str, PackageState, u32)]) -> 
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: map,
     }
 }
@@ -972,6 +973,7 @@ fn plan_state_store_full_lifecycle() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     };
 
@@ -2437,6 +2439,7 @@ fn full_lifecycle_plan_events_receipt_through_store() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: packages.clone(),
     };
     store.save_state(&exec_state).expect("save initial state");
@@ -2500,6 +2503,7 @@ fn full_lifecycle_plan_events_receipt_through_store() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages: final_packages,
     };
     store

--- a/crates/shipper/tests/pipeline_integration.rs
+++ b/crates/shipper/tests/pipeline_integration.rs
@@ -92,6 +92,7 @@ fn make_state(plan_id: &str, pkgs: &[(&str, &str, PackageState, u32)]) -> Execut
         registry: Registry::crates_io(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     }
 }
@@ -190,6 +191,7 @@ fn config_plan_state_receipt_end_to_end_pipeline() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     };
     state::save_state(&state_dir, &exec_state).expect("save state");
@@ -1226,6 +1228,7 @@ fn full_pipeline_plan_preflight_publish_verify_receipt() {
         registry: ws.plan.registry.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     };
     state::save_state(&state_dir, &exec_state).expect("save state");

--- a/crates/shipper/tests/snapshots/state_integration__state_retry_cycle.snap
+++ b/crates/shipper/tests/snapshots/state_integration__state_retry_cycle.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-state/tests/state_integration.rs
+source: crates/shipper/tests/state_integration.rs
 expression: json
 ---
 {
@@ -12,6 +12,7 @@ expression: json
   },
   "created_at": "2025-01-15T12:00:00Z",
   "updated_at": "2025-01-15T12:00:00Z",
+  "attempt_history": [],
   "packages": {
     "retried@1.0.0": {
       "name": "retried",

--- a/crates/shipper/tests/state_integration.rs
+++ b/crates/shipper/tests/state_integration.rs
@@ -40,6 +40,7 @@ fn make_state(plan_id: &str, packages: BTreeMap<String, PackageProgress>) -> Exe
         registry: sample_registry(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        attempt_history: Vec::new(),
         packages,
     }
 }
@@ -995,6 +996,7 @@ fn make_deterministic_state(
         registry: sample_registry(),
         created_at: fixed_time(),
         updated_at: fixed_time(),
+        attempt_history: Vec::new(),
         packages,
     }
 }


### PR DESCRIPTION
## Summary
- add AttemptDetail to persisted execution state with serde defaults for old state.json compatibility
- record cargo publish attempt history in sequential and parallel publish paths
- keep retry scheduling honest: terminal attempts do not advertise 
ext_attempt_at, and retry events are flushed before state records the scheduled retry

## Validation
- cargo test -p shipper-core --locked
- cargo test -p shipper-types --locked
- cargo test -p shipper --locked
- cargo test -p shipper-core run_publish_state_attempts_counter_increments_on_retry --locked
- cargo clippy -p shipper-core --all-targets --locked -- -D warnings
- cargo clippy -p shipper-types --all-targets --locked -- -D warnings
- cargo clippy -p shipper --all-targets --locked -- -D warnings
- cargo fmt --all -- --check
- cargo xtask package-surface
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask policy-report
- git diff --check