### PR TITLE
feat(auth): validate trusted publishing prerequisites

### DIFF
--- a/crates/shipper-cli/src/doctor/checks/auth.rs
+++ b/crates/shipper-cli/src/doctor/checks/auth.rs
@@ -29,11 +29,124 @@ pub(in crate::doctor) fn check(ws: &plan::PlannedWorkspace) -> Result<Vec<Findin
             evidence: "auth_type: NONE FOUND (set CARGO_REGISTRY_TOKEN)".to_string(),
             try_next: vec![
                 "run `cargo login <token>` for local token auth",
-                "configure Trusted Publishing for GitHub Actions releases",
+                "configure Trusted Publishing with `permissions: id-token: write` and `rust-lang/crates-io-auth-action@v1`",
                 "rerun `shipper doctor` and `shipper preflight`",
             ],
             docs: Some("docs/how-to/run-in-github-actions.md"),
         });
+    } else if auth_type == Some(AuthType::TrustedPublishing) {
+        findings.push(Finding {
+            id: "trusted-publishing-token-not-minted",
+            severity: FindingLevel::Blocked,
+            status: FindingLevel::Blocked,
+            title: "Trusted Publishing token exchange is incomplete",
+            why_it_matters:
+                "GitHub OIDC request variables are present, but Cargo still needs a short-lived registry token before Shipper can prove ownership or publish",
+            evidence: trusted_publishing_evidence("trusted (detected)"),
+            try_next: vec![
+                "run `rust-lang/crates-io-auth-action@v1` before invoking Shipper",
+                "pass `steps.auth.outputs.token` to Shipper as `CARGO_REGISTRY_TOKEN`",
+                "rerun `shipper doctor` and `shipper preflight`",
+            ],
+            docs: Some("docs/how-to/run-in-github-actions.md"),
+        });
+    } else if auth_type == Some(AuthType::Unknown) {
+        findings.push(Finding {
+            id: "trusted-publishing-oidc-incomplete",
+            severity: FindingLevel::Blocked,
+            status: FindingLevel::Blocked,
+            title: "Trusted Publishing OIDC environment is incomplete",
+            why_it_matters:
+                "Trusted Publishing requires both GitHub OIDC request variables; a partial environment cannot mint a crates.io token",
+            evidence: trusted_publishing_evidence("unknown"),
+            try_next: vec![
+                "set `permissions: id-token: write` on the release job",
+                "run Shipper after the GitHub OIDC request URL and token are both available",
+                "or configure an explicit Cargo token fallback before rerunning preflight",
+            ],
+            docs: Some("docs/how-to/run-in-github-actions.md"),
+        });
     }
+    findings.extend(trusted_publishing_workflow_findings(ws));
     Ok(findings)
