### PR TITLE
plans: close JSON evidence contract active goal

### DIFF
--- a/.shipper-meta/goals/active.toml
+++ b/.shipper-meta/goals/active.toml
@@ -1,8 +1,9 @@
 id = "shipper-json-evidence-contracts"
 title = "JSON evidence contracts and release-closure output"
-status = "active"
+status = "complete"
 owner = "EffortlessMetrics"
 created = "2026-05-18"
+completed = "2026-05-18"
 
 objective = """
 Make Shipper's machine-readable release evidence contract-driven: stable JSON


### PR DESCRIPTION
## Summary
- mark the JSON evidence contracts active goal complete now that spec, publish envelope, and resume envelope work are landed
- record the completion date while leaving schema-file validation as a planned/deferred follow-up

## Validation
- python TOML parse for .shipper-meta/goals/active.toml
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask policy-report
- cargo fmt --all -- --check
- git diff --check