### PR TITLE
docs(spec): define JSON evidence contracts

### DIFF
--- a/docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md
+++ b/docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md
@@ -1,0 +1,189 @@
+# SHIPPER-SPEC-0004: JSON Evidence Contracts
+
+Status: proposed
+Owner: EffortlessMetrics
+Created: 2026-05-18
+Milestone: 0.4.0
+Linked proposal: docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md
+Linked specs: docs/specs/SHIPPER-SPEC-0001-source-of-truth-stack.md
+Linked ADRs: docs/adr/SHIPPER-ADR-0001-claims-become-checkable-state.md
+Linked plan: plans/0.4.0/json-evidence-contracts.md
+Linked issues: #109
+Linked PRs: #315, #316, #317
+Support-tier impact: docs/status/SUPPORT_TIERS.md
+Policy impact: policy ledgers remain the source of truth for exceptions and receipts
+Proof commands: cargo xtask check-doc-contracts --mode advisory; cargo xtask policy-report; cargo xtask package-surface; cargo fmt --all -- --check
+
+## Problem
+
+Shipper is becoming release-closure infrastructure. Humans can read the CLI
+output, but CI systems, internal developer portals, and agents need stable JSON
+evidence that is boring to parse and hard to misread.
+
+Recent work added versioned JSON identifiers to more command surfaces, but the
+repo still needs one behavior contract that defines how JSON evidence is named,
+changed, tested, and promoted. Without that contract, JSON output can drift by
+accident and support-tier claims can overstate what machine consumers may rely
+on.
+
+## Behavior Contract
+
+- Every stable command-owned JSON evidence object must include a top-level
+  `schema_version` string.
+- Schema versions use the form `shipper.<surface>.v<N>`, where `<surface>` is a
+  lowercase dot-separated command or artifact surface and `<N>` is a positive
+  integer.
+- Stable schema names are user-facing contracts. A stable schema name must not
+  be reused for breaking changes.
+- Additive fields are backward-compatible when existing fields keep their
+  meaning, type, and presence rules.
+- Removing a field, renaming a field, changing a field type, changing enum
+  spelling, or moving a field to a different object is a breaking change.
+- Breaking changes require a new schema version and a support-tier update that
+  names the proof command for the new version.
+- Human-readable output remains the default unless a command explicitly
+  documents JSON as its primary output.
+- JSON output must keep stdout machine-readable. Human progress, banners, and
+  warnings that are not part of the JSON object must go to stderr or to durable
+  artifacts.
+- JSON output must not invent proof. Unknown, unavailable, skipped, advisory,
+  or not-yet-proven facts must be represented explicitly instead of omitted in a
+  way that implies success.
+- Release artifacts under `.shipper/` are evidence surfaces, not repo-management
+  metadata. Repo-goal metadata remains under `.shipper-meta/`.
+
+## Stable JSON Surfaces
+
+These surfaces currently have support-tier proof and may be consumed by agents
+or CI under the compatibility rules above:
+
+| Surface | Schema or object | Proof source |
+|---|---|---|
+| `shipper plan --format json` | `shipper.plan.v1` | `cargo test -p shipper-cli --test bdd_workflow given_multi_crate_when_plan_json_then_valid_json_output` |
+| `shipper preflight --format json` | `shipper.preflight.v1` | `cargo test -p shipper-cli preflight` |
+| `shipper status --format json` | `shipper.status.v1` | `cargo test -p shipper-cli --test e2e_status status_json_format_produces_registry_report` |
+| `shipper status --watch --format json` | `shipper.status.watch.v1` | `cargo test -p shipper-cli status_watch_report_summarizes_state_and_scheduled_events --lib` |
+| `shipper doctor --format json` | `shipper.doctor.v1` | `cargo test -p shipper-cli --test e2e_doctor doctor_json_format_reports_diagnostics_without_token_value` |
+| `shipper publish --format json` | receipt JSON on stdout | `cargo test -p shipper-cli --test e2e_publish publish_json_format_writes_receipt_to_stdout` |
+| `shipper resume --format json` | receipt JSON on stdout | `cargo test -p shipper-cli --test bdd_resume given_pending_state_when_resume_json_then_stdout_is_receipt_json` |
+
+The publish and resume JSON rows are stable as receipt-output contracts. A
+future command-owned envelope such as `shipper.publish.v1` or
+`shipper.resume.v1` must be promoted separately after proof exists.
+
+## Advisory Or Planned JSON Surfaces
+
+- Reconciliation evidence under `.shipper/reconciliation.json` is a product
+  target for ambiguity proof. It must not be promoted beyond its implemented
+  evidence and tests.
+- Remediation plans under `.shipper/remediation-plan.json` are planned
+  recovery evidence. They must not be described as stable until receipt-driven
+  dry-run proof exists.
+- Release readiness summaries may link JSON artifacts, but the readiness
+  document remains a release artifact, not a schema registry.
+
+## Non-Goals
+
+- Adding new runtime JSON output.
+- Generating JSON Schema files for every command.
+- Replacing Rust snapshot or integration tests with schema-only validation.
+- Changing the receipt schema.
+- Changing human output.
+- Promoting publish or resume command envelopes before implementation proof
+  exists.
+
+## Required Evidence
+
+For this spec and plan:
+
+- `cargo xtask check-doc-contracts --mode advisory`
+- `cargo xtask policy-report`
+- `cargo xtask package-surface`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+For future stable JSON surfaces:
+
+- a focused test that parses the command output as JSON
+- assertions for `schema_version` when the surface is command-owned
+- assertions for the fields named in the support-tier proof claim
+- snapshot updates only when the serialized contract intentionally changes
+- support-tier entries that name the exact proof command
+
+## Acceptance Examples
+
+- Adding `estimated_publish_duration` to `shipper.preflight.v1` is compatible
+  when existing fields keep their meaning and tests cover the new field.
+- Renaming `schema_version` to `version` in `shipper.plan.v1` is invalid; it
+  requires a new schema version.
+- Printing a human "Publishing..." banner to stdout before JSON is invalid for
+  `--format json`; stdout must remain parseable as the documented JSON object.
+- A README claim that "publish JSON is versioned" is invalid until a
+  `shipper.publish.v1`-style command envelope exists and support tiers name its
+  proof command.
+- A command may emit receipt JSON without a command-owned `schema_version` only
+  if the support-tier row says the contract is receipt JSON, not a command
+  envelope.
+
+## Test Mapping
+
+Current proof is mapped through support tiers:
+
+- plan JSON: `given_multi_crate_when_plan_json_then_valid_json_output`
+- preflight JSON: preflight CLI tests
+- status JSON: `status_json_format_produces_registry_report`
+- status watch JSON: `status_watch_report_summarizes_state_and_scheduled_events`
+- doctor JSON: `doctor_json_format_reports_diagnostics_without_token_value`
+- publish JSON receipt stdout:
+  `publish_json_format_writes_receipt_to_stdout`
+- resume JSON receipt stdout:
+  `given_pending_state_when_resume_json_then_stdout_is_receipt_json`
+
+Future implementation PRs should add one focused proof command per promoted
+surface before support tiers change.
+
+## Implementation Mapping
+
+The rollout belongs in `plans/0.4.0/json-evidence-contracts.md`.
+
+Implementation PRs should stay narrow:
+
+- docs/spec and plan definition
+- active goal manifest update
+- one command surface per runtime PR
+- support-tier promotion only after proof exists
+- optional schema-file generation after command contracts are stable
+
+## CI Proof
+
+CI proof for JSON evidence contracts is initially indirect:
+
+- command tests parse JSON output
+- snapshots detect intentional serialized-output changes
+- doc-contract checks validate source-of-truth links
+- policy-report includes doc-contract status
+
+If JSON Schema files are added later, CI should validate examples against those
+schemas before any support-tier promotion depends on them.
+
+## Promotion Rule
+
+A JSON surface can be stable only when:
+
+- the behavior is implemented
+- stdout is parseable as documented JSON in `--format json`
+- the output has a top-level `schema_version` when command-owned
+- a proof command parses and asserts the contract
+- `docs/status/SUPPORT_TIERS.md` names that proof command
+
+Receipt JSON emitted by publish or resume remains a receipt contract until a
+command-owned envelope is implemented and promoted.
+
+## Open Questions
+
+- Should Shipper generate JSON Schema files for stable command-owned surfaces
+  after the command contracts settle?
+- Should publish and resume keep receipt JSON as their long-term stdout
+  contract, or wrap receipts in command-owned envelopes that link artifacts and
+  next actions?
+- Which artifacts should carry schema versions independently of command output?

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -5,7 +5,7 @@ Owner: EffortlessMetrics
 Created: 2026-05-13
 Milestone: 0.4.0
 Linked proposal: docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md