+}
+
+fn trusted_publishing_evidence(auth_label: &str) -> String {
+    format!(
+        "auth_type: {auth_label}; registry_token: {}; oidc_request_url: {}; oidc_request_token: {}",
+        presence(
+            std::env::var_os("CARGO_REGISTRY_TOKEN").is_some()
+                || std::env::vars_os().any(|(key, _)| {
+                    key.to_string_lossy().starts_with("CARGO_REGISTRIES_")
+                        && key.to_string_lossy().ends_with("_TOKEN")
+                })
+        ),
+        presence(std::env::var_os("ACTIONS_ID_TOKEN_REQUEST_URL").is_some()),
+        presence(std::env::var_os("ACTIONS_ID_TOKEN_REQUEST_TOKEN").is_some())
+    )
+}
+
+fn presence(is_set: bool) -> &'static str {
+    if is_set { "set" } else { "missing" }
+}
+
+fn trusted_publishing_workflow_findings(ws: &plan::PlannedWorkspace) -> Vec<Finding> {
+    let release_workflow = ws
+        .workspace_root
+        .join(".github")
+        .join("workflows")
+        .join("release.yml");
+    let Ok(content) = std::fs::read_to_string(&release_workflow) else {
+        return Vec::new();
+    };
+
+    let lower = content.to_ascii_lowercase();
+    let mentions_trusted_publishing =
+        lower.contains("crates-io-auth-action") || lower.contains("trusted publishing");
+    if !mentions_trusted_publishing {
+        return Vec::new();
+    }
+
+    let id_token_write = lower.contains("id-token: write");
+    let auth_action = lower.contains("rust-lang/crates-io-auth-action@v1");
+    let release_environment = lower.contains("environment: release");
+    let token_fallback = lower.contains("secrets.cargo_registry_token");
+
+    let missing = [
+        (!id_token_write).then_some("id-token: write"),
+        (!auth_action).then_some("rust-lang/crates-io-auth-action@v1"),
+        (!release_environment).then_some("environment: release"),
+        (!token_fallback).then_some("secrets.CARGO_REGISTRY_TOKEN fallback"),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>();
+
+    if missing.is_empty() {
+        return Vec::new();
+    }
+
+    vec![Finding {
+        id: "trusted-publishing-workflow-prerequisites",
+        severity: FindingLevel::Warning,
+        status: FindingLevel::Warning,
+        title: "Trusted Publishing workflow prerequisites need review",
+        why_it_matters: "Trusted Publishing depends on GitHub OIDC permission, the crates.io auth action, release-environment scope, and an explicit token fallback for incident recovery",
+        evidence: format!(
+            "release_workflow: {}; id_token_write: {}; crates_io_auth_action: {}; release_environment: {}; token_fallback: {}; missing: {}",
+            release_workflow.display(),
+            presence(id_token_write),
+            presence(auth_action),
+            presence(release_environment),
+            presence(token_fallback),
+            missing.join(", ")
+        ),
+        try_next: vec![
+            "add `permissions: id-token: write` to the release workflow",
+            "run `rust-lang/crates-io-auth-action@v1` before publish/preflight",
+            "bind publish/rehearsal jobs to the crates.io Trusted Publishing environment",
+            "keep `secrets.CARGO_REGISTRY_TOKEN` as an explicit fallback while rollout is advisory",
+        ],
+        docs: Some("docs/how-to/run-in-github-actions.md"),
+    }]
 }

--- a/crates/shipper-cli/src/doctor/findings.rs
+++ b/crates/shipper-cli/src/doctor/findings.rs
@@ -3,12 +3,14 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum FindingLevel {
     Blocked,
+    Warning,
 }
 
 impl FindingLevel {
     fn as_str(self) -> &'static str {
         match self {
             FindingLevel::Blocked => "blocked",
+            FindingLevel::Warning => "warning",
         }
     }
 }

--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -2258,13 +2258,8 @@ fn build_preflight_json_report(rep: &PreflightReport) -> PreflightJsonReport<'_>
                 .collect(),
         });
     }
-    if !rep.token_detected {
-        gaps.push(PreflightEvidenceItem {
-            id: "registry_auth_missing",
-            status: "not_proven",
-            summary: "No registry token or Trusted Publishing context was detected.".to_string(),
-            packages: Vec::new(),
-        });
+    if let Some(gap) = preflight_auth_gap(rep) {
+        gaps.push(gap);
     }
 
     let failed_checks = dry_run_failed
@@ -2358,8 +2353,8 @@ fn print_preflight_proof_explanation(rep: &PreflightReport, total: usize, dry_ru
             package_refs(ownership_unverified.iter().copied())
         );
     }
