### PR TITLE
plans: set active source-of-truth goal

### DIFF
--- a/.shipper-meta/goals/active.toml
+++ b/.shipper-meta/goals/active.toml
@@ -1,36 +1,99 @@
-id = "shipper-reconcile-registry-truth"
-title = "Registry-truth reconciliation for ambiguous publish outcomes"
-status = "complete"
+id = "shipper-source-of-truth-stack"
+title = "Source-of-truth stack and doc-contract enforcement"
+status = "active"
 owner = "EffortlessMetrics"
-created = "2026-05-13"
+created = "2026-05-18"
 
 objective = """
-Close Reconcile from the source-of-truth stack: ambiguous cargo publish outcomes
-must reconcile against registry truth before retrying or resuming, and the
-support-tier claim must match implementation proof.
+Make Shipper's proposals, specs, ADRs, implementation plans, active goals,
+support tiers, policy reports, and release artifacts link into an executable
+source-of-truth system that maintainers and agents can follow without stale
+issue archaeology.
 """
 
 end_state = [
-  "Ambiguous publish outcomes resolve to Published, NotPublished, or StillUnknown.",
-  "Registry evidence is persisted in events and execution state.",
-  "Resume honors persisted reconciliation outcomes.",
-  "StillUnknown stops before blind retry and requires operator action.",
-  "Support-tier and product claims are promoted only after proof exists.",
+  "The active goal points to the current accepted spec and plan.",
+  "Doc-contract checks validate IDs, headers, statuses, and links.",
+  "Policy-report includes doc-contract status.",
+  "CI runs doc-contract checks in advisory mode and uploads reports.",
+  "Release-readiness proof can be executed from spec and plan, not issue prose.",
 ]
 
 [[work_item]]