-Linked specs: docs/specs/SHIPPER-SPEC-0001-source-of-truth-stack.md
+Linked specs: docs/specs/SHIPPER-SPEC-0001-source-of-truth-stack.md; docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md
 Linked ADRs:
 Linked plan:
 Linked issues: #109, #195
@@ -36,6 +36,7 @@ make stronger claims than this file supports.
 | Unversioned `cargo install shipper` from crates.io | planned | Cargo requires `--version` while the public crate is prerelease-only; promote when a non-prerelease `shipper` version is published and smoke-tested | packaging/ux |
 | Manifest-level topological publish planning | stable | Planner regression tests; `shipper plan`; roadmap #109 | engine |
 | Plan JSON publish graph | stable | `cargo test -p shipper-cli --test bdd_workflow given_multi_crate_when_plan_json_then_valid_json_output`; `shipper plan --format json` emits `shipper.plan.v1` | cli/integrations |
+| JSON evidence compatibility contract | stable/internal | `docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md`; `plans/0.4.0/json-evidence-contracts.md`; `cargo xtask check-doc-contracts --mode advisory` | cli/integrations |
 | File-policy enforcement | stable/internal | `cargo xtask check-file-policy --mode blocking-allowlist`; `cargo xtask policy-report`; CI `Policy` job | release/ci |
 | Rust 1.95 / 0.4 policy floor | stable/internal | Workspace lints; `cargo xtask check-lint-policy`; `cargo clippy --workspace --all-targets --all-features -- -D warnings` | rust/lints |
 | No-panic production baseline | stable/internal | `cargo xtask no-panic check`; `policy/no-panic-baseline.json` | rust/lints |