-    if !rep.token_detected {
-        println!("    - no registry token or Trusted Publishing context was detected.");
+    if let Some(gap) = preflight_auth_gap(rep) {
+        println!("    - {}", evidence_bullet(&gap.summary));
     }
 
     println!("  Failed checks:");
@@ -2388,6 +2383,59 @@ fn package_refs<'a>(packages: impl Iterator<Item = &'a PreflightPackage>) -> Str
 
 fn package_ref(package: &PreflightPackage) -> String {
     format!("{}@{}", package.name, package.version)
+}
+
+fn evidence_bullet(summary: &str) -> String {
+    let mut chars = summary.chars();
+    let Some(first) = chars.next() else {
+        return String::new();
+    };
+    let mut bullet = String::new();
+    bullet.push(first.to_ascii_lowercase());
+    bullet.extend(chars);
+    bullet
+}
+
+fn preflight_auth_gap(rep: &PreflightReport) -> Option<PreflightEvidenceItem> {
+    if rep.token_detected {
+        return None;
+    }
+
+    let has_trusted_context = rep.packages.iter().any(|package| {
+        matches!(
+            package.auth_type,
+            Some(shipper_core::types::AuthType::TrustedPublishing)
+        )
+    });
+    let has_partial_trusted_context = rep.packages.iter().any(|package| {
+        matches!(
+            package.auth_type,
+            Some(shipper_core::types::AuthType::Unknown)
+        )
+    });
+
+    if has_trusted_context {
+        Some(PreflightEvidenceItem {
+            id: "trusted_publishing_token_not_minted",
+            status: "not_proven",
+            summary: "Trusted Publishing OIDC context was detected, but no short-lived registry token was minted into Cargo auth before preflight.".to_string(),
+            packages: Vec::new(),
+        })
+    } else if has_partial_trusted_context {
+        Some(PreflightEvidenceItem {
+            id: "trusted_publishing_oidc_incomplete",
+            status: "not_proven",
+            summary: "Trusted Publishing OIDC environment is incomplete; both GitHub OIDC request variables are required before a registry token can be minted.".to_string(),
+            packages: Vec::new(),
+        })
+    } else {
+        Some(PreflightEvidenceItem {
+            id: "registry_auth_missing",
+            status: "not_proven",
+            summary: "No registry token or Trusted Publishing context was detected.".to_string(),
+            packages: Vec::new(),
+        })
+    }
 }
 
 fn package_noun(count: usize) -> &'static str {

