### PR TITLE
feat(auth): warn on token fallback auth

### DIFF
--- a/crates/shipper-cli/src/doctor/checks/auth.rs
+++ b/crates/shipper-cli/src/doctor/checks/auth.rs
@@ -67,7 +67,7 @@ pub(in crate::doctor) fn check(ws: &plan::PlannedWorkspace) -> Result<Vec<Findin
             docs: Some("docs/how-to/run-in-github-actions.md"),
         });
     }
-    findings.extend(trusted_publishing_workflow_findings(ws));
+    findings.extend(trusted_publishing_workflow_findings(ws, auth_type));
     Ok(findings)
 }
 
@@ -90,7 +90,10 @@ fn presence(is_set: bool) -> &'static str {
     if is_set { "set" } else { "missing" }
 }
 
-fn trusted_publishing_workflow_findings(ws: &plan::PlannedWorkspace) -> Vec<Finding> {
+fn trusted_publishing_workflow_findings(
+    ws: &plan::PlannedWorkspace,
+    auth_type: Option<AuthType>,
+) -> Vec<Finding> {
     let release_workflow = ws
         .workspace_root
         .join(".github")
@@ -122,31 +125,52 @@ fn trusted_publishing_workflow_findings(ws: &plan::PlannedWorkspace) -> Vec<Find
     .flatten()
     .collect::<Vec<_>>();
 
-    if missing.is_empty() {
-        return Vec::new();
+    let mut findings = Vec::new();
+    if !missing.is_empty() {
+        findings.push(Finding {
+            id: "trusted-publishing-workflow-prerequisites",
+            severity: FindingLevel::Warning,
+            status: FindingLevel::Warning,
+            title: "Trusted Publishing workflow prerequisites need review",
+            why_it_matters: "Trusted Publishing depends on GitHub OIDC permission, the crates.io auth action, release-environment scope, and an explicit token fallback for incident recovery",
+            evidence: format!(
+                "release_workflow: {}; id_token_write: {}; crates_io_auth_action: {}; release_environment: {}; token_fallback: {}; missing: {}",
+                release_workflow.display(),
+                presence(id_token_write),
+                presence(auth_action),
+                presence(release_environment),
+                presence(token_fallback),
+                missing.join(", ")
+            ),
+            try_next: vec![
+                "add `permissions: id-token: write` to the release workflow",
+                "run `rust-lang/crates-io-auth-action@v1` before publish/preflight",
+                "bind publish/rehearsal jobs to the crates.io Trusted Publishing environment",
+                "keep `secrets.CARGO_REGISTRY_TOKEN` as an explicit fallback while rollout is advisory",
+            ],
+            docs: Some("docs/how-to/run-in-github-actions.md"),
+        });
     }
 
-    vec![Finding {
-        id: "trusted-publishing-workflow-prerequisites",
-        severity: FindingLevel::Warning,
-        status: FindingLevel::Warning,
-        title: "Trusted Publishing workflow prerequisites need review",
-        why_it_matters: "Trusted Publishing depends on GitHub OIDC permission, the crates.io auth action, release-environment scope, and an explicit token fallback for incident recovery",
-        evidence: format!(
-            "release_workflow: {}; id_token_write: {}; crates_io_auth_action: {}; release_environment: {}; token_fallback: {}; missing: {}",
-            release_workflow.display(),
-            presence(id_token_write),
-            presence(auth_action),
-            presence(release_environment),
-            presence(token_fallback),
-            missing.join(", ")
-        ),
-        try_next: vec![
-            "add `permissions: id-token: write` to the release workflow",
-            "run `rust-lang/crates-io-auth-action@v1` before publish/preflight",
-            "bind publish/rehearsal jobs to the crates.io Trusted Publishing environment",
-            "keep `secrets.CARGO_REGISTRY_TOKEN` as an explicit fallback while rollout is advisory",
-        ],
-        docs: Some("docs/how-to/run-in-github-actions.md"),
-    }]
+    if token_fallback && auth_type == Some(AuthType::Token) {
+        findings.push(Finding {
+            id: "trusted-publishing-token-fallback-configured",
+            severity: FindingLevel::Warning,
+            status: FindingLevel::Warning,
+            title: "Long-lived Cargo token fallback is configured",
+            why_it_matters: "Cargo receives both a minted Trusted Publishing token and a fallback secret through the same token interface, so operators need an explicit reminder that a long-lived token path still exists",
+            evidence: format!(
+                "release_workflow: {}; auth_type: token (detected); token_fallback: set; token_value: redacted",
+                release_workflow.display()
+            ),
+            try_next: vec![
+                "prefer the token minted by `rust-lang/crates-io-auth-action@v1`",
+                "treat `secrets.CARGO_REGISTRY_TOKEN` as incident fallback only",
+                "remove the fallback after Trusted Publishing registration and release rehearsal are proven",
+            ],
+            docs: Some("docs/how-to/run-in-github-actions.md"),
+        });
+    }
+
+    findings
 }

--- a/crates/shipper-cli/tests/cli_e2e.rs
+++ b/crates/shipper-cli/tests/cli_e2e.rs
@@ -456,6 +456,57 @@ jobs:
 }
 
 #[test]
+fn doctor_command_warns_when_token_fallback_is_configured() {
+    let td = tempdir().expect("tempdir");
+    create_workspace(td.path());
+    fs::create_dir_all(td.path().join("cargo-home")).expect("mkdir");
+    write_file(
+        &td.path().join(".github/workflows/release.yml"),
+        r#"
+name: Release
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - run: shipper publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN }}
+"#,
+    );
+
+    let mut cmd = shipper_cmd();
+    let out = cmd
+        .arg("--manifest-path")
+        .arg(td.path().join("Cargo.toml"))
+        .arg("--state-dir")
+        .arg(".shipper")
+        .arg("doctor")
+        .env("CARGO_HOME", td.path().join("cargo-home"))
+        .env("CARGO_REGISTRY_TOKEN", "secret-token")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(out).expect("utf8");
+    assert!(stdout.contains("auth_type: token (detected)"));
+    assert!(stdout.contains(
+        "Long-lived Cargo token fallback is configured (trusted-publishing-token-fallback-configured)"
+    ));
+    assert!(stdout.contains("token_value: redacted"));
+    assert!(!stdout.contains("secret-token"));
+}
+
+#[test]
 fn status_command_snapshot() {
     let td = tempdir().expect("tempdir");
     create_workspace(td.path());

--- a/crates/shipper-core/src/engine/mod.rs
+++ b/crates/shipper-core/src/engine/mod.rs
@@ -3033,6 +3033,123 @@ mod tests {
 
     #[test]
     #[serial]
+    fn run_preflight_warns_when_token_auth_overrides_oidc() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        let mut env_vars = fake_program_env_vars(&bin);
+        env_vars.extend([
+            ("SHIPPER_CARGO_EXIT", Some("0".to_string())),
+            (
+                "CARGO_HOME",
+                Some(td.path().to_str().expect("utf8").to_string()),
+            ),
+            ("CARGO_REGISTRY_TOKEN", Some("token-abc".to_string())),
+            ("CARGO_REGISTRIES_CRATES_IO_TOKEN", None::<String>),
+            (
+                "ACTIONS_ID_TOKEN_REQUEST_URL",
+                Some("https://example.invalid/oidc".to_string()),
+            ),
+            (
+                "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+                Some("oidc-token".to_string()),
+            ),
+        ]);
+        temp_env::with_vars(env_vars, || {
+            let server = spawn_registry_server(
+                std::collections::BTreeMap::from([
+                    (
+                        "/api/v1/crates/demo/0.1.0".to_string(),
+                        vec![(404, "{}".to_string())],
+                    ),
+                    (
+                        "/api/v1/crates/demo".to_string(),
+                        vec![(404, "{}".to_string())],
+                    ),
+                ]),
+                2,
+            );
+
+            let ws = planned_workspace(td.path(), server.base_url.clone());
+            let mut opts = default_opts(PathBuf::from(".shipper"));
+            opts.allow_dirty = true;
+            opts.skip_ownership_check = true;
+
+            let mut reporter = CollectingReporter::default();
+            let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
+
+            assert!(report.token_detected);
+            assert_eq!(report.packages[0].auth_type, Some(AuthType::Token));
+            let warnings = reporter.warns.join("\n");
+            assert!(
+                warnings.contains("Trusted Publishing OIDC environment is present"),
+                "warnings: {warnings}"
+            );
+            assert!(
+                !warnings.contains("token-abc"),
+                "warnings must not expose token values: {warnings}"
+            );
+            server.join();
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn run_preflight_does_not_warn_for_plain_token_auth() {
+        let td = tempdir().expect("tempdir");
+        let bin = td.path().join("bin");
+        write_fake_tools(&bin);
+        let mut env_vars = fake_program_env_vars(&bin);
+        env_vars.extend([
+            ("SHIPPER_CARGO_EXIT", Some("0".to_string())),
+            (
+                "CARGO_HOME",
+                Some(td.path().to_str().expect("utf8").to_string()),
+            ),
+            ("CARGO_REGISTRY_TOKEN", Some("token-abc".to_string())),
+            ("CARGO_REGISTRIES_CRATES_IO_TOKEN", None::<String>),
+            ("ACTIONS_ID_TOKEN_REQUEST_URL", None::<String>),
+            ("ACTIONS_ID_TOKEN_REQUEST_TOKEN", None::<String>),
+        ]);
+        temp_env::with_vars(env_vars, || {
+            let server = spawn_registry_server(
+                std::collections::BTreeMap::from([
+                    (
+                        "/api/v1/crates/demo/0.1.0".to_string(),
+                        vec![(404, "{}".to_string())],
+                    ),
+                    (
+                        "/api/v1/crates/demo".to_string(),
+                        vec![(404, "{}".to_string())],
+                    ),
+                ]),
+                2,
+            );
+
+            let ws = planned_workspace(td.path(), server.base_url.clone());
+            let mut opts = default_opts(PathBuf::from(".shipper"));
+            opts.allow_dirty = true;
+            opts.skip_ownership_check = true;
+
+            let mut reporter = CollectingReporter::default();
+            let report = run_preflight(&ws, &opts, &mut reporter).expect("preflight");
+
+            assert!(report.token_detected);
+            assert_eq!(report.packages[0].auth_type, Some(AuthType::Token));
+            assert!(
+                reporter
+                    .warns
+                    .iter()
+                    .all(|warning| !warning.contains("Trusted Publishing OIDC environment")),
+                "warnings: {:?}",
+                reporter.warns
+            );
+            server.join();
+        });
+    }
+
+    #[test]
+    #[serial]
     fn run_preflight_checks_git_when_allow_dirty_is_false() {
         let td = tempdir().expect("tempdir");
         let bin = td.path().join("bin");

--- a/crates/shipper-core/src/engine/preflight/mod.rs
+++ b/crates/shipper-core/src/engine/preflight/mod.rs
@@ -15,7 +15,9 @@ use crate::ops::auth;
 use crate::plan::PlannedWorkspace;
 use crate::runtime::execution::resolve_state_dir;
 use crate::state::events;
-use crate::types::{EventType, Finishability, PreflightReport, PublishEvent, RuntimeOptions};
+use crate::types::{
+    AuthType, EventType, Finishability, PreflightReport, PublishEvent, RuntimeOptions,
+};
 
 pub(in crate::engine) mod dry_run;
 pub(in crate::engine) mod duration;
@@ -80,6 +82,7 @@ pub(in crate::engine) fn run(
     let token = auth::resolve_token(&ws.plan.registry.name)?;
     let token_detected = token.as_ref().map(|s| !s.is_empty()).unwrap_or(false);
     let auth_type = auth::detect_auth_type_from_token(token.as_deref());
+    warn_if_token_auth_overrides_oidc(&ws.plan.registry.name, &auth_type, reporter);
 
     if effects.strict_ownership && !token_detected {
         event_log.record(PublishEvent {
@@ -153,6 +156,29 @@ pub(in crate::engine) fn run(
             None
         },
     })
+}
+
+fn warn_if_token_auth_overrides_oidc(
+    registry_name: &str,
+    auth_type: &Option<AuthType>,
+    reporter: &mut dyn Reporter,
+) {
+    let default_registry = matches!(
+        registry_name,
+        "" | auth::CRATES_IO_REGISTRY | "crates.io" | "crates_io"
+    );
+    if !default_registry || auth_type != &Some(AuthType::Token) {
+        return;
+    }
+
+    let oidc_url_present = std::env::var_os("ACTIONS_ID_TOKEN_REQUEST_URL").is_some();
+    let oidc_token_present = std::env::var_os("ACTIONS_ID_TOKEN_REQUEST_TOKEN").is_some();
+    if oidc_url_present || oidc_token_present {
+        reporter.warn(
+            "Trusted Publishing OIDC environment is present, but Shipper is using Cargo token auth. \
+             This is allowed as fallback; prefer the short-lived token minted by rust-lang/crates-io-auth-action@v1 for release runs.",
+        );
+    }
 }
 
 /// Resolve the event sink. In `fresh_audit` mode we never touch the

--- a/docs/how-to/run-in-github-actions.md
+++ b/docs/how-to/run-in-github-actions.md
@@ -155,6 +155,12 @@ per-crate Trusted Publishing registration; that remains a crates.io-side
 setup step and is proven by the token exchange plus preflight ownership
 checks for existing crates.
 
+When the workflow keeps `secrets.CARGO_REGISTRY_TOKEN` as a fallback,
+`shipper doctor` and `shipper preflight` keep that path visible with
+advisory warnings. Treat the fallback as incident recovery or bootstrap
+support; the normal release path should use the short-lived token produced
+by `rust-lang/crates-io-auth-action@v1`.
+
 **Troubleshooting**:
 
 - `id-token: write` missing → GitHub refuses the OIDC exchange → the

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -76,6 +76,11 @@ Also detects authentication type:
 | `Unknown` | Partial OIDC environment (only one of `ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN` set) |
 | `-` | No authentication found |
 
+If GitHub OIDC request variables are present but Cargo token auth wins,
+preflight emits an advisory warning. That state is allowed while long-lived
+token fallback is still configured, but release runs should prefer the
+short-lived token minted by `rust-lang/crates-io-auth-action@v1`.
+
 **Error on failure (strict mode only):**
 
 ```

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -48,6 +48,7 @@ make stronger claims than this file supports.
 | Resume after synthetic publish interruption | stable/internal | `cargo test -p shipper-cli --test e2e_rehearse -- --nocapture`; CI `BDD Tests` job; proves persisted `state.json`/`events.jsonl` let `shipper resume` complete without duplicate publishes against fake Cargo and a mock registry | engine |
 | Resume under live runner interruption | planned | Manual release-candidate procedure in `docs/how-to/run-recover-rehearsal.md`; promote only after a completed crates.io rehearsal artifact proves cancelled-run artifact recovery and resume on a real runner | engine |
 | Trusted Publishing prerequisite diagnostics | advisory | `shipper doctor`; `cargo test -p shipper-cli --test cli_e2e doctor_command_detects_trusted_publishing_auth`; validates visible GitHub OIDC env and release workflow prerequisites without claiming crates.io-side registration proof | release/ci |
+| Long-lived token fallback warnings | advisory | `cargo test -p shipper-core run_preflight_warns_when_token_auth_overrides_oidc --lib`; `cargo test -p shipper-cli --test cli_e2e doctor_command_warns_when_token_fallback_is_configured`; warns when Cargo token auth wins while Trusted Publishing signals or fallback config are present | release/ci |
 | Trusted Publishing default | planned/advisory | Future Trusted Publishing spec and #96 | release/ci |
 
 ## Rules


### PR DESCRIPTION
## Summary
- warn during preflight when GitHub OIDC signals are present but Cargo token auth wins
- show `shipper doctor` advisory when a Trusted Publishing workflow still carries a long-lived `CARGO_REGISTRY_TOKEN` fallback
- document that fallback warnings are advisory and that normal release runs should prefer the crates.io auth action's short-lived token

## Security / trust boundary
- warning logic never logs token values; tests assert the sample secret is absent
- behavior is advisory only: no finishability, publish, resume, or auth resolution changes
- Shipper still cannot distinguish a minted token from the fallback secret once either arrives as `CARGO_REGISTRY_TOKEN`

## Validation
- cargo fmt --all -- --check
- cargo test -p shipper-core run_preflight --lib -- --nocapture
- cargo test -p shipper-cli --test cli_e2e -- --nocapture
- cargo test -p shipper-cli --test bdd_doctor -- --nocapture
- cargo test -p shipper-cli --test bdd_preflight -- --nocapture
- cargo clippy -p shipper-core -p shipper-cli --all-targets --locked -- -D warnings
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask policy-report
- cargo xtask package-surface
- git diff --check