--- a/plans/0.4.0/json-evidence-contracts.md
+++ b/plans/0.4.0/json-evidence-contracts.md
@@ -1,0 +1,219 @@
+# Plan: JSON Evidence Contracts
+
+Status: proposed
+Owner: EffortlessMetrics
+Created: 2026-05-18
+Milestone: 0.4.0
+Linked proposal: docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md
+Linked specs: docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md
+Linked ADRs: docs/adr/SHIPPER-ADR-0001-claims-become-checkable-state.md
+Linked plan: plans/0.4.0/source-of-truth-stack.md
+Linked issues: #109
+Linked PRs: #315, #316, #317
+Support-tier impact: docs/status/SUPPORT_TIERS.md
+Policy impact: no new policy exceptions
+Proof commands: cargo xtask check-doc-contracts --mode advisory; cargo xtask policy-report; cargo xtask package-surface; cargo fmt --all -- --check
+
+## End State
+
+Shipper's machine-readable release evidence has a documented compatibility
+contract:
+
+- stable command-owned JSON surfaces carry `shipper.<surface>.v<N>`
+  `schema_version` values
+- receipt JSON output is named honestly as receipt evidence until command
+  envelopes exist
+- support tiers name proof commands for each stable JSON claim
+- future runtime PRs promote one command surface at a time
+- agents can read the spec before changing JSON output
+
+## PR Sequence
+
+### PR 1 - JSON evidence contract spec
+
+Linked spec: docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md
+Blocks: PR 2
+Blocked by: #317
+
+#### Goal
+
+Define the naming, compatibility, proof, and support-tier rules for Shipper JSON
+evidence contracts.
+
+#### Production Delta
+
+No product runtime behavior change.
+
+#### Non-Goals
+
+New JSON output, schema-file generation, receipt schema changes, active-goal
+state, release proof, and product behavior changes.
+
+#### Acceptance
+
+- JSON evidence contract spec exists.
+- This plan exists and links to the spec.
+- Support tiers link JSON claims back to the spec without promoting new runtime
+  behavior.
+
+#### Proof Commands
+
+- `cargo xtask check-doc-contracts --mode advisory`
+- `cargo xtask policy-report`
+- `cargo xtask package-surface`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+#### Rollback
+
+Revert the spec, plan, and support-tier link if the compatibility policy is
+replaced before runtime work depends on it.
+
+### PR 2 - Active goal for release-closure evidence
+
+Linked spec: docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md
+Blocks: PR 3
+Blocked by: PR 1
+
+#### Goal
+
+Add `.shipper-meta/goals/active.toml` for the release-closure evidence lane so
+agents do not infer work from chat or stale issue text.
+
+#### Production Delta
+
+No product runtime behavior change.
+
+#### Non-Goals
+
+Runtime JSON output changes and release proof.
+
+#### Acceptance
+
+- Active goal TOML parses.
+- Work items link to this spec and the current plan.
+- `.shipper/` remains reserved for runtime release evidence.
+
+#### Proof Commands
+
+- TOML parse check for `.shipper-meta/goals/active.toml`
+- `cargo xtask check-doc-contracts --mode advisory`
+- `cargo xtask check-file-policy --mode blocking-allowlist`
+- `cargo xtask policy-report`
+- `git diff --check`
+
+#### Rollback
+
+Archive or revert the active goal if the lane changes.
+
+### PR 3 - Publish JSON command envelope
+
+Linked spec: docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md
+Blocks: PR 4
+Blocked by: PR 2
+
+#### Goal
+
+Decide and implement whether `shipper publish --format json` remains receipt
+JSON or gains a command-owned `shipper.publish.v1` envelope with artifact paths
+and next-action evidence.
+
+#### Production Delta
+
+CLI output contract change only.
+
+#### Non-Goals
+
+Engine publish behavior changes, registry behavior changes, and receipt schema
+changes unless explicitly required by the selected contract.
+
+#### Acceptance
+
+- stdout is parseable JSON.
+- tests assert the selected contract.
+- support tiers name the exact proof command.
+
+#### Proof Commands
+
+- focused `shipper publish --format json` CLI test
+- `cargo clippy -p shipper-cli --all-targets --locked -- -D warnings`
+- `cargo xtask policy-report`
+- `git diff --check`
+
+#### Rollback
+
+Restore the previous receipt-stdout contract and support-tier text if the
+envelope shape is rejected.
+
+### PR 4 - Resume JSON command envelope
+
+Linked spec: docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md
+Blocks: PR 5
+Blocked by: PR 3
+
+#### Goal
+
+Give `shipper resume --format json` a contract that answers whether resume is
+safe, which packages are complete, what remains, and which artifacts prove it.
+
+#### Production Delta
+
+CLI output contract change only.
+
+#### Non-Goals
+
+Resume engine behavior changes and interruption rehearsal.
+
+#### Acceptance
+
+- stdout is parseable JSON.
+- the output reports plan/state/event/receipt artifact paths.
+- tests assert safe-to-resume and package-state fields.
+- support tiers name the exact proof command.
+
+#### Proof Commands
+
+- focused `shipper resume --format json` CLI test
+- `cargo clippy -p shipper-cli --all-targets --locked -- -D warnings`
+- `cargo xtask policy-report`
+- `git diff --check`
+
+#### Rollback
+
+Restore the previous receipt-stdout contract and support-tier text if the
+envelope shape is rejected.
+
+### PR 5 - Schema-file validation, if needed
+
+Linked spec: docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md
+Blocks:
+Blocked by: PR 3, PR 4
+
+#### Goal
+
+Add generated or hand-maintained JSON Schema files only after the command
+contracts settle enough to justify schema validation.
+
+#### Production Delta
+
+Tooling and CI validation only.
+
+#### Non-Goals
+
+New command output.
+
+#### Acceptance
+
+- examples validate against schemas
+- CI checks schema/examples
+- support tiers name schema validation only for surfaces it actually proves
+
+#### Proof Commands
+
+- future schema validation command
+- `cargo xtask policy-report`
+- `git diff --check`
+
+#### Rollback
+
+Remove schema validation if it creates churn before command contracts settle.


### PR DESCRIPTION
## Summary
- add SHIPPER-SPEC-0004 for JSON evidence naming, compatibility, proof, and promotion rules
- add the 0.4.0 JSON evidence contract rollout plan
- link support tiers to the JSON evidence compatibility contract without promoting new runtime behavior

## Validation
- cargo fmt --all -- --check
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask policy-report
- cargo xtask package-surface
- git diff --check