--- a/crates/shipper-cli/tests/cli_e2e.rs
+++ b/crates/shipper-cli/tests/cli_e2e.rs
@@ -271,7 +271,7 @@ fn doctor_command_snapshot() {
         evidence: auth_type: NONE FOUND (set CARGO_REGISTRY_TOKEN)
         try next:
           - run `cargo login <token>` for local token auth
-          - configure Trusted Publishing for GitHub Actions releases
+          - configure Trusted Publishing with `permissions: id-token: write` and `rust-lang/crates-io-auth-action@v1`
           - rerun `shipper doctor` and `shipper preflight`
         docs: docs/how-to/run-in-github-actions.md
 
@@ -329,11 +329,130 @@ fn doctor_command_detects_trusted_publishing_auth() {
 
     Findings:
     ---------
-      none
+      [blocked] Trusted Publishing token exchange is incomplete (trusted-publishing-token-not-minted)
+        status: blocked
+        severity: blocked
+        why: GitHub OIDC request variables are present, but Cargo still needs a short-lived registry token before Shipper can prove ownership or publish
+        evidence: auth_type: trusted (detected); registry_token: missing; oidc_request_url: set; oidc_request_token: set
+        try next:
+          - run `rust-lang/crates-io-auth-action@v1` before invoking Shipper
+          - pass `steps.auth.outputs.token` to Shipper as `CARGO_REGISTRY_TOKEN`
+          - rerun `shipper doctor` and `shipper preflight`
+        docs: docs/how-to/run-in-github-actions.md
 
     Diagnostics complete.
     "
     );
+}
+
+#[test]
+fn doctor_command_reports_partial_trusted_publishing_env() {
+    let td = tempdir().expect("tempdir");
+    create_workspace(td.path());
+    fs::create_dir_all(td.path().join("cargo-home")).expect("mkdir");
+
+    let mut cmd = shipper_cmd();
+    let out = cmd
+        .arg("--manifest-path")
+        .arg(td.path().join("Cargo.toml"))
+        .arg("--state-dir")
+        .arg(".shipper")
+        .arg("doctor")
+        .env("CARGO_HOME", td.path().join("cargo-home"))
+        .env_remove("CARGO_REGISTRY_TOKEN")
+        .env_remove("CARGO_REGISTRIES_CRATES_IO_TOKEN")
+        .env(
+            "ACTIONS_ID_TOKEN_REQUEST_URL",
+            "https://example.invalid/oidc",
+        )
+        .env_remove("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(out).expect("utf8");
+    assert_snapshot!(
+        normalize_output(&stdout),
+        @"
+    Shipper Doctor - Diagnostics Report
+    ----------------------------------
+    workspace_root: <WORKSPACE_ROOT>
+    registry: crates-io (https://crates.io)
+    auth_type: unknown
+    state_dir: <STATE_DIR>
+    state_dir_exists: false (will be created)
+
+    cargo: <CARGO_VERSION>
+    git: <GIT_VERSION>
+
+    registry_reachable: true
+    index_base: https://index.crates.io
+
+    git_context: not a git repository
+
+    Findings:
+    ---------
+      [blocked] Trusted Publishing OIDC environment is incomplete (trusted-publishing-oidc-incomplete)
+        status: blocked
+        severity: blocked
+        why: Trusted Publishing requires both GitHub OIDC request variables; a partial environment cannot mint a crates.io token
+        evidence: auth_type: unknown; registry_token: missing; oidc_request_url: set; oidc_request_token: missing
+        try next:
+          - set `permissions: id-token: write` on the release job
+          - run Shipper after the GitHub OIDC request URL and token are both available
+          - or configure an explicit Cargo token fallback before rerunning preflight
+        docs: docs/how-to/run-in-github-actions.md
+
+    Diagnostics complete.
+    "
+    );
+}
+
+#[test]
+fn doctor_command_warns_on_incomplete_trusted_publishing_workflow() {
+    let td = tempdir().expect("tempdir");
+    create_workspace(td.path());
+    fs::create_dir_all(td.path().join("cargo-home")).expect("mkdir");
+    write_file(
+        &td.path().join(".github/workflows/release.yml"),
+        r#"
+name: Release
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rust-lang/crates-io-auth-action@v1
+      - run: shipper publish
+"#,
+    );
+
+    let mut cmd = shipper_cmd();
+    let out = cmd
+        .arg("--manifest-path")
+        .arg(td.path().join("Cargo.toml"))
+        .arg("--state-dir")
+        .arg(".shipper")
+        .arg("doctor")
+        .env("CARGO_HOME", td.path().join("cargo-home"))
+        .env("CARGO_REGISTRY_TOKEN", "secret-token")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(out).expect("utf8");
+    assert!(stdout.contains("auth_type: token (detected)"));
+    assert!(stdout.contains(
+        "Trusted Publishing workflow prerequisites need review (trusted-publishing-workflow-prerequisites)"
+    ));
+    assert!(stdout.contains("id_token_write: missing"));
+    assert!(stdout.contains("release_environment: missing"));
+    assert!(stdout.contains("token_fallback: missing"));
+    assert!(!stdout.contains("secret-token"));
 }
 
 #[test]
@@ -1252,6 +1371,56 @@ fn preflight_command_json_output_structure() {
     assert!(pkg.get("auth_type").is_some());
     assert!(pkg.get("ownership_verified").is_some());
     assert!(pkg.get("dry_run_passed").is_some());
+
+    registry.join();
+}
+
+#[test]
+fn preflight_json_reports_trusted_publishing_without_minted_token() {
+    let td = tempdir().expect("tempdir");
+    create_workspace(td.path());
+    fs::create_dir_all(td.path().join("cargo-home")).expect("mkdir");
+    let registry = spawn_registry(vec![404], 2);
+
+    let mut cmd = shipper_cmd();
+    let out = cmd
+        .arg("--manifest-path")
+        .arg(td.path().join("Cargo.toml"))
+        .arg("--api-base")
+        .arg(&registry.base_url)
+        .arg("--allow-dirty")
+        .arg("--skip-ownership-check")
+        .arg("preflight")
+        .arg("--format")
+        .arg("json")
+        .env("CARGO_HOME", td.path().join("cargo-home"))
+        .env_remove("CARGO_REGISTRY_TOKEN")
+        .env_remove("CARGO_REGISTRIES_CRATES_IO_TOKEN")
+        .env(
+            "ACTIONS_ID_TOKEN_REQUEST_URL",
+            "https://example.invalid/oidc",
+        )
+        .env("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "oidc-token")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(out).expect("utf8");
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(json["token_detected"], false);
+    assert_eq!(
+        json.pointer("/packages/0/auth_type")
+            .and_then(serde_json::Value::as_str),
+        Some("trusted_publishing")
+    );
+
+    let gaps = json["gaps"].as_array().expect("gaps array");
+    assert!(gaps.iter().any(|item| {
+        item["id"].as_str() == Some("trusted_publishing_token_not_minted")
+            && item["status"].as_str() == Some("not_proven")
+    }));
 
     registry.join();
 }

--- a/docs/how-to/run-in-github-actions.md
+++ b/docs/how-to/run-in-github-actions.md
@@ -147,6 +147,14 @@ jobs:
         run: shipper publish --policy safe
 ```
 
+`shipper doctor` validates the local workflow prerequisites it can see:
+`id-token: write`, `environment: release`,
+`rust-lang/crates-io-auth-action@v1`, and an explicit
+`secrets.CARGO_REGISTRY_TOKEN` fallback. It does not validate crates.io's
+per-crate Trusted Publishing registration; that remains a crates.io-side
+setup step and is proven by the token exchange plus preflight ownership
+checks for existing crates.
+
 **Troubleshooting**:
 
 - `id-token: write` missing → GitHub refuses the OIDC exchange → the

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -72,7 +72,7 @@ Also detects authentication type:
 | Auth Type | Meaning |
 |-----------|---------|
 | `Token` | A Cargo registry token was found |
-| `Trusted` | GitHub Actions OIDC trusted publishing environment detected |
+| `Trusted` | GitHub Actions OIDC trusted publishing environment detected; the workflow still must run `rust-lang/crates-io-auth-action@v1` and pass its output as `CARGO_REGISTRY_TOKEN` before ownership checks or live publish can use it |
 | `Unknown` | Partial OIDC environment (only one of `ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN` set) |
 | `-` | No authentication found |
 
@@ -398,7 +398,7 @@ Parse the JSON output to make decisions in your pipeline:
 | Production release | `--strict-ownership` |
 | Pre-release validation (no publish) | `shipper preflight --format json` |
 | Fast CI (skip verification) | `--policy fast` |
-| Trusted publishing (GitHub OIDC) | No extra flags needed — auth is auto-detected |
+| Trusted publishing (GitHub OIDC) | No Shipper flags needed after the workflow mints a short-lived token and exports it as `CARGO_REGISTRY_TOKEN`; run `shipper doctor` to validate the visible workflow prerequisites |
 | Dirty working tree in CI | `--allow-dirty` (e.g., when CI modifies files) |
 
 ### Event Log

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -47,6 +47,7 @@ make stronger claims than this file supports.
 | Preflight registry pacing estimate | stable | `cargo test -p shipper-core estimate_preflight_duration --lib`; `cargo test -p shipper-cli preflight`; `estimated_publish_duration` JSON field | engine/cli |
 | Resume after synthetic publish interruption | stable/internal | `cargo test -p shipper-cli --test e2e_rehearse -- --nocapture`; CI `BDD Tests` job; proves persisted `state.json`/`events.jsonl` let `shipper resume` complete without duplicate publishes against fake Cargo and a mock registry | engine |
 | Resume under live runner interruption | planned | Manual release-candidate procedure in `docs/how-to/run-recover-rehearsal.md`; promote only after a completed crates.io rehearsal artifact proves cancelled-run artifact recovery and resume on a real runner | engine |
+| Trusted Publishing prerequisite diagnostics | advisory | `shipper doctor`; `cargo test -p shipper-cli --test cli_e2e doctor_command_detects_trusted_publishing_auth`; validates visible GitHub OIDC env and release workflow prerequisites without claiming crates.io-side registration proof | release/ci |
 | Trusted Publishing default | planned/advisory | Future Trusted Publishing spec and #96 | release/ci |
 
 ## Rules


### PR DESCRIPTION
## Summary
- teach `shipper doctor` to distinguish missing auth, partial GitHub OIDC, and OIDC-present-without-minted-Cargo-token states
- add advisory release workflow prerequisite diagnostics for Trusted Publishing setup
- surface Trusted Publishing token-exchange gaps in preflight human/JSON evidence and document the crates.io registration limit

## Security / trust boundary
- validates only local env/workflow signals Shipper can observe
- records token/OIDC presence only; no token values are printed or asserted
- does not claim to validate crates.io-side Trusted Publishing registration

## Validation
- cargo fmt --all -- --check
- cargo test -p shipper-cli --test cli_e2e -- --nocapture
- cargo test -p shipper-cli --test bdd_doctor -- --nocapture
- cargo test -p shipper-cli --test bdd_preflight -- --nocapture
- cargo clippy -p shipper-cli --all-targets --locked -- -D warnings
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask policy-report
- cargo xtask package-surface
- git diff --check