### PR TITLE
ci(release): add synthetic interruption resume rehearsal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,8 +345,14 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
-      - name: Run BDD tests
+      - name: Run publish BDD tests
         run: cargo test -p shipper-cli --test bdd_publish -- --nocapture
+
+      - name: Run resume BDD tests
+        run: cargo test -p shipper-cli --test bdd_resume -- --nocapture
+
+      - name: Run synthetic interruption resume rehearsal
+        run: cargo test -p shipper-cli --test e2e_rehearse -- --nocapture
 
   fuzz-smoke:
     name: Fuzz Smoke (PR)

--- a/docs/ci/test-evidence-lanes.md
+++ b/docs/ci/test-evidence-lanes.md
@@ -42,7 +42,7 @@ Every workflow under `.github/workflows/` and the lane each one occupies. The au
 | `msrv` | every PR | ~1 min | `cargo check --workspace` on the declared MSRV (1.95). |
 | `security` | every PR | ~1 min | `cargo audit` against the current advisory database. |
 | `docs` | every PR | ~1 min | `cargo doc --workspace --no-deps` clean under `-D warnings` (catches `rustdoc::invalid-html-tags` and friends). |
-| `bdd` | every PR | ~2 min | Cucumber scenarios for core publish/resume/reconcile flows. |
+| `bdd` | every PR | ~3 min | Publish and resume BDD scenarios plus the synthetic interruption-resume rehearsal (`e2e_rehearse`) that proves persisted state/events let `shipper resume` complete without duplicate publishes. |
 | `fuzz-smoke` | every PR except `schedule` | ~10 min | Six fuzz targets at low-energy: parser, encrypt, sanitizer, plan, state, events. |
 | `cross-platform` | every PR | ~2 min per leg | Multi-target builds: Linux x86_64/aarch64, Windows MSVC, macOS x86_64/aarch64. |
 | `release-build` | every PR | ~2 min | Release-profile build (LTO + strip) catches release-only mis-compiles before tag time. |
@@ -124,6 +124,14 @@ A maintainer should apply the label when:
 | `create-release` | Attaches platform binaries and `.shipper/` state to the GitHub Release. Runs only after `publish-crates-io` succeeds. |
 | `release-rehearse` | `workflow_dispatch mode=rehearse`: plan + preflight dry-run only. Useful before cutting a tag. |
 | `release-resume` | `workflow_dispatch mode=resume`: re-enters the publish train from a prior run's `shipper-state-final` artifact. Plan-ID match required. |
+
+The live recover rehearsal remains a manual release-candidate procedure because
+it intentionally publishes throwaway crates.io versions and then yanks them.
+The every-PR CI proof is the synthetic side: `ci.yml` runs
+`cargo test -p shipper-cli --test e2e_rehearse -- --nocapture`, which exercises
+a real `shipper publish` interruption/resume sequence against fake Cargo and a
+mock registry, then checks `state.json`, append-only `events.jsonl`, skipped
+published crates, and duplicate-publish invariants.
 
 ## Evidence Composition
 

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -45,7 +45,8 @@ make stronger claims than this file supports.
 | crates.io first-publish backoff profile | stable | `cargo test -p shipper-core runtime::execution --lib`; `cargo test -p shipper-core publish --lib`; `RegistryProfile::crates_io()` | engine |
 | Retry-After retry floor | stable | `cargo test -p shipper-core retry_after --lib`; `cargo test -p shipper-core publish --lib`; raw cargo stderr/stdout retry signal path | engine |
 | Preflight registry pacing estimate | stable | `cargo test -p shipper-core estimate_preflight_duration --lib`; `cargo test -p shipper-cli preflight`; `estimated_publish_duration` JSON field | engine/cli |
-| Resume under real interruption | planned | Future interruption rehearsal proof | engine |
+| Resume after synthetic publish interruption | stable/internal | `cargo test -p shipper-cli --test e2e_rehearse -- --nocapture`; CI `BDD Tests` job; proves persisted `state.json`/`events.jsonl` let `shipper resume` complete without duplicate publishes against fake Cargo and a mock registry | engine |
+| Resume under live runner interruption | planned | Manual release-candidate procedure in `docs/how-to/run-recover-rehearsal.md`; promote only after a completed crates.io rehearsal artifact proves cancelled-run artifact recovery and resume on a real runner | engine |
 | Trusted Publishing default | planned/advisory | Future Trusted Publishing spec and #96 | release/ci |
 
 ## Rules


### PR DESCRIPTION
## Summary
- make CI run publish BDD, resume BDD, and the synthetic interruption-resume rehearsal as explicit steps
- document that every-PR proof is synthetic while live crates.io recover rehearsal remains a manual release-candidate procedure
- split the support-tier claim into stable/internal synthetic proof and planned live runner interruption proof

## Validation
- cargo test -p shipper-cli --test e2e_rehearse -- --nocapture
- cargo test -p shipper-cli --test bdd_resume -- --nocapture
- cargo test -p shipper-cli --test bdd_publish -- --nocapture
- cargo fmt --all -- --check
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask check-workflow-surfaces --mode blocking-allowlist
- cargo xtask check-process-policy --mode blocking-allowlist
- cargo xtask check-network-policy --mode blocking-allowlist
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask policy-report
- cargo xtask package-surface
- git diff --check