### PR TITLE
docs(spec): define release operator visibility lane

### DIFF
--- a/.shipper-meta/goals/active.toml
+++ b/.shipper-meta/goals/active.toml
@@ -1,79 +1,92 @@
-id = "shipper-json-evidence-contracts"
-title = "JSON evidence contracts and release-closure output"
-status = "complete"
+id = "shipper-release-operator-visibility"
+title = "Release operator visibility and survive proof"
+status = "active"
 owner = "EffortlessMetrics"
 created = "2026-05-18"
-completed = "2026-05-18"
 
 objective = """
-Make Shipper's machine-readable release evidence contract-driven: stable JSON
-surfaces name schema versions or honest receipt contracts, publish and resume
-envelope decisions are explicit, and support tiers link each claim to proof
-commands.
+Use Shipper's existing attempt-history, wait/readiness-event, and status/watch
+foundations to close the remaining release black-box recorder gaps: event-follow
+tail safety, event/state drift checks, state rebuild, and live interruption
+proof.
 """
 
 end_state = [
-  "JSON evidence contract spec and plan are accepted.",
-  "Publish JSON emits a proved command envelope.",
-  "Resume JSON emits a proved command envelope.",
-  "Support tiers describe only implemented JSON contracts.",
-  "Schema-file validation is deferred until command contracts justify it.",
+  "Inspect-events follow mode handles incomplete tail lines without emitting partial events.",
+  "Publish finalization detects material event/state/receipt drift.",
+  "State can be rebuilt from events for recovery or comparison.",
+  "Live-runner interruption proof exists before the support-tier claim is promoted.",
 ]
 
 [[work_item]]
-id = "json-evidence-contract-spec"
+id = "operator-visibility-source-of-truth"
 status = "complete"
 proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