-id = "reconcile-claim-proof"
-status = "complete"
-proposal = "docs/proposals/SHIPPER-PROP-0002-registry-truth-and-reconciliation.md"
-spec = "docs/specs/SHIPPER-SPEC-0003-registry-reconciliation.md"
-plan = "plans/reconcile/implementation-plan.md"
-issue = "102"
+id = "active-goal-refresh"
+status = "active"
+proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
+spec = "docs/specs/SHIPPER-SPEC-0001-source-of-truth-stack.md"
+plan = "plans/0.4.0/source-of-truth-stack.md"
+issue = "109"
 commands = [
+  "python -c \"import pathlib,tomllib; tomllib.loads(pathlib.Path('.shipper-meta/goals/active.toml').read_text()); print('active goal TOML parses')\"",
+  "cargo xtask check-file-policy --mode blocking-allowlist",
+  "cargo xtask policy-report",
   "cargo fmt --all -- --check",
-  "cargo test -p shipper-types --locked",
-  "cargo test -p shipper-core reconcile --lib --locked",
-  "cargo test -p shipper-core state --lib --locked",
-  "cargo test -p shipper-cli --test bdd_publish --locked",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "source-of-truth-status-normalization"
+status = "ready"
+proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
+spec = "docs/specs/SHIPPER-SPEC-0001-source-of-truth-stack.md"
+plan = "plans/0.4.0/source-of-truth-stack.md"
+issue = "109"
+commands = [
+  "cargo xtask check-doc-contracts --mode advisory",
+  "cargo xtask check-file-policy --mode blocking-allowlist",
+  "cargo xtask policy-report",
+  "cargo fmt --all -- --check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "release-readiness-proof-plan"
+status = "ready"
+proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
+spec = "docs/specs/SHIPPER-SPEC-0002-release-readiness-proof.md"
+plan = "plans/0.4.0/release-readiness-proof.md"
+issue = "195"
+commands = [
   "cargo xtask check-doc-contracts --mode advisory",
   "cargo xtask policy-report",
+  "cargo fmt --all -- --check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "release-readiness-artifact-skeleton"
+status = "planned"
+proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
+spec = "docs/specs/SHIPPER-SPEC-0002-release-readiness-proof.md"
+plan = "plans/0.4.0/release-readiness-proof.md"
+issue = "195"
+commands = [
+  "cargo xtask check-doc-contracts --mode advisory",
+  "cargo xtask policy-report",
+  "cargo fmt --all -- --check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "release-readiness-proof-execution"
+status = "planned"
+proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
+spec = "docs/specs/SHIPPER-SPEC-0002-release-readiness-proof.md"
+plan = "plans/0.4.0/release-readiness-proof.md"
+issue = "195"
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo clippy --workspace --all-targets --all-features -- -D warnings",
+  "cargo test --workspace --all-features",
+  "cargo test --workspace --doc",
+  "cargo check --workspace",
+  "cargo audit",
+  "cargo doc --workspace --no-deps --document-private-items",
+  "cargo test -p shipper-cli --test bdd_publish",
+  "cargo xtask check-doc-contracts --mode advisory",
+  "cargo xtask policy-report",
+  "cargo run -p shipper -- plan",
 ]

--- a/.shipper-meta/goals/archive/shipper-reconcile-registry-truth.toml
+++ b/.shipper-meta/goals/archive/shipper-reconcile-registry-truth.toml
@@ -1,0 +1,36 @@
+id = "shipper-reconcile-registry-truth"
+title = "Registry-truth reconciliation for ambiguous publish outcomes"
+status = "complete"
+owner = "EffortlessMetrics"
+created = "2026-05-13"
+
+objective = """
+Close Reconcile from the source-of-truth stack: ambiguous cargo publish outcomes
+must reconcile against registry truth before retrying or resuming, and the
+support-tier claim must match implementation proof.
+"""
+
+end_state = [
+  "Ambiguous publish outcomes resolve to Published, NotPublished, or StillUnknown.",
+  "Registry evidence is persisted in events and execution state.",
+  "Resume honors persisted reconciliation outcomes.",
+  "StillUnknown stops before blind retry and requires operator action.",
+  "Support-tier and product claims are promoted only after proof exists.",
+]
+
+[[work_item]]
+id = "reconcile-claim-proof"
+status = "complete"
+proposal = "docs/proposals/SHIPPER-PROP-0002-registry-truth-and-reconciliation.md"
+spec = "docs/specs/SHIPPER-SPEC-0003-registry-reconciliation.md"
+plan = "plans/reconcile/implementation-plan.md"
+issue = "102"
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test -p shipper-types --locked",
+  "cargo test -p shipper-core reconcile --lib --locked",
+  "cargo test -p shipper-core state --lib --locked",
+  "cargo test -p shipper-cli --test bdd_publish --locked",
+  "cargo xtask check-doc-contracts --mode advisory",
+  "cargo xtask policy-report",
+]

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -349,12 +349,12 @@ created = "2026-05-13"
 review_after = "2026-08-13"
 
 [[glob]]
-pattern = ".shipper-meta/goals/*.toml"
+pattern = ".shipper-meta/goals/**/*.toml"
 kind = "agent_goal_manifest"
 surface = "tooling"
 classification = "config"
 owner = "agent-maintainers"
-reason = "Machine-readable active goal manifests and templates for Codex/Droid execution state. Kept outside `.shipper/` so runtime state remains separate from repo-management state."
+reason = "Machine-readable active goal manifests, templates, and archived goal manifests for Codex/Droid execution state. Kept outside `.shipper/` so runtime state remains separate from repo-management state."
 covered_by = ["manual review", "future: cargo xtask check-doc-contracts"]
 created = "2026-05-13"
 review_after = "2026-08-13"


### PR DESCRIPTION
## Summary
- replace the completed Reconcile active goal with the source-of-truth stack completion lane
- archive the completed Reconcile manifest under .shipper-meta/goals/archive
- extend the goal-manifest file-policy receipt to cover archived TOML manifests

## Validation
- python TOML parse check for .shipper-meta/goals/active.toml
- python TOML parse check for .shipper-meta/goals/archive/shipper-reconcile-registry-truth.toml
- cargo fmt --all -- --check
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask policy-report
- git diff --check