### PR TITLE
feat(events): emit publish wait and readiness scheduling events

### DIFF
--- a/crates/shipper-core/src/engine/mod.rs
+++ b/crates/shipper-core/src/engine/mod.rs
@@ -15,7 +15,7 @@ use crate::runtime::environment;
 use crate::runtime::execution::short_state;
 use crate::runtime::execution::{
     backoff_delay, classify_cargo_failure, pkg_key, record_attempt_detail, registry_aware_backoff,
-    resolve_state_dir, retry_next_attempt_at, update_state,
+    resolve_state_dir, retry_after_delay, retry_next_attempt_at, update_state,
 };
 use crate::state::events;
 use crate::state::execution_state as state;
@@ -848,6 +848,17 @@ pub fn run_publish(
                                 false
                             };
                             if attempt < opts.max_attempts {
+                                if crate::runtime::execution::looks_like_rate_limit(&failure_output)
+                                {
+                                    record_rate_limit_observed_event(
+                                        &mut event_log,
+                                        &events_path,
+                                        &pkg_label,
+                                        is_new_crate,
+                                        retry_after_delay(&failure_output),
+                                        &msg,
+                                    )?;
+                                }
                                 let delay = registry_aware_backoff(
                                     opts.base_delay,
                                     opts.max_delay,
@@ -899,8 +910,16 @@ pub fn run_publish(
                 enabled: effects.readiness_enabled,
                 ..opts.readiness.clone()
             };
-            let (visible, checks) =
-                verify_published(&reg, &p.name, &p.version, &readiness_config, reporter)?;
+            let (visible, checks) = verify_published(
+                &reg,
+                &p.name,
+                &p.version,
+                &readiness_config,
+                reporter,
+                &mut event_log,
+                &events_path,
+                &pkg_label,
+            )?;
             readiness_evidence = checks;
             if visible {
                 update_state(&mut st, &state_dir, &key, PackageState::Published)?;
@@ -1614,6 +1633,26 @@ fn record_retry_backoff_event(
 ) -> Result<()> {
     event_log.record(PublishEvent {
         timestamp: Utc::now(),
+        event_type: EventType::RetryScheduled {
+            attempt,
+            max_attempts,
+            delay_ms: delay.as_millis() as u64,
+            next_attempt_at,
+            reason: reason.clone(),
+            message: message.to_string(),
+        },
+        package: pkg_label.to_string(),
+    });
+    record_publish_wait_event(
+        event_log,
+        events_path,
+        pkg_label,
+        delay,
+        "retry backoff",
+        Some(next_attempt_at),
+    )?;
+    event_log.record(PublishEvent {
+        timestamp: Utc::now(),
         event_type: EventType::RetryBackoffStarted {
             attempt,
             max_attempts,
@@ -1621,6 +1660,50 @@ fn record_retry_backoff_event(
             next_attempt_at,
             reason: reason.clone(),
             message: message.to_string(),
+        },
+        package: pkg_label.to_string(),
+    });
+    event_log.write_to_file(events_path)?;
+    event_log.clear();
+    Ok(())
+}
+
+fn record_rate_limit_observed_event(
+    event_log: &mut events::EventLog,
+    events_path: &Path,
+    pkg_label: &str,
+    is_new_crate: bool,
+    retry_after: Option<std::time::Duration>,
+    message: &str,
+) -> Result<()> {
+    event_log.record(PublishEvent {
+        timestamp: Utc::now(),
+        event_type: EventType::RateLimitObserved {
+            is_new_crate,
+            retry_after_ms: retry_after.map(|delay| delay.as_millis() as u64),
+            message: message.to_string(),
+        },
+        package: pkg_label.to_string(),
+    });
+    event_log.write_to_file(events_path)?;
+    event_log.clear();
+    Ok(())
+}
+
+fn record_publish_wait_event(
+    event_log: &mut events::EventLog,
+    events_path: &Path,
+    pkg_label: &str,
+    delay: std::time::Duration,
+    reason: &str,
+    until: Option<chrono::DateTime<Utc>>,
+) -> Result<()> {
+    event_log.record(PublishEvent {
+        timestamp: Utc::now(),
+        event_type: EventType::PublishWaiting {
+            reason: reason.to_string(),
+            delay_ms: delay.as_millis() as u64,
+            until: until.unwrap_or_else(|| retry_next_attempt_at(delay)),
         },
         package: pkg_label.to_string(),
     });
@@ -1662,12 +1745,33 @@ fn verify_published(
     version: &str,
     config: &crate::types::ReadinessConfig,
     reporter: &mut dyn Reporter,
+    event_log: &mut events::EventLog,
+    events_path: &Path,
+    pkg_label: &str,
 ) -> Result<(bool, Vec<ReadinessEvidence>)> {
     reporter.info(&format!(
         "{}@{}: readiness check ({:?})...",
         crate_name, version, config.method
     ));
-    let (visible, evidence) = reg.is_version_visible_with_backoff(crate_name, version, config)?;
+    let started_at = Instant::now();
+    record_readiness_event(
+        event_log,
+        events_path,
+        PublishEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::ReadinessStarted {
+                method: config.method,
+            },
+            package: pkg_label.to_string(),
+        },
+    )?;
+    let mut emit_event = |event| record_readiness_event(event_log, events_path, event);
+    let (visible, evidence) = reg.is_version_visible_with_backoff_and_events(
+        crate_name,
+        version,
+        config,
+        &mut emit_event,
+    )?;
     if visible {
         reporter.info(&format!(
             "{}@{}: visible after {} checks",
@@ -1675,6 +1779,18 @@ fn verify_published(
             version,
             evidence.len()
         ));
+        record_readiness_event(
+            event_log,
+            events_path,
+            PublishEvent {
+                timestamp: Utc::now(),
+                event_type: EventType::ReadinessComplete {
+                    duration_ms: started_at.elapsed().as_millis() as u64,
+                    attempts: evidence.len() as u32,
+                },
+                package: pkg_label.to_string(),
+            },
+        )?;
     } else {
         reporter.warn(&format!(
             "{}@{}: not visible after {} checks",
@@ -1682,8 +1798,30 @@ fn verify_published(
             version,
             evidence.len()
         ));
+        record_readiness_event(
+            event_log,
+            events_path,
+            PublishEvent {
+                timestamp: Utc::now(),
+                event_type: EventType::ReadinessTimeout {
+                    max_wait_ms: config.max_total_wait.as_millis() as u64,
+                },
+                package: pkg_label.to_string(),
+            },
+        )?;
     }
     Ok((visible, evidence))
+}
+
+fn record_readiness_event(
+    event_log: &mut events::EventLog,
+    events_path: &Path,
+    event: PublishEvent,
+) -> Result<()> {
+    event_log.record(event);
+    event_log.write_to_file(events_path)?;
+    event_log.clear();
+    Ok(())
 }
 
 #[cfg(test)]
@@ -2100,8 +2238,20 @@ mod tests {
         };
 
         let mut reporter = CollectingReporter::default();
-        let (ok, evidence) =
-            verify_published(&reg, "demo", "0.1.0", &config, &mut reporter).expect("verify");
+        let td = tempdir().expect("tempdir");
+        let events_path = td.path().join("events.jsonl");
+        let mut event_log = events::EventLog::new();
+        let (ok, evidence) = verify_published(
+            &reg,
+            "demo",
+            "0.1.0",
+            &config,
+            &mut reporter,
+            &mut event_log,
+            &events_path,
+            "demo@0.1.0",
+        )
+        .expect("verify");
         assert!(ok);
         assert!(!reporter.infos.is_empty());
         assert!(!evidence.is_empty());
@@ -2130,8 +2280,20 @@ mod tests {
         };
 
         let mut reporter = CollectingReporter::default();
-        let (ok, _evidence) =
-            verify_published(&reg, "demo", "0.1.0", &config, &mut reporter).expect("verify");
+        let td = tempdir().expect("tempdir");
+        let events_path = td.path().join("events.jsonl");
+        let mut event_log = events::EventLog::new();
+        let (ok, _evidence) = verify_published(
+            &reg,
+            "demo",
+            "0.1.0",
+            &config,
+            &mut reporter,
+            &mut event_log,
+            &events_path,
+            "demo@0.1.0",
+        )
+        .expect("verify");
         assert!(!ok);
     }
 
@@ -4792,6 +4954,26 @@ mod tests {
             assert_eq!(state.attempt_history[0].max_attempts, opts.max_attempts);
             assert!(state.attempt_history[0].error_class.is_none());
             assert!(state.attempt_history[0].next_attempt_at.is_none());
+            let events = events::EventLog::read_from_file(&td.path().join(".shipper/events.jsonl"))
+                .expect("read events");
+            assert!(
+                events
+                    .all_events()
+                    .iter()
+                    .any(|event| matches!(event.event_type, EventType::ReadinessStarted { .. }))
+            );
+            assert!(
+                events
+                    .all_events()
+                    .iter()
+                    .any(|event| matches!(event.event_type, EventType::ReadinessPoll { .. }))
+            );
+            assert!(
+                events
+                    .all_events()
+                    .iter()
+                    .any(|event| matches!(event.event_type, EventType::ReadinessComplete { .. }))
+            );
             server.join();
         });
     }
@@ -4864,22 +5046,28 @@ mod tests {
                 ("SHIPPER_CARGO_EXIT", Some("1".to_string())),
                 (
                     "SHIPPER_CARGO_STDERR",
-                    Some("HTTP 503 service unavailable".to_string()),
+                    Some("rate limit exceeded".to_string()),
                 ),
             ],
             || {
                 // All registry checks return 404 so the package is never found
                 let server = spawn_registry_server(
-                    std::collections::BTreeMap::from([(
-                        "/api/v1/crates/demo/0.1.0".to_string(),
-                        vec![
-                            (404, "{}".to_string()),
-                            (404, "{}".to_string()),
-                            (404, "{}".to_string()),
-                            (404, "{}".to_string()),
-                        ],
-                    )]),
-                    4,
+                    std::collections::BTreeMap::from([
+                        (
+                            "/api/v1/crates/demo/0.1.0".to_string(),
+                            vec![
+                                (404, "{}".to_string()),
+                                (404, "{}".to_string()),
+                                (404, "{}".to_string()),
+                                (404, "{}".to_string()),
+                            ],
+                        ),
+                        (
+                            "/api/v1/crates/demo".to_string(),
+                            vec![(200, "{}".to_string())],
+                        ),
+                    ]),
+                    5,
                 );
                 let ws = planned_workspace(td.path(), server.base_url.clone());
                 let mut opts = default_opts(PathBuf::from(".shipper"));
@@ -4899,15 +5087,36 @@ mod tests {
                 assert_eq!(st.attempt_history[0].attempt, 1);
                 assert_eq!(
                     st.attempt_history[0].error_class,
-                    Some(ErrorClass::Retryable)
+                    Some(ErrorClass::Ambiguous)
                 );
                 assert!(st.attempt_history[0].next_attempt_at.is_some());
                 assert_eq!(st.attempt_history[1].attempt, 2);
                 assert_eq!(
                     st.attempt_history[1].error_class,
-                    Some(ErrorClass::Retryable)
+                    Some(ErrorClass::Ambiguous)
                 );
                 assert!(st.attempt_history[1].next_attempt_at.is_none());
+                let events =
+                    events::EventLog::read_from_file(&td.path().join(".shipper/events.jsonl"))
+                        .expect("read events");
+                assert!(
+                    events.all_events().iter().any(|event| matches!(
+                        event.event_type,
+                        EventType::RateLimitObserved { .. }
+                    ))
+                );
+                assert!(
+                    events
+                        .all_events()
+                        .iter()
+                        .any(|event| matches!(event.event_type, EventType::RetryScheduled { .. }))
+                );
+                assert!(
+                    events
+                        .all_events()
+                        .iter()
+                        .any(|event| matches!(event.event_type, EventType::PublishWaiting { .. }))
+                );
                 server.join();
             },
         );
@@ -5678,8 +5887,20 @@ mod tests {
         };
 
         let mut reporter = CollectingReporter::default();
-        let (ok, evidence) =
-            verify_published(&reg, "demo", "0.1.0", &config, &mut reporter).expect("verify");
+        let td = tempdir().expect("tempdir");
+        let events_path = td.path().join("events.jsonl");
+        let mut event_log = events::EventLog::new();
+        let (ok, evidence) = verify_published(
+            &reg,
+            "demo",
+            "0.1.0",
+            &config,
+            &mut reporter,
+            &mut event_log,
+            &events_path,
+            "demo@0.1.0",
+        )
+        .expect("verify");
         assert!(
             ok,
             "disabled readiness with 200 response should return true"

--- a/crates/shipper-core/src/engine/parallel/publish.rs
+++ b/crates/shipper-core/src/engine/parallel/publish.rs
@@ -17,7 +17,7 @@ use crate::ops::cargo;
 use crate::plan::PlannedWorkspace;
 use crate::runtime::execution::{
     append_attempt_detail, backoff_delay, classify_cargo_failure, pkg_key, registry_aware_backoff,
-    retry_next_attempt_at, update_state_locked,
+    retry_after_delay, retry_next_attempt_at, update_state_locked,
 };
 use crate::state::events;
 use crate::state::execution_state as state;
@@ -29,7 +29,7 @@ use shipper_types::{
 };
 
 use super::policy::policy_effects;
-use super::readiness::is_version_visible_with_backoff;
+use super::readiness::is_version_visible_with_backoff_and_events;
 use super::reconcile::reconcile_ambiguous_upload;
 use super::webhook::{WebhookEvent, maybe_send_event};
 use super::{Reporter, SendReporter, drain_retry_waits};
@@ -108,7 +108,30 @@ fn record_retry_backoff(
     reason: &ErrorClass,
     message: &str,
 ) {
-    let mut log = event_log.lock().unwrap();
+    let Ok(mut log) = event_log.lock() else {
+        return;
+    };
+    log.record(PublishEvent {
+        timestamp: Utc::now(),
+        event_type: EventType::RetryScheduled {
+            attempt,
+            max_attempts,
+            delay_ms: delay.as_millis() as u64,
+            next_attempt_at,
+            reason: reason.clone(),
+            message: message.to_string(),
+        },
+        package: pkg_label.to_string(),
+    });
+    log.record(PublishEvent {
+        timestamp: Utc::now(),
+        event_type: EventType::PublishWaiting {
+            reason: "retry backoff".to_string(),
+            delay_ms: delay.as_millis() as u64,
+            until: next_attempt_at,
+        },
+        package: pkg_label.to_string(),
+    });
     log.record(PublishEvent {
         timestamp: Utc::now(),
         event_type: EventType::RetryBackoffStarted {
@@ -123,6 +146,44 @@ fn record_retry_backoff(
     });
     let _ = log.write_to_file(events_path);
     log.clear();
+}
+
+fn record_rate_limit_observed(
+    event_log: &Arc<Mutex<events::EventLog>>,
+    events_path: &Path,
+    pkg_label: &str,
+    is_new_crate: bool,
+    retry_after: Option<std::time::Duration>,
+    message: &str,
+) {
+    let Ok(mut log) = event_log.lock() else {
+        return;
+    };
+    log.record(PublishEvent {
+        timestamp: Utc::now(),
+        event_type: EventType::RateLimitObserved {
+            is_new_crate,
+            retry_after_ms: retry_after.map(|delay| delay.as_millis() as u64),
+            message: message.to_string(),
+        },
+        package: pkg_label.to_string(),
+    });
+    let _ = log.write_to_file(events_path);
+    log.clear();
+}
+
+fn record_readiness_event(
+    event_log: &Arc<Mutex<events::EventLog>>,
+    events_path: &Path,
+    event: PublishEvent,
+) -> Result<()> {
+    let mut log = event_log
+        .lock()
+        .map_err(|_| anyhow::anyhow!("event log lock poisoned while recording readiness event"))?;
+    log.record(event);
+    log.write_to_file(events_path)?;
+    log.clear();
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -762,6 +823,16 @@ pub(super) fn publish_package(
                                 false
                             };
                         if attempt < opts.max_attempts {
+                            if crate::runtime::execution::looks_like_rate_limit(&failure_output) {
+                                record_rate_limit_observed(
+                                    event_log,
+                                    events_path,
+                                    &pkg_label,
+                                    is_new_crate,
+                                    retry_after_delay(&failure_output),
+                                    &msg,
+                                );
+                            }
                             let delay = registry_aware_backoff(
                                 opts.base_delay,
                                 opts.max_delay,
@@ -813,13 +884,48 @@ pub(super) fn publish_package(
             p.name, p.version
         ));
 
-        let verify_result =
-            is_version_visible_with_backoff(reg, &p.name, &p.version, &readiness_config);
+        let readiness_started_at = Instant::now();
+        if let Err(e) = record_readiness_event(
+            event_log,
+            events_path,
+            PublishEvent {
+                timestamp: Utc::now(),
+                event_type: EventType::ReadinessStarted {
+                    method: readiness_config.method,
+                },
+                package: pkg_label.clone(),
+            },
+        ) {
+            return PackagePublishResult { result: Err(e) };
+        }
+        let mut emit_readiness_event =
+            |event| record_readiness_event(event_log, events_path, event);
+        let verify_result = is_version_visible_with_backoff_and_events(
+            reg,
+            &p.name,
+            &p.version,
+            &readiness_config,
+            &mut emit_readiness_event,
+        );
 
         match verify_result {
             Ok((visible, checks)) => {
                 readiness_evidence = checks;
                 if visible {
+                    if let Err(e) = record_readiness_event(
+                        event_log,
+                        events_path,
+                        PublishEvent {
+                            timestamp: Utc::now(),
+                            event_type: EventType::ReadinessComplete {
+                                duration_ms: readiness_started_at.elapsed().as_millis() as u64,
+                                attempts: readiness_evidence.len() as u32,
+                            },
+                            package: pkg_label.clone(),
+                        },
+                    ) {
+                        return PackagePublishResult { result: Err(e) };
+                    }
                     {
                         let mut state = st.lock().unwrap();
                         update_state_locked(&mut state, &key, PackageState::Published);
@@ -854,6 +960,19 @@ pub(super) fn publish_package(
 
                     break;
                 } else {
+                    if let Err(e) = record_readiness_event(
+                        event_log,
+                        events_path,
+                        PublishEvent {
+                            timestamp: Utc::now(),
+                            event_type: EventType::ReadinessTimeout {
+                                max_wait_ms: readiness_config.max_total_wait.as_millis() as u64,
+                            },
+                            package: pkg_label.clone(),
+                        },
+                    ) {
+                        return PackagePublishResult { result: Err(e) };
+                    }
                     let message =
                         "published locally, but version not observed on registry within timeout";
                     last_err = Some((ErrorClass::Ambiguous, message.to_string()));

--- a/crates/shipper-core/src/engine/parallel/readiness.rs
+++ b/crates/shipper-core/src/engine/parallel/readiness.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use chrono::Utc;
 
 use shipper_registry::HttpRegistryClient as RegistryClient;
-use shipper_types::{ReadinessConfig, ReadinessEvidence, ReadinessMethod};
+use shipper_types::{EventType, PublishEvent, ReadinessConfig, ReadinessEvidence, ReadinessMethod};
 
 /// Check readiness visibility with exponential backoff and optional sparse-index fallback.
 pub(super) fn is_version_visible_with_backoff(
@@ -19,10 +19,22 @@ pub(super) fn is_version_visible_with_backoff(
     version: &str,
     config: &ReadinessConfig,
 ) -> Result<(bool, Vec<ReadinessEvidence>)> {
+    is_version_visible_with_backoff_and_events(reg, crate_name, version, config, &mut |_| Ok(()))
+}
+
+pub(super) fn is_version_visible_with_backoff_and_events(
+    reg: &RegistryClient,
+    crate_name: &str,
+    version: &str,
+    config: &ReadinessConfig,
+    emit_event: &mut dyn FnMut(PublishEvent) -> Result<()>,
+) -> Result<(bool, Vec<ReadinessEvidence>)> {
     let mut evidence = Vec::new();
+    let package = format!("{crate_name}@{version}");
 
     if !config.enabled {
         let visible = reg.version_exists(crate_name, version)?;
+        emit_event(readiness_poll_event(&package, 1, visible))?;
         evidence.push(ReadinessEvidence {
             attempt: 1,
             visible,
@@ -36,6 +48,11 @@ pub(super) fn is_version_visible_with_backoff(
     let mut attempt = 0u32;
 
     if config.initial_delay > Duration::ZERO {
+        emit_event(readiness_poll_scheduled_event(
+            &package,
+            1,
+            config.initial_delay,
+        ))?;
         thread::sleep(config.initial_delay);
     }
 
@@ -82,6 +99,7 @@ pub(super) fn is_version_visible_with_backoff(
             timestamp: Utc::now(),
             delay_before: jittered_delay,
         });
+        emit_event(readiness_poll_event(&package, attempt, visible))?;
 
         if visible {
             return Ok((true, evidence));
@@ -99,6 +117,11 @@ pub(super) fn is_version_visible_with_backoff(
         let jitter = 1.0 + (rand::random::<f64>() * 2.0 * jitter_range - jitter_range);
         let next_delay =
             Duration::from_millis((capped_delay.as_millis() as f64 * jitter).round() as u64);
+        emit_event(readiness_poll_scheduled_event(
+            &package,
+            attempt.saturating_add(1),
+            next_delay,
+        ))?;
         thread::sleep(next_delay);
     }
 }
@@ -122,6 +145,27 @@ fn is_version_visible_via_index(
     };
 
     Ok(shipper_sparse_index::contains_version(&content, version))
+}
+
+fn readiness_poll_event(package: &str, attempt: u32, visible: bool) -> PublishEvent {
+    PublishEvent {
+        timestamp: Utc::now(),
+        event_type: EventType::ReadinessPoll { attempt, visible },
+        package: package.to_string(),
+    }
+}
+
+fn readiness_poll_scheduled_event(package: &str, attempt: u32, delay: Duration) -> PublishEvent {
+    PublishEvent {
+        timestamp: Utc::now(),
+        event_type: EventType::ReadinessPollScheduled {
+            attempt,
+            delay_ms: delay.as_millis() as u64,
+            next_poll_at: Utc::now()
+                + chrono::Duration::from_std(delay).unwrap_or_else(|_| chrono::Duration::zero()),
+        },
+        package: package.to_string(),
+    }
 }
 
 #[cfg(test)]

--- a/crates/shipper-core/src/state/events/proptests.rs
+++ b/crates/shipper-core/src/state/events/proptests.rs
@@ -59,14 +59,43 @@ fn arb_event_type() -> impl Strategy<Value = EventType> {
         (arb_error_class(), ".*")
             .prop_map(|(class, message)| EventType::PackageFailed { class, message }),
         ".*".prop_map(|reason| EventType::PackageSkipped { reason }),
+        (".*", 0..u64::MAX).prop_map(|(reason, delay_ms)| EventType::PublishWaiting {
+            reason,
+            delay_ms,
+            until: Utc::now(),
+        }),
+        (any::<bool>(), prop::option::of(0..u64::MAX), ".*").prop_map(
+            |(is_new_crate, retry_after_ms, message)| EventType::RateLimitObserved {
+                is_new_crate,
+                retry_after_ms,
+                message,
+            },
+        ),
         arb_readiness_method().prop_map(|method| EventType::ReadinessStarted { method }),
         (1..100u32, any::<bool>())
             .prop_map(|(attempt, visible)| EventType::ReadinessPoll { attempt, visible }),
+        (1..100u32, 0..u64::MAX).prop_map(|(attempt, delay_ms)| {
+            EventType::ReadinessPollScheduled {
+                attempt,
+                delay_ms,
+                next_poll_at: Utc::now(),
+            }
+        }),
         (0..u64::MAX, 1..100u32).prop_map(|(d, a)| EventType::ReadinessComplete {
             duration_ms: d,
             attempts: a,
         }),
         (0..u64::MAX).prop_map(|d| EventType::ReadinessTimeout { max_wait_ms: d }),
+        (1..100u32, 1..100u32, 0..u64::MAX, arb_error_class(), ".*").prop_map(
+            |(attempt, max_attempts, delay_ms, reason, message)| EventType::RetryScheduled {
+                attempt,
+                max_attempts,
+                delay_ms,
+                next_attempt_at: Utc::now(),
+                reason,
+                message,
+            },
+        ),
         Just(EventType::PreflightStarted),
         (any::<bool>(), ".*").prop_map(|(passed, output)| {
             EventType::PreflightWorkspaceVerify { passed, output }

--- a/crates/shipper-core/src/state/events/snapshots/shipper_core__state__events__tests__publish_waiting_debug.snap
+++ b/crates/shipper-core/src/state/events/snapshots/shipper_core__state__events__tests__publish_waiting_debug.snap
@@ -1,0 +1,13 @@
+---
+source: crates/shipper-core/src/state/events/tests.rs
+expression: event
+---
+PublishEvent {
+    timestamp: 2025-01-15T12:00:00Z,
+    event_type: PublishWaiting {
+        reason: "retry backoff",
+        delay_ms: 10000,
+        until: 2025-01-15T12:00:00Z,
+    },
+    package: "my-crate@1.0.0",
+}

--- a/crates/shipper-core/src/state/events/snapshots/shipper_core__state__events__tests__rate_limit_observed_debug.snap
+++ b/crates/shipper-core/src/state/events/snapshots/shipper_core__state__events__tests__rate_limit_observed_debug.snap
@@ -1,0 +1,15 @@
+---
+source: crates/shipper-core/src/state/events/tests.rs
+expression: event
+---
+PublishEvent {
+    timestamp: 2025-01-15T12:00:00Z,
+    event_type: RateLimitObserved {
+        is_new_crate: true,
+        retry_after_ms: Some(
+            90000,
+        ),
+        message: "HTTP 429",
+    },
+    package: "my-crate@1.0.0",
+}

--- a/crates/shipper-core/src/state/events/snapshots/shipper_core__state__events__tests__readiness_poll_scheduled_debug.snap
+++ b/crates/shipper-core/src/state/events/snapshots/shipper_core__state__events__tests__readiness_poll_scheduled_debug.snap
@@ -1,0 +1,13 @@
+---
+source: crates/shipper-core/src/state/events/tests.rs
+expression: event
+---
+PublishEvent {
+    timestamp: 2025-01-15T12:00:00Z,
+    event_type: ReadinessPollScheduled {
+        attempt: 4,
+        delay_ms: 1500,
+        next_poll_at: 2025-01-15T12:00:00Z,
+    },
+    package: "my-crate@1.0.0",
+}

--- a/crates/shipper-core/src/state/events/snapshots/shipper_core__state__events__tests__retry_scheduled_debug.snap
+++ b/crates/shipper-core/src/state/events/snapshots/shipper_core__state__events__tests__retry_scheduled_debug.snap
@@ -1,0 +1,16 @@
+---
+source: crates/shipper-core/src/state/events/tests.rs
+expression: event
+---
+PublishEvent {
+    timestamp: 2025-01-15T12:00:00Z,
+    event_type: RetryScheduled {
+        attempt: 2,
+        max_attempts: 5,
+        delay_ms: 10000,
+        next_attempt_at: 2025-01-15T12:00:00Z,
+        reason: Retryable,
+        message: "HTTP 503",
+    },
+    package: "my-crate@1.0.0",
+}

--- a/crates/shipper-core/src/state/events/tests.rs
+++ b/crates/shipper-core/src/state/events/tests.rs
@@ -1467,6 +1467,127 @@ fn roundtrip_readiness_poll_preserves_all_fields() {
 }
 
 #[test]
+fn roundtrip_readiness_poll_scheduled_preserves_all_fields() {
+    let next_poll_at = DateTime::parse_from_rfc3339("2026-05-17T10:00:30Z")
+        .expect("timestamp")
+        .with_timezone(&Utc);
+    let event = fixed_event(
+        EventType::ReadinessPollScheduled {
+            attempt: 8,
+            delay_ms: 30_000,
+            next_poll_at,
+        },
+        "x@1.0.0",
+    );
+    let json = serde_json::to_string(&event).expect("serialize");
+    let parsed: PublishEvent = serde_json::from_str(&json).expect("deserialize");
+    match &parsed.event_type {
+        EventType::ReadinessPollScheduled {
+            attempt,
+            delay_ms,
+            next_poll_at: parsed_next_poll_at,
+        } => {
+            assert_eq!(*attempt, 8);
+            assert_eq!(*delay_ms, 30_000);
+            assert_eq!(*parsed_next_poll_at, next_poll_at);
+        }
+        other => panic!("wrong variant: {other:?}"),
+    }
+}
+
+#[test]
+fn roundtrip_retry_scheduled_preserves_all_fields() {
+    let next_attempt_at = DateTime::parse_from_rfc3339("2026-05-17T10:01:00Z")
+        .expect("timestamp")
+        .with_timezone(&Utc);
+    let event = fixed_event(
+        EventType::RetryScheduled {
+            attempt: 2,
+            max_attempts: 4,
+            delay_ms: 60_000,
+            next_attempt_at,
+            reason: ErrorClass::Retryable,
+            message: "rate limited".to_string(),
+        },
+        "x@1.0.0",
+    );
+    let json = serde_json::to_string(&event).expect("serialize");
+    let parsed: PublishEvent = serde_json::from_str(&json).expect("deserialize");
+    match &parsed.event_type {
+        EventType::RetryScheduled {
+            attempt,
+            max_attempts,
+            delay_ms,
+            next_attempt_at: parsed_next_attempt_at,
+            reason,
+            message,
+        } => {
+            assert_eq!(*attempt, 2);
+            assert_eq!(*max_attempts, 4);
+            assert_eq!(*delay_ms, 60_000);
+            assert_eq!(*parsed_next_attempt_at, next_attempt_at);
+            assert_eq!(*reason, ErrorClass::Retryable);
+            assert_eq!(message, "rate limited");
+        }
+        other => panic!("wrong variant: {other:?}"),
+    }
+}
+
+#[test]
+fn roundtrip_publish_waiting_and_rate_limit_preserve_fields() {
+    let until = DateTime::parse_from_rfc3339("2026-05-17T10:02:00Z")
+        .expect("timestamp")
+        .with_timezone(&Utc);
+    let waiting = fixed_event(
+        EventType::PublishWaiting {
+            reason: "retry backoff".to_string(),
+            delay_ms: 120_000,
+            until,
+        },
+        "x@1.0.0",
+    );
+    let parsed: PublishEvent =
+        serde_json::from_str(&serde_json::to_string(&waiting).expect("serialize"))
+            .expect("deserialize");
+    match &parsed.event_type {
+        EventType::PublishWaiting {
+            reason,
+            delay_ms,
+            until: parsed_until,
+        } => {
+            assert_eq!(reason, "retry backoff");
+            assert_eq!(*delay_ms, 120_000);
+            assert_eq!(*parsed_until, until);
+        }
+        other => panic!("wrong variant: {other:?}"),
+    }
+
+    let rate_limit = fixed_event(
+        EventType::RateLimitObserved {
+            is_new_crate: true,
+            retry_after_ms: Some(90_000),
+            message: "HTTP 429".to_string(),
+        },
+        "x@1.0.0",
+    );
+    let parsed: PublishEvent =
+        serde_json::from_str(&serde_json::to_string(&rate_limit).expect("serialize"))
+            .expect("deserialize");
+    match &parsed.event_type {
+        EventType::RateLimitObserved {
+            is_new_crate,
+            retry_after_ms,
+            message,
+        } => {
+            assert!(*is_new_crate);
+            assert_eq!(*retry_after_ms, Some(90_000));
+            assert_eq!(message, "HTTP 429");
+        }
+        other => panic!("wrong variant: {other:?}"),
+    }
+}
+
+#[test]
 fn roundtrip_readiness_timeout_preserves_all_fields() {
     let event = fixed_event(
         EventType::ReadinessTimeout {
@@ -1645,6 +1766,61 @@ fn snapshot_readiness_poll_debug() {
         "my-crate@1.0.0",
     );
     insta::assert_debug_snapshot!("readiness_poll_debug", event);
+}
+
+#[test]
+fn snapshot_readiness_poll_scheduled_debug() {
+    let event = fixed_event(
+        EventType::ReadinessPollScheduled {
+            attempt: 4,
+            delay_ms: 1500,
+            next_poll_at: fixed_time(),
+        },
+        "my-crate@1.0.0",
+    );
+    insta::assert_debug_snapshot!("readiness_poll_scheduled_debug", event);
+}
+
+#[test]
+fn snapshot_retry_scheduled_debug() {
+    let event = fixed_event(
+        EventType::RetryScheduled {
+            attempt: 2,
+            max_attempts: 5,
+            delay_ms: 10_000,
+            next_attempt_at: fixed_time(),
+            reason: ErrorClass::Retryable,
+            message: "HTTP 503".to_string(),
+        },
+        "my-crate@1.0.0",
+    );
+    insta::assert_debug_snapshot!("retry_scheduled_debug", event);
+}
+
+#[test]
+fn snapshot_publish_waiting_debug() {
+    let event = fixed_event(
+        EventType::PublishWaiting {
+            reason: "retry backoff".to_string(),
+            delay_ms: 10_000,
+            until: fixed_time(),
+        },
+        "my-crate@1.0.0",
+    );
+    insta::assert_debug_snapshot!("publish_waiting_debug", event);
+}
+
+#[test]
+fn snapshot_rate_limit_observed_debug() {
+    let event = fixed_event(
+        EventType::RateLimitObserved {
+            is_new_crate: true,
+            retry_after_ms: Some(90_000),
+            message: "HTTP 429".to_string(),
+        },
+        "my-crate@1.0.0",
+    );
+    insta::assert_debug_snapshot!("rate_limit_observed_debug", event);
 }
 
 #[test]

--- a/crates/shipper-registry/src/context.rs
+++ b/crates/shipper-registry/src/context.rs
@@ -1,11 +1,13 @@
 use anyhow::{Context, Result, bail};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use reqwest::StatusCode;
 use reqwest::blocking::Client;
 use serde::Deserialize;
 use std::time::{Duration, Instant};
 
-use shipper_types::{ReadinessConfig, ReadinessEvidence, ReadinessMethod, Registry};
+use shipper_types::{
+    EventType, PublishEvent, ReadinessConfig, ReadinessEvidence, ReadinessMethod, Registry,
+};
 
 #[derive(Debug, Clone)]
 pub struct RegistryClient {
@@ -248,11 +250,30 @@ impl RegistryClient {
         version: &str,
         config: &ReadinessConfig,
     ) -> Result<(bool, Vec<ReadinessEvidence>)> {
+        self.is_version_visible_with_backoff_and_events(
+            crate_name,
+            version,
+            config,
+            &mut |_| Ok(()),
+        )
+    }
+
+    /// Check if a version is visible with exponential backoff and jitter,
+    /// emitting scheduling events for callers that persist release timelines.
+    pub fn is_version_visible_with_backoff_and_events(
+        &self,
+        crate_name: &str,
+        version: &str,
+        config: &ReadinessConfig,
+        emit_event: &mut dyn FnMut(PublishEvent) -> Result<()>,
+    ) -> Result<(bool, Vec<ReadinessEvidence>)> {
         let mut evidence = Vec::new();
+        let package = format!("{crate_name}@{version}");
 
         if !config.enabled {
             // If readiness checks are disabled, just check once
             let visible = self.version_exists(crate_name, version)?;
+            emit_event(readiness_poll_event(&package, 1, visible))?;
             evidence.push(ReadinessEvidence {
                 attempt: 1,
                 visible,
@@ -267,6 +288,11 @@ impl RegistryClient {
 
         // Initial delay before first poll
         if config.initial_delay > Duration::ZERO {
+            emit_event(readiness_poll_scheduled_event(
+                &package,
+                1,
+                config.initial_delay,
+            ))?;
             std::thread::sleep(config.initial_delay);
         }
 
@@ -316,6 +342,7 @@ impl RegistryClient {
                 timestamp: Utc::now(),
                 delay_before: jittered_delay,
             });
+            emit_event(readiness_poll_event(&package, attempt, visible))?;
 
             if visible {
                 return Ok((true, evidence));
@@ -337,6 +364,11 @@ impl RegistryClient {
             let next_delay =
                 Duration::from_millis((capped_delay.as_millis() as f64 * jitter).round() as u64);
 
+            emit_event(readiness_poll_scheduled_event(
+                &package,
+                attempt.saturating_add(1),
+                next_delay,
+            ))?;
             std::thread::sleep(next_delay);
         }
     }
@@ -363,6 +395,30 @@ impl RegistryClient {
         let millis = (delay.as_millis() as f64 * jitter).round() as u128;
         Duration::from_millis(millis as u64)
     }
+}
+
+fn readiness_poll_event(package: &str, attempt: u32, visible: bool) -> PublishEvent {
+    PublishEvent {
+        timestamp: Utc::now(),
+        event_type: EventType::ReadinessPoll { attempt, visible },
+        package: package.to_string(),
+    }
+}
+
+fn readiness_poll_scheduled_event(package: &str, attempt: u32, delay: Duration) -> PublishEvent {
+    PublishEvent {
+        timestamp: Utc::now(),
+        event_type: EventType::ReadinessPollScheduled {
+            attempt,
+            delay_ms: delay.as_millis() as u64,
+            next_poll_at: next_instant(delay),
+        },
+        package: package.to_string(),
+    }
+}
+
+fn next_instant(delay: Duration) -> DateTime<Utc> {
+    Utc::now() + chrono::Duration::from_std(delay).unwrap_or_else(|_| chrono::Duration::zero())
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/shipper-types/src/lib.rs
+++ b/crates/shipper-types/src/lib.rs
@@ -1642,6 +1642,24 @@ pub enum EventType {
         reason: String,
     },
 
+    // Operator-wait visibility. Emitted before Shipper deliberately sleeps so
+    // status/watch consumers can tell the difference between "stuck" and
+    // "waiting on a known release-control condition".
+    PublishWaiting {
+        reason: String,
+        delay_ms: u64,
+        until: DateTime<Utc>,
+    },
+
+    // Registry pacing signal captured before retry scheduling. This is separate
+    // from RetryBackoffStarted because it records why the registry profile path
+    // was selected.
+    RateLimitObserved {
+        is_new_crate: bool,
+        retry_after_ms: Option<u64>,
+        message: String,
+    },
+
     // Reconciliation events (for `ErrorClass::Ambiguous` outcomes)
     PublishReconciling {
         method: ReadinessMethod,
@@ -1737,6 +1755,14 @@ pub enum EventType {
         reason: ErrorClass,
         message: String,
     },
+    RetryScheduled {
+        attempt: u32,
+        max_attempts: u32,
+        delay_ms: u64,
+        next_attempt_at: DateTime<Utc>,
+        reason: ErrorClass,
+        message: String,
+    },
 
     // Readiness events
     ReadinessStarted {
@@ -1745,6 +1771,11 @@ pub enum EventType {
     ReadinessPoll {
         attempt: u32,
         visible: bool,
+    },
+    ReadinessPollScheduled {
+        attempt: u32,
+        delay_ms: u64,
+        next_poll_at: DateTime<Utc>,
     },
     ReadinessComplete {
         duration_ms: u64,
@@ -4794,7 +4825,7 @@ mod tests {
 
             // --- EventType all variants roundtrip ---
             #[test]
-            fn event_type_all_variants_roundtrip(variant in 0u8..18) {
+            fn event_type_all_variants_roundtrip(variant in 0u8..22) {
                 let event_type = match variant {
                     0 => EventType::PlanCreated { plan_id: "id1".to_string(), package_count: 5 },
                     1 => EventType::ExecutionStarted,
@@ -4805,14 +4836,18 @@ mod tests {
                     6 => EventType::PackagePublished { duration_ms: 100 },
                     7 => EventType::PackageFailed { class: ErrorClass::Retryable, message: "err".to_string() },
                     8 => EventType::PackageSkipped { reason: "exists".to_string() },
-                    9 => EventType::ReadinessStarted { method: ReadinessMethod::Api },
-                    10 => EventType::ReadinessPoll { attempt: 1, visible: false },
-                    11 => EventType::ReadinessComplete { duration_ms: 500, attempts: 3 },
-                    12 => EventType::ReadinessTimeout { max_wait_ms: 60000 },
-                    13 => EventType::IndexReadinessStarted { crate_name: "a".to_string(), version: "1.0.0".to_string() },
-                    14 => EventType::IndexReadinessCheck { crate_name: "a".to_string(), version: "1.0.0".to_string(), found: true },
-                    15 => EventType::IndexReadinessComplete { crate_name: "a".to_string(), version: "1.0.0".to_string(), visible: true },
-                    16 => EventType::PreflightStarted,
+                    9 => EventType::PublishWaiting { reason: "retry backoff".to_string(), delay_ms: 1000, until: Utc::now() },
+                    10 => EventType::RateLimitObserved { is_new_crate: true, retry_after_ms: Some(30_000), message: "rate limited".to_string() },
+                    11 => EventType::ReadinessStarted { method: ReadinessMethod::Api },
+                    12 => EventType::ReadinessPoll { attempt: 1, visible: false },
+                    13 => EventType::ReadinessPollScheduled { attempt: 2, delay_ms: 1000, next_poll_at: Utc::now() },
+                    14 => EventType::ReadinessComplete { duration_ms: 500, attempts: 3 },
+                    15 => EventType::ReadinessTimeout { max_wait_ms: 60000 },
+                    16 => EventType::IndexReadinessStarted { crate_name: "a".to_string(), version: "1.0.0".to_string() },
+                    17 => EventType::IndexReadinessCheck { crate_name: "a".to_string(), version: "1.0.0".to_string(), found: true },
+                    18 => EventType::IndexReadinessComplete { crate_name: "a".to_string(), version: "1.0.0".to_string(), visible: true },
+                    19 => EventType::RetryScheduled { attempt: 1, max_attempts: 3, delay_ms: 1000, next_attempt_at: Utc::now(), reason: ErrorClass::Retryable, message: "retry".to_string() },
+                    20 => EventType::PreflightStarted,
                     _ => EventType::PreflightComplete { finishability: Finishability::Proven },
                 };
                 let json = serde_json::to_string(&event_type).unwrap();
@@ -5598,7 +5633,7 @@ mod tests {
 
             #[test]
             fn event_type_debug_never_panics(
-                variant in 0u8..18,
+                variant in 0u8..22,
                 msg in "\\PC{0,100}",
             ) {
                 let event_type = match variant {
@@ -5611,14 +5646,18 @@ mod tests {
                     6 => EventType::PackagePublished { duration_ms: 100 },
                     7 => EventType::PackageFailed { class: ErrorClass::Retryable, message: msg.clone() },
                     8 => EventType::PackageSkipped { reason: msg.clone() },
-                    9 => EventType::ReadinessStarted { method: ReadinessMethod::Api },
-                    10 => EventType::ReadinessPoll { attempt: 1, visible: false },
-                    11 => EventType::ReadinessComplete { duration_ms: 500, attempts: 3 },
-                    12 => EventType::ReadinessTimeout { max_wait_ms: 60000 },
-                    13 => EventType::IndexReadinessStarted { crate_name: msg.clone(), version: "1.0.0".to_string() },
-                    14 => EventType::IndexReadinessCheck { crate_name: msg.clone(), version: "1.0.0".to_string(), found: true },
-                    15 => EventType::IndexReadinessComplete { crate_name: msg.clone(), version: "1.0.0".to_string(), visible: true },
-                    16 => EventType::PreflightStarted,
+                    9 => EventType::PublishWaiting { reason: msg.clone(), delay_ms: 1000, until: Utc::now() },
+                    10 => EventType::RateLimitObserved { is_new_crate: true, retry_after_ms: Some(30_000), message: msg.clone() },
+                    11 => EventType::ReadinessStarted { method: ReadinessMethod::Api },
+                    12 => EventType::ReadinessPoll { attempt: 1, visible: false },
+                    13 => EventType::ReadinessPollScheduled { attempt: 2, delay_ms: 1000, next_poll_at: Utc::now() },
+                    14 => EventType::ReadinessComplete { duration_ms: 500, attempts: 3 },
+                    15 => EventType::ReadinessTimeout { max_wait_ms: 60000 },
+                    16 => EventType::IndexReadinessStarted { crate_name: msg.clone(), version: "1.0.0".to_string() },
+                    17 => EventType::IndexReadinessCheck { crate_name: msg.clone(), version: "1.0.0".to_string(), found: true },
+                    18 => EventType::IndexReadinessComplete { crate_name: msg.clone(), version: "1.0.0".to_string(), visible: true },
+                    19 => EventType::RetryScheduled { attempt: 1, max_attempts: 3, delay_ms: 1000, next_attempt_at: Utc::now(), reason: ErrorClass::Retryable, message: msg.clone() },
+                    20 => EventType::PreflightStarted,
                     _ => EventType::PreflightComplete { finishability: Finishability::Proven },
                 };
                 let debug = format!("{:?}", event_type);


### PR DESCRIPTION
## Summary
- add serialized publish wait, retry scheduled, rate-limit observed, and readiness poll scheduled events
- emit readiness start/poll/schedule/complete/timeout events from sequential and parallel visibility checks
- record retry scheduling and publish-wait evidence before backoff sleeps
- add event roundtrip, proptest, snapshot, and publish integration coverage

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo test -p shipper-core run_publish_state_attempts_counter_increments_on_retry --locked
- cargo clippy -p shipper-core --all-targets --locked -- -D warnings
- cargo xtask policy-report
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo test -p shipper-core --locked

## Notes
- Read-only subagent review found no issues in the current diff.