-spec = "docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md"
-plan = "plans/0.4.0/json-evidence-contracts.md"
+spec = "docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md"
+plan = "plans/0.4.0/release-operator-visibility-and-survive-proof.md"
 issue = "109"
 commands = [
   "cargo xtask check-doc-contracts --mode advisory",
   "cargo xtask policy-report",
-  "cargo xtask package-surface",
+  "cargo xtask check-file-policy --mode blocking-allowlist",
   "cargo fmt --all -- --check",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "publish-json-command-envelope"
-status = "complete"
+id = "inspect-events-follow-incomplete-tail"
+status = "active"
 proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
-spec = "docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md"
-plan = "plans/0.4.0/json-evidence-contracts.md"
+spec = "docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md"
+plan = "plans/0.4.0/release-operator-visibility-and-survive-proof.md"
 issue = "109"
 commands = [
-  "cargo test -p shipper-cli --test e2e_publish publish_json_format_writes_command_envelope_to_stdout",
-  "cargo clippy -p shipper-cli --all-targets --locked -- -D warnings",
+  "cargo test -p shipper-cli inspect_events --lib --locked",
+  "cargo test -p shipper-cli --test cli_e2e --locked",
   "cargo xtask policy-report",
   "cargo fmt --all -- --check",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "resume-json-command-envelope"
-status = "complete"
+id = "events-state-receipt-drift-checks"
+status = "ready"
 proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
-spec = "docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md"
-plan = "plans/0.4.0/json-evidence-contracts.md"
+spec = "docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md"
+plan = "plans/0.4.0/release-operator-visibility-and-survive-proof.md"
 issue = "109"
 commands = [
-  "cargo test -p shipper-cli --test bdd_resume given_pending_state_when_resume_json_then_stdout_is_command_envelope",
-  "cargo clippy -p shipper-cli --all-targets --locked -- -D warnings",
+  "cargo test -p shipper-core drift --lib --locked",
+  "cargo test -p shipper-core state --lib --locked",
   "cargo xtask policy-report",
   "cargo fmt --all -- --check",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "schema-file-validation"
+id = "rebuild-state-from-events"
+status = "ready"
+proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
+spec = "docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md"
+plan = "plans/0.4.0/release-operator-visibility-and-survive-proof.md"
+issue = "109"
+commands = [
+  "cargo test -p shipper-core state_rebuild --lib --locked",
+  "cargo xtask policy-report",
+  "cargo fmt --all -- --check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "live-runner-interruption-rehearsal"
 status = "planned"
 proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
-spec = "docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md"
-plan = "plans/0.4.0/json-evidence-contracts.md"
+spec = "docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md"
+plan = "plans/0.4.0/release-operator-visibility-and-survive-proof.md"
 issue = "109"
 commands = [
-  "cargo xtask check-doc-contracts --mode advisory",
+  "cargo test -p shipper-cli --test e2e_rehearse -- --nocapture",
   "cargo xtask policy-report",
+  "cargo fmt --all -- --check",
   "git diff --check",
 ]

--- a/docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md
+++ b/docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md
@@ -1,0 +1,165 @@
+# SHIPPER-SPEC-0005: Release Operator Visibility and Survive Proof
+
+Status: proposed
+Owner: EffortlessMetrics
+Created: 2026-05-18
+Milestone: 0.4.0
+Linked proposal: docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md
+Linked specs: docs/specs/SHIPPER-SPEC-0001-source-of-truth-stack.md; docs/specs/SHIPPER-SPEC-0003-registry-reconciliation.md; docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md
+Linked ADRs: docs/adr/SHIPPER-ADR-0001-claims-become-checkable-state.md; docs/adr/SHIPPER-ADR-0002-registry-truth-over-cargo-output.md
+Linked plan: plans/0.4.0/release-operator-visibility-and-survive-proof.md
+Linked issues: #109
+Linked PRs:
+Support-tier impact: docs/status/SUPPORT_TIERS.md
+Policy impact: policy ledgers remain authoritative for exceptions and receipts
+Proof commands: cargo xtask check-doc-contracts --mode advisory; cargo xtask policy-report; cargo fmt --all -- --check
+
+## Problem
+
+Shipper already has several visibility foundations: state carries attempt
+history, publish/readiness events record retry and wait schedules, status-watch
+JSON is versioned, and synthetic resume proof exists. The remaining product gap
+is to turn those pieces into a durable release black-box recorder that survives
+real interruption and lets operators or agents follow event streams without
+misreading partial evidence.
+
+The immediate gap is narrow but important: event-follow consumers must not
+break or emit misleading output when a writer has flushed only part of the final
+JSONL line. The larger survive gap is that state, events, receipts, and
+reconciliation evidence must be checked and rebuildable before live-runner
+interruption can be promoted from planned to stable.
+
+## Behavior Contract
+
+Existing stable and internal foundations remain part of this lane's baseline:
+
+- execution state records attempt history for publish attempts
+- retry and readiness scheduling events exist as durable event variants
+- `shipper status --watch --format json` emits `shipper.status.watch.v1`
+- synthetic interruption/resume proof exists against fake Cargo and mock
+  registry surfaces
+
+Future changes in this lane must preserve and harden these rules:
+
+- `inspect-events --follow` must stream only complete events
+- if the final JSONL line is incomplete, follow mode must keep the read offset
+  before that line and retry on the next poll
+- text and JSON follow modes must not treat partial JSON as a valid event
+- malformed completed entries must produce actionable output instead of hiding
+  evidence corruption
+- event follow output must not contain unredacted tokens or sensitive command
+  output
+- `events.jsonl` remains the authoritative release timeline
+- `state.json` remains the resumable projection
+- `receipt.json` remains the final summary
+- `reconciliation.json`, when present, remains the ambiguity evidence
+  projection
+- finalization must detect material drift between events, state, receipt, and
+  reconciliation evidence
+- rebuild-from-events must produce a state projection for recovery or
+  comparison
+- live-runner interruption claims require a real rehearsal artifact before
+  support-tier promotion
+
+## Non-Goals
+
+- Re-implementing attempt history, retry events, readiness events, or
+  status-watch JSON that already exist.
+- Changing publish order or dependency planning.
+- Changing registry reconciliation outcomes.
+- Replacing existing command-owned JSON envelopes.
+- Making live-runner interruption stable before a real runner rehearsal exists.
+- Publishing crates, tagging a release, or creating release artifacts.
+- Adding receipt-driven remediation behavior in this spec.
+
+## Required Evidence
+
+Source-of-truth proof for this spec:
+
+- `cargo xtask check-doc-contracts --mode advisory`
+- `cargo xtask check-file-policy --mode blocking-allowlist`
+- `cargo xtask policy-report`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+Future implementation proof must cover:
+
+- incomplete tail handling in `inspect-events --follow`
+- completed malformed event handling
+- finalization drift checks between events, state, receipt, and reconciliation
+  evidence
+- rebuild-from-events producing a comparable execution-state projection
+- live-runner interruption rehearsal that uploads `.shipper/`, resumes from
+  artifacts, and proves no duplicate publish
+
+## Acceptance Examples
+
+- A writer appends half of an event line. `inspect-events --follow` emits
+  nothing for that partial line and retries it on the next poll.
+- The same partial line later receives its trailing newline. Follow mode emits
+  the event exactly once.
+- A completed malformed JSONL entry is reported as evidence corruption; it is
+  not silently skipped as if release progress were healthy.
+- Finalization sees a package in `state.json` with no corresponding durable
+  event. It reports drift instead of producing a misleading receipt.
+- Rebuild-from-events reconstructs package states from the event stream and can
+  be compared with `state.json`.
+- A live interruption claim remains planned if the proof is only synthetic or
+  local; promotion requires a real runner rehearsal artifact.
+
+## Test Mapping
+
+Expected implementation proof:
+
+- `cargo test -p shipper-cli inspect_events --lib --locked`
+- `cargo test -p shipper-cli --test cli_e2e --locked`
+- `cargo test -p shipper-core drift --lib --locked`
+- `cargo test -p shipper-core state_rebuild --lib --locked`
+- `cargo test -p shipper-cli --test e2e_rehearse -- --nocapture`
+- `cargo xtask check-doc-contracts --mode advisory`
+- `cargo xtask policy-report`
+
+Tests must use fake Cargo and mock registries. Real registry proof belongs only
+in the live-runner rehearsal artifact and release-readiness evidence.
+
+## Implementation Mapping
+
+The implementation plan belongs in
+`plans/0.4.0/release-operator-visibility-and-survive-proof.md`.
+
+The lane should land in narrow PRs:
+
+- source-of-truth activation
+- inspect-events follow incomplete-tail hardening
+- finalization drift checks
+- rebuild state from events
+- live interruption rehearsal
+- support-tier promotion only after proof exists
+
+## CI Proof
+
+CI should prove unit, integration, BDD, policy, and doc-contract gates for each
+implementation PR. Live interruption proof should run in a dedicated workflow
+or release rehearsal job that uploads the `.shipper/` evidence packet.
+
+CI success is not sufficient for support-tier promotion unless the relevant
+artifact proves the specific claim.
+
+## Promotion Rule
+
+Support-tier claims may move only when the named proof exists:
+
+- inspect-events follow hardening can be stable after focused tests prove
+  incomplete-tail and malformed-entry behavior
+- events/state/receipt drift detection stays planned until finalization checks
+  fail on inconsistent evidence
+- rebuild-from-events stays planned until tests prove a reconstructed projection
+- live-runner interruption stays planned until a real runner rehearsal artifact
+  proves artifact recovery and safe resume
+
+## Open Questions
+
+- Should rebuild-from-events be a library-only capability first or a CLI command
+  in the same lane?
+- Which live-runner rehearsal should be safe enough before crates.io dogfood
+  release proof?

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -5,7 +5,7 @@ Owner: EffortlessMetrics
 Created: 2026-05-13
 Milestone: 0.4.0
 Linked proposal: docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md
-Linked specs: docs/specs/SHIPPER-SPEC-0001-source-of-truth-stack.md; docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md
+Linked specs: docs/specs/SHIPPER-SPEC-0001-source-of-truth-stack.md; docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md; docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md
 Linked ADRs:
 Linked plan:
 Linked issues: #109, #195
@@ -49,11 +49,12 @@ make stronger claims than this file supports.
 | Preflight registry pacing estimate | stable | `cargo test -p shipper-core estimate_preflight_duration --lib`; `cargo test -p shipper-cli preflight`; `estimated_publish_duration` JSON field | engine/cli |
 | Status JSON registry comparison | stable | `cargo test -p shipper-cli --test e2e_status status_json_format_produces_registry_report`; `shipper status --format json` emits `shipper.status.v1` registry/package state | cli/integrations |
 | Status watch JSON progress | stable | `cargo test -p shipper-cli status_watch_report_summarizes_state_and_scheduled_events --lib`; `shipper status --watch --format json` emits `shipper.status.watch.v1` progress state | cli/integrations |
+| Release black-box recorder hardening | planned | `docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md`; `plans/0.4.0/release-operator-visibility-and-survive-proof.md`; promote only after inspect-events follow hardening, drift checks, event rebuild proof, and live interruption rehearsal artifacts exist | engine/cli |
 | Doctor JSON diagnostics | stable | `cargo test -p shipper-cli --test e2e_doctor doctor_json_format_reports_diagnostics_without_token_value`; `shipper doctor --format json` emits `shipper.doctor.v1` without token values | cli/integrations |
 | Publish JSON command envelope | stable | `cargo test -p shipper-cli --test e2e_publish publish_json_format_writes_command_envelope_to_stdout`; `shipper publish --format json` emits `shipper.publish.v1` with package summary, artifact paths, and nested receipt evidence for the targeted registry | cli/integrations |
 | Resume JSON command envelope | stable | `cargo test -p shipper-cli --test bdd_resume given_pending_state_when_resume_json_then_stdout_is_command_envelope`; `shipper resume --format json` emits `shipper.resume.v1` with safety summary, package counts, artifact paths, and nested receipt evidence for the targeted registry | cli/integrations |
 | Resume after synthetic publish interruption | stable/internal | `cargo test -p shipper-cli --test e2e_rehearse -- --nocapture`; CI `BDD Tests` job; proves persisted `state.json`/`events.jsonl` let `shipper resume` complete without duplicate publishes against fake Cargo and a mock registry | engine |
-| Resume under live runner interruption | planned | Manual release-candidate procedure in `docs/how-to/run-recover-rehearsal.md`; promote only after a completed crates.io rehearsal artifact proves cancelled-run artifact recovery and resume on a real runner | engine |
+| Resume under live runner interruption | planned | Manual release-candidate procedure in `docs/how-to/run-recover-rehearsal.md`; `docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md`; promote only after a completed crates.io rehearsal artifact proves cancelled-run artifact recovery and resume on a real runner | engine |
 | Trusted Publishing prerequisite diagnostics | advisory | `shipper doctor`; `cargo test -p shipper-cli --test cli_e2e doctor_command_detects_trusted_publishing_auth`; validates visible GitHub OIDC env and release workflow prerequisites without claiming crates.io-side registration proof | release/ci |
 | Long-lived token fallback warnings | advisory | `cargo test -p shipper-core run_preflight_warns_when_token_auth_overrides_oidc --lib`; `cargo test -p shipper-cli --test cli_e2e doctor_command_warns_when_token_fallback_is_configured`; warns when Cargo token auth wins while Trusted Publishing signals or fallback config are present | release/ci |
 | Trusted Publishing default | planned/advisory | Future Trusted Publishing spec and #96 | release/ci |

--- a/plans/0.4.0/release-operator-visibility-and-survive-proof.md
+++ b/plans/0.4.0/release-operator-visibility-and-survive-proof.md
@@ -1,0 +1,252 @@
+# Plan: Release Operator Visibility and Survive Proof
+
+Status: proposed
+Owner: EffortlessMetrics
+Created: 2026-05-18
+Milestone: 0.4.0
+Linked proposal: docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md
+Linked specs: docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md
+Linked ADRs: docs/adr/SHIPPER-ADR-0001-claims-become-checkable-state.md; docs/adr/SHIPPER-ADR-0002-registry-truth-over-cargo-output.md
+Linked plan: plans/0.4.0/json-evidence-contracts.md
+Linked issues: #109
+Linked PRs:
+Support-tier impact: docs/status/SUPPORT_TIERS.md
+Policy impact: no new policy exceptions
+Proof commands: cargo xtask check-doc-contracts --mode advisory; cargo xtask policy-report; cargo fmt --all -- --check
+
+## End State
+
+Shipper release execution is visible and survivable:
+
+- event-follow consumers do not misread incomplete JSONL tail lines
+- finalization detects material event/state/receipt/reconciliation drift
+- state can be rebuilt from events for recovery or comparison
+- live-runner interruption is proven by an uploaded `.shipper/` evidence packet
+  before the support-tier claim is promoted
+
+Existing foundations, including attempt history, wait/readiness events, status
+watch JSON, and synthetic resume proof, are treated as already landed baseline.
+
+## PR Sequence
+
+### PR 1 - Source-of-truth activation
+
+Linked spec: docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md
+Blocks: PR 2
+Blocked by:
+
+#### Goal
+
+Define the behavior contract, implementation plan, active goal, and planned
+support-tier hooks for release operator visibility and survive proof.
+
+#### Production Delta
+
+No product runtime behavior change.
+
+#### Non-Goals
+
+Runtime behavior, schema changes, drift checks, state rebuild, live-runner
+rehearsal, and support-tier promotion.
+
+#### Acceptance
+
+- Spec and plan exist and link to each other.
+- `.shipper-meta/goals/active.toml` points to this lane.
+- Support tiers remain planned/advisory and do not promote unproven claims.
+
+#### Proof Commands
+
+- `python -c "import pathlib,tomllib; tomllib.loads(pathlib.Path('.shipper-meta/goals/active.toml').read_text()); print('active goal TOML parses')"`
+- `cargo xtask check-doc-contracts --mode advisory`
+- `cargo xtask check-file-policy --mode blocking-allowlist`
+- `cargo xtask policy-report`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+#### Rollback
+
+Revert this spec, plan, active goal, and support-tier planned rows if the lane
+is superseded before runtime work depends on it.
+
+### PR 2 - Inspect-events follow incomplete-tail hardening
+
+Linked spec: docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md
+Blocks: PR 3
+Blocked by: PR 1
+
+#### Goal
+
+Make `inspect-events --follow` stream only complete JSONL entries and retry an
+incomplete final line on the next poll.
+
+#### Production Delta
+
+CLI event-log reading and rendering only.
+
+#### Non-Goals
+
+Event schema changes, status/watch output changes, state rebuild, drift checks,
+and live-runner rehearsal.
+
+#### Acceptance
+
+- Human and JSON follow modes emit no partial event for an incomplete tail line.
+- The offset remains before an incomplete final line.
+- When the line becomes complete, it emits exactly once.
+- Completed malformed entries remain visible as actionable errors.
+
+#### Proof Commands
+
+- `cargo test -p shipper-cli inspect_events --lib --locked`
+- `cargo test -p shipper-cli --test cli_e2e --locked`
+- `cargo xtask policy-report`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+#### Rollback
+
+Restore prior inspect-events behavior if follow mode creates misleading output.
+
+### PR 3 - Events-as-truth drift checks
+
+Linked spec: docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md
+Blocks: PR 4
+Blocked by: PR 2
+
+#### Goal
+
+Verify event/state/receipt/reconciliation consistency at publish finalization.
+
+#### Production Delta
+
+Finalization validation only.
+
+#### Non-Goals
+
+State rebuild and live interruption rehearsal.
+
+#### Acceptance
+
+- Finalization detects package state without matching events.
+- Reconciliation evidence is required when ambiguity occurred.
+- Receipt summaries match final state or fail with actionable drift evidence.
+
+#### Proof Commands
+
+- `cargo test -p shipper-core drift --lib --locked`
+- `cargo test -p shipper-core state --lib --locked`
+- `cargo xtask policy-report`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+#### Rollback
+
+Revert drift checks if they block valid releases or misclassify evidence.
+
+### PR 4 - Rebuild state from events
+
+Linked spec: docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md
+Blocks: PR 5
+Blocked by: PR 3
+
+#### Goal
+
+Build a recoverable state projection from `events.jsonl`.
+
+#### Production Delta
+
+Library recovery function first; CLI command only if it remains narrow.
+
+#### Non-Goals
+
+Changing normal resume behavior or live interruption rehearsal.
+
+#### Acceptance
+
+- Events can reconstruct published, pending, failed, ambiguous, and reconciled
+  package states.
+- Rebuilt state can be compared with current state for drift diagnostics.
+
+#### Proof Commands
+
+- `cargo test -p shipper-core state_rebuild --lib --locked`
+- `cargo xtask policy-report`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+#### Rollback
+
+Remove rebuild support if reconstruction is incomplete or misleading.
+
+### PR 5 - Live interruption rehearsal
+
+Linked spec: docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md
+Blocks: PR 6
+Blocked by: PR 4
+
+#### Goal
+
+Prove that a real runner interruption can upload `.shipper/`, resume from
+artifacts, avoid duplicate publishes, and leave coherent evidence.
+
+#### Production Delta
+
+CI/release rehearsal workflow and evidence artifacts only.
+
+#### Non-Goals
+
+Publishing a production release or promoting the support-tier claim before the
+artifact exists.
+
+#### Acceptance
+
+- Controlled interruption produces a `.shipper/` artifact.
+- Resume uses the artifact and completes without duplicate publish.
+- Events, state, receipt, and reconciliation evidence remain coherent.
+
+#### Proof Commands
+
+- dedicated interruption rehearsal workflow
+- `cargo test -p shipper-cli --test e2e_rehearse -- --nocapture`
+- `cargo xtask policy-report`
+- `git diff --check`
+
+#### Rollback
+
+Disable the rehearsal workflow and revert support-tier text if proof is
+unreliable.
+
+### PR 6 - Support-tier promotion
+
+Linked spec: docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md
+Blocks:
+Blocked by: PR 5
+
+#### Goal
+
+Promote only the claims proven by the implementation and rehearsal artifacts.
+
+#### Production Delta
+
+Documentation/status only.
+
+#### Non-Goals
+
+Runtime changes.
+
+#### Acceptance
+
+- Support tiers name exact proof commands and artifacts.
+- README and product claims do not exceed proven evidence.
+
+#### Proof Commands
+
+- `cargo xtask check-doc-contracts --mode advisory`
+- `cargo xtask policy-report`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+#### Rollback
+
+Demote any claim whose proof artifact is missing or weak.


### PR DESCRIPTION
## Summary
- add SHIPPER-SPEC-0005 for release operator visibility and survive proof
- add the matching 0.4.0 plan with narrow follow-up PR sequence
- set the active goal to inspect-events follow tail safety, drift checks, state rebuild, and live interruption proof
- add planned support-tier hooks without promoting unproven claims

## Validation
- python TOML parse for .shipper-meta/goals/active.toml
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask policy-report
- cargo fmt --all -- --check
- git diff --check