### PR TITLE
feat(state): fail finalization on evidence drift

### DIFF
--- a/crates/shipper-core/src/engine/mod.rs
+++ b/crates/shipper-core/src/engine/mod.rs
@@ -350,6 +350,7 @@ pub fn run_publish(
             &state_dir,
             &events_path,
             &mut event_log,
+            &st,
             parallel_receipts,
             run_started,
             git_context,
@@ -376,6 +377,17 @@ pub fn run_publish(
             ),
             publish::resume::ResumeGate::Skip
         ) {
+            if matches!(
+                progress.state,
+                PackageState::Published | PackageState::Skipped { .. }
+            ) {
+                publish::resume::record_terminal_resume_skip_event(
+                    &progress,
+                    &pkg_label,
+                    &events_path,
+                    &mut event_log,
+                )?;
+            }
             continue;
         }
 
@@ -804,6 +816,15 @@ pub fn run_publish(
                             ));
                             record_attempt_detail(&mut st, &state_dir, attempt_detail)?;
                             update_state(&mut st, &state_dir, &key, PackageState::Published)?;
+                            event_log.record(PublishEvent {
+                                timestamp: Utc::now(),
+                                event_type: EventType::PackagePublished {
+                                    duration_ms: start_instant.elapsed().as_millis() as u64,
+                                },
+                                package: pkg_label.clone(),
+                            });
+                            event_log.write_to_file(&events_path)?;
+                            event_log.clear();
                             last_err = None;
                             break;
                         }
@@ -983,6 +1004,15 @@ pub fn run_publish(
             if matches!(current_state, Some(PackageState::Uploaded)) {
                 if reg.version_exists(&p.name, &p.version)? {
                     update_state(&mut st, &state_dir, &key, PackageState::Published)?;
+                    event_log.record(PublishEvent {
+                        timestamp: Utc::now(),
+                        event_type: EventType::PackagePublished {
+                            duration_ms: start_instant.elapsed().as_millis() as u64,
+                        },
+                        package: pkg_label.clone(),
+                    });
+                    event_log.write_to_file(&events_path)?;
+                    event_log.clear();
                 } else {
                     last_err = Some((
                         ErrorClass::Ambiguous,
@@ -999,6 +1029,15 @@ pub fn run_publish(
             // Final chance: maybe it eventually showed up.
             if reg.version_exists(&p.name, &p.version)? {
                 update_state(&mut st, &state_dir, &key, PackageState::Published)?;
+                event_log.record(PublishEvent {
+                    timestamp: Utc::now(),
+                    event_type: EventType::PackagePublished {
+                        duration_ms: start_instant.elapsed().as_millis() as u64,
+                    },
+                    package: pkg_label.clone(),
+                });
+                event_log.write_to_file(&events_path)?;
+                event_log.clear();
             } else {
                 let failed = PackageState::Failed {
                     class: class.clone(),
@@ -1083,6 +1122,7 @@ pub fn run_publish(
         &state_dir,
         &events_path,
         &mut event_log,
+        &st,
         receipts,
         run_started,
         git_context,

--- a/crates/shipper-core/src/engine/publish/finalize.rs
+++ b/crates/shipper-core/src/engine/publish/finalize.rs
@@ -40,6 +40,7 @@ pub(in crate::engine) fn finish_sequential_run(
     state_dir: &Path,
     events_path: &Path,
     event_log: &mut events::EventLog,
+    state: &ExecutionState,
     receipts: Vec<PackageReceipt>,
     run_started: DateTime<Utc>,
     git_context: Option<GitContext>,
@@ -60,6 +61,7 @@ pub(in crate::engine) fn finish_sequential_run(
     write_receipt(
         ws,
         state_dir,
+        state,
         receipts,
         run_started,
         git_context,
@@ -75,6 +77,7 @@ pub(in crate::engine) fn finish_parallel_run(
     state_dir: &Path,
     events_path: &Path,
     event_log: &mut events::EventLog,
+    state: &ExecutionState,
     receipts: Vec<PackageReceipt>,
     run_started: DateTime<Utc>,
     git_context: Option<GitContext>,
@@ -95,6 +98,7 @@ pub(in crate::engine) fn finish_parallel_run(
     write_receipt(
         ws,
         state_dir,
+        state,
         receipts,
         run_started,
         git_context,
@@ -107,6 +111,7 @@ pub(in crate::engine) fn finish_parallel_run(
 fn write_receipt(
     ws: &PlannedWorkspace,
     state_dir: &Path,
+    state: &ExecutionState,
     receipts: Vec<PackageReceipt>,
     run_started: DateTime<Utc>,
     git_context: Option<GitContext>,
@@ -125,11 +130,17 @@ fn write_receipt(
         environment,
     };
 
-    crate::state::reconciliation::write_report_from_events(
+    let reconciliation_report = crate::state::reconciliation::write_report_from_events(
         state_dir,
         &ws.plan.plan_id,
         &ws.plan.registry,
         events_path,
+    )?;
+    crate::state::consistency::verify_finalization_consistency(
+        events_path,
+        state,
+        &receipt,
+        reconciliation_report.as_ref(),
     )?;
     state::write_receipt(state_dir, &receipt)?;
     Ok(receipt)

--- a/crates/shipper-core/src/engine/publish/resume.rs
+++ b/crates/shipper-core/src/engine/publish/resume.rs
@@ -66,6 +66,17 @@ pub(in crate::engine) fn record_terminal_resume_skip(
         package.name, package.version, short
     ));
 
+    record_terminal_resume_skip_event(progress, pkg_label, events_path, event_log)
+}
+
+pub(in crate::engine) fn record_terminal_resume_skip_event(
+    progress: &PackageProgress,
+    pkg_label: &str,
+    events_path: &std::path::Path,
+    event_log: &mut events::EventLog,
+) -> Result<()> {
+    let short = short_state(&progress.state);
+
     // #125: explicitly record resume's "state already terminal, trusting it"
     // decision so events.jsonl stays legible even though historical receipt
     // shape excludes already-terminal packages in the resume path.

--- a/crates/shipper-core/src/state/consistency.rs
+++ b/crates/shipper-core/src/state/consistency.rs
@@ -13,11 +13,14 @@
 use std::collections::BTreeSet;
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 
-use shipper_types::{EventType, ExecutionState, PackageState, StateEventDrift};
+use shipper_types::{
+    EventType, ExecutionState, PackageState, Receipt, ReconciliationReport, StateEventDrift,
+};
 
 use super::events::EventLog;
+use super::rebuild::{StateRebuildOptions, rebuild_state_from_events};
 
 /// Verify that `events.jsonl` and the in-memory `ExecutionState` agree on which
 /// packages are Published.
@@ -40,12 +43,17 @@ pub fn verify_events_state_consistency(
         )
     })?;
 
-    // Package labels that have a `PackagePublished` event in events.jsonl.
+    // Package labels that have a `PackagePublished` event in events.jsonl, or a
+    // trusted resume skip event documenting a previously published package.
     // Labels are the `package` field of the event (format: `name@version`).
     let events_published: BTreeSet<String> = log
         .all_events()
         .iter()
-        .filter(|e| matches!(e.event_type, EventType::PackagePublished { .. }))
+        .filter(|e| match &e.event_type {
+            EventType::PackagePublished { .. } => true,
+            EventType::PackageSkipped { reason } => reason == "resume: state already published",
+            _ => false,
+        })
         .map(|e| e.package.clone())
         .collect();
 
@@ -99,12 +107,227 @@ pub fn format_drift_summary(drift: &StateEventDrift) -> String {
     lines.join("\n")
 }
 
+/// Verify the end-of-run evidence packet before `receipt.json` becomes the
+/// durable summary.
+///
+/// This check is stricter than [`verify_events_state_consistency`]: it compares
+/// the current state projection, the receipt that is about to be written, the
+/// event-derived state projection, and reconciliation evidence when
+/// reconciliation events exist. Drift is returned as an error so finalization
+/// cannot produce a misleading receipt.
+pub fn verify_finalization_consistency(
+    events_path: &Path,
+    state: &ExecutionState,
+    receipt: &Receipt,
+    reconciliation_report: Option<&ReconciliationReport>,
+) -> Result<()> {
+    let event_log = EventLog::read_from_file(events_path).with_context(|| {
+        format!(
+            "failed to read event log for finalization consistency check: {}",
+            events_path.display()
+        )
+    })?;
+    let rebuilt_state = rebuild_state_from_events(
+        events_path,
+        StateRebuildOptions::new(receipt.registry.clone()).with_fallback_plan_id(&receipt.plan_id),
+    )
+    .with_context(|| {
+        format!(
+            "failed to rebuild state projection from events for finalization check: {}",
+            events_path.display()
+        )
+    })?;
+
+    let mut findings = Vec::new();
+    let trusted_resume_terminal_skips = trusted_resume_terminal_skips(&event_log);
+    verify_plan_ids(receipt, &rebuilt_state, &mut findings);
+    verify_state_matches_events(
+        state,
+        &rebuilt_state,
+        &trusted_resume_terminal_skips,
+        &mut findings,
+    );
+    verify_receipt_matches_state(state, receipt, &mut findings);
+    verify_reconciliation_evidence(&event_log, receipt, reconciliation_report, &mut findings);
+
+    if findings.is_empty() {
+        return Ok(());
+    }
+
+    bail!(
+        "release evidence drift detected; refusing to write receipt.json\n{}",
+        findings
+            .into_iter()
+            .map(|finding| format!("  - {finding}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    )
+}
+
+fn verify_plan_ids(receipt: &Receipt, rebuilt_state: &ExecutionState, findings: &mut Vec<String>) {
+    if rebuilt_state.plan_id != receipt.plan_id {
+        findings.push(format!(
+            "events plan_id {} does not match receipt plan_id {}",
+            rebuilt_state.plan_id, receipt.plan_id
+        ));
+    }
+}
+
+fn verify_state_matches_events(
+    state: &ExecutionState,
+    rebuilt_state: &ExecutionState,
+    trusted_resume_terminal_skips: &BTreeSet<String>,
+    findings: &mut Vec<String>,
+) {
+    for (key, progress) in &state.packages {
+        match rebuilt_state.packages.get(key) {
+            Some(event_progress) if event_progress.state == progress.state => {}
+            Some(event_progress)
+                if matches!(
+                    (&progress.state, &event_progress.state),
+                    (PackageState::Published, PackageState::Skipped { .. })
+                ) && trusted_resume_terminal_skips.contains(key) => {}
+            Some(event_progress)
+                if matches!(
+                    (&progress.state, &event_progress.state),
+                    (PackageState::Skipped { .. }, PackageState::Skipped { .. })
+                ) && trusted_resume_terminal_skips.contains(key) => {}
+            Some(event_progress) => findings.push(format!(
+                "{key} state drift: state.json says {}; events project {}",
+                state_name(&progress.state),
+                state_name(&event_progress.state)
+            )),
+            None if matches!(progress.state, PackageState::Pending) => {}
+            None => findings.push(format!(
+                "{key} state drift: state.json says {} but events contain no package projection",
+                state_name(&progress.state)
+            )),
+        }
+    }
+
+    for (key, progress) in &rebuilt_state.packages {
+        if !state.packages.contains_key(key) {
+            findings.push(format!(
+                "{key} state drift: events project {} but state.json has no package entry",
+                state_name(&progress.state)
+            ));
+        }
+    }
+}
+
+fn trusted_resume_terminal_skips(event_log: &EventLog) -> BTreeSet<String> {
+    event_log
+        .all_events()
+        .iter()
+        .filter_map(|event| match &event.event_type {
+            EventType::PackageSkipped { reason }
+                if reason.starts_with("resume: state already ") =>
+            {
+                Some(event.package.clone())
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn verify_receipt_matches_state(
+    state: &ExecutionState,
+    receipt: &Receipt,
+    findings: &mut Vec<String>,
+) {
+    for package in &receipt.packages {
+        let key = format!("{}@{}", package.name, package.version);
+        match state.packages.get(&key) {
+            Some(progress) if progress.state == package.state => {}
+            Some(progress) => findings.push(format!(
+                "{key} receipt drift: receipt says {}; state.json says {}",
+                state_name(&package.state),
+                state_name(&progress.state)
+            )),
+            None => findings.push(format!(
+                "{key} receipt drift: receipt has package but state.json has no package entry"
+            )),
+        }
+    }
+}
+
+fn verify_reconciliation_evidence(
+    event_log: &EventLog,
+    receipt: &Receipt,
+    reconciliation_report: Option<&ReconciliationReport>,
+    findings: &mut Vec<String>,
+) {
+    let reconciled_packages: BTreeSet<String> = event_log
+        .all_events()
+        .iter()
+        .filter(|event| matches!(event.event_type, EventType::PublishReconciled { .. }))
+        .map(|event| event.package.clone())
+        .collect();
+
+    if reconciled_packages.is_empty() {
+        if reconciliation_report.is_some() {
+            findings.push(
+                "reconciliation.json is present but events contain no reconciliation outcomes"
+                    .to_string(),
+            );
+        }
+        return;
+    }
+
+    let Some(report) = reconciliation_report else {
+        findings.push(format!(
+            "events contain reconciliation outcomes for {} but reconciliation.json was not produced",
+            reconciled_packages.into_iter().collect::<Vec<_>>().join(", ")
+        ));
+        return;
+    };
+
+    if report.plan_id != receipt.plan_id {
+        findings.push(format!(
+            "reconciliation plan_id {} does not match receipt plan_id {}",
+            report.plan_id, receipt.plan_id
+        ));
+    }
+
+    let report_packages: BTreeSet<String> = report
+        .records
+        .iter()
+        .map(|record| record.package.clone())
+        .collect();
+
+    for package in reconciled_packages.difference(&report_packages) {
+        findings.push(format!(
+            "{package} reconciliation drift: event outcome is missing from reconciliation.json"
+        ));
+    }
+    for package in report_packages.difference(&reconciled_packages) {
+        findings.push(format!(
+            "{package} reconciliation drift: reconciliation.json has no matching event outcome"
+        ));
+    }
+}
+
+fn state_name(state: &PackageState) -> &'static str {
+    match state {
+        PackageState::Pending => "pending",
+        PackageState::Uploaded => "uploaded",
+        PackageState::Published => "published",
+        PackageState::Skipped { .. } => "skipped",
+        PackageState::Failed { .. } => "failed",
+        PackageState::Ambiguous { .. } => "ambiguous",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
 
     use chrono::Utc;
-    use shipper_types::{ExecutionState, PackageProgress, PublishEvent, Registry};
+    use shipper_types::{
+        EnvironmentFingerprint, PackageEvidence, PackageProgress, PackageReceipt, PublishEvent,
+        ReconciliationEvidenceKind, ReconciliationEvidenceSource, ReconciliationOperatorAction,
+        ReconciliationRecord, ReconciliationReport, ReconciliationTrigger, Registry,
+    };
     use tempfile::tempdir;
 
     use super::*;
@@ -157,6 +380,83 @@ mod tests {
         }
     }
 
+    fn plan_created_event() -> PublishEvent {
+        PublishEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::PlanCreated {
+                plan_id: "test-plan".to_string(),
+                package_count: 1,
+            },
+            package: "all".to_string(),
+        }
+    }
+
+    fn receipt(packages: Vec<PackageReceipt>) -> Receipt {
+        Receipt {
+            receipt_version: "shipper.receipt.v2".to_string(),
+            plan_id: "test-plan".to_string(),
+            registry: Registry::crates_io(),
+            started_at: Utc::now(),
+            finished_at: Utc::now(),
+            packages,
+            event_log_path: Path::new(".shipper/events.jsonl").to_path_buf(),
+            git_context: None,
+            environment: EnvironmentFingerprint {
+                shipper_version: "test".to_string(),
+                cargo_version: None,
+                rust_version: None,
+                os: "test".to_string(),
+                arch: "test".to_string(),
+            },
+        }
+    }
+
+    fn package_receipt(name: &str, version: &str, state: PackageState) -> PackageReceipt {
+        PackageReceipt {
+            name: name.to_string(),
+            version: version.to_string(),
+            attempts: 1,
+            state,
+            started_at: Utc::now(),
+            finished_at: Utc::now(),
+            duration_ms: 10,
+            evidence: PackageEvidence {
+                attempts: vec![],
+                readiness_checks: vec![],
+            },
+            compromised_at: None,
+            compromised_by: None,
+            superseded_by: None,
+        }
+    }
+
+    fn reconciliation_report(package: &str) -> ReconciliationReport {
+        let (name, version) = package.rsplit_once('@').expect("package label");
+        ReconciliationReport {
+            schema_version: "shipper.reconciliation.v1".to_string(),
+            plan_id: "test-plan".to_string(),
+            registry: Registry::crates_io(),
+            generated_at: Utc::now(),
+            evidence_sources: vec![ReconciliationEvidenceSource {
+                kind: ReconciliationEvidenceKind::EventLog,
+                path: ".shipper/events.jsonl".to_string(),
+            }],
+            records: vec![ReconciliationRecord {
+                package: package.to_string(),
+                name: name.to_string(),
+                version: version.to_string(),
+                trigger: ReconciliationTrigger::CargoAmbiguousExit,
+                method: None,
+                cargo_exit_class: Some(shipper_types::ErrorClass::Ambiguous),
+                outcome: shipper_types::ReconciliationOutcome::Published {
+                    attempts: 1,
+                    elapsed_ms: 10,
+                },
+                operator_action: ReconciliationOperatorAction::MarkPublishedContinue,
+            }],
+        }
+    }
+
     #[test]
     fn consistent_when_state_and_events_agree() {
         let td = tempdir().expect("tempdir");
@@ -169,6 +469,27 @@ mod tests {
             pkg_progress("a", "1.0.0", PackageState::Published),
             pkg_progress("b", "2.0.0", PackageState::Published),
         ]);
+
+        let drift = verify_events_state_consistency(&td.path().join(EVENTS_FILE), &state)
+            .expect("check runs");
+        assert!(drift.is_consistent(), "expected no drift; got {:?}", drift);
+    }
+
+    #[test]
+    fn consistent_when_resume_skip_documents_published_state() {
+        let td = tempdir().expect("tempdir");
+        write_events(
+            td.path(),
+            vec![PublishEvent {
+                timestamp: Utc::now(),
+                event_type: EventType::PackageSkipped {
+                    reason: "resume: state already published".to_string(),
+                },
+                package: "a@1.0.0".to_string(),
+            }],
+        );
+
+        let state = make_state(vec![pkg_progress("a", "1.0.0", PackageState::Published)]);
 
         let drift = verify_events_state_consistency(&td.path().join(EVENTS_FILE), &state)
             .expect("check runs");
@@ -203,6 +524,143 @@ mod tests {
         assert!(!drift.is_consistent());
         assert_eq!(drift.in_state_only, vec!["a@1.0.0".to_string()]);
         assert!(drift.in_events_only.is_empty());
+    }
+
+    #[test]
+    fn drift_finalization_rejects_state_published_without_event_projection() {
+        let td = tempdir().expect("tempdir");
+        write_events(td.path(), vec![plan_created_event()]);
+        let state = make_state(vec![pkg_progress("a", "1.0.0", PackageState::Published)]);
+        let receipt = receipt(vec![package_receipt("a", "1.0.0", PackageState::Published)]);
+
+        let err =
+            verify_finalization_consistency(&td.path().join(EVENTS_FILE), &state, &receipt, None)
+                .expect_err("state/event drift should fail finalization");
+
+        assert!(
+            err.to_string().contains("release evidence drift detected"),
+            "{err:#}"
+        );
+        assert!(
+            err.to_string()
+                .contains("state.json says published but events contain no package projection"),
+            "{err:#}"
+        );
+    }
+
+    #[test]
+    fn drift_finalization_accepts_reconciled_published_projection() {
+        let td = tempdir().expect("tempdir");
+        write_events(
+            td.path(),
+            vec![
+                plan_created_event(),
+                PublishEvent {
+                    timestamp: Utc::now(),
+                    event_type: EventType::PublishReconciled {
+                        outcome: shipper_types::ReconciliationOutcome::Published {
+                            attempts: 1,
+                            elapsed_ms: 10,
+                        },
+                    },
+                    package: "a@1.0.0".to_string(),
+                },
+            ],
+        );
+        let state = make_state(vec![pkg_progress("a", "1.0.0", PackageState::Published)]);
+        let receipt = receipt(vec![package_receipt("a", "1.0.0", PackageState::Published)]);
+        let report = reconciliation_report("a@1.0.0");
+
+        verify_finalization_consistency(
+            &td.path().join(EVENTS_FILE),
+            &state,
+            &receipt,
+            Some(&report),
+        )
+        .expect("reconciled published event should project to published state");
+    }
+
+    #[test]
+    fn drift_finalization_accepts_trusted_resume_published_skip_projection() {
+        let td = tempdir().expect("tempdir");
+        write_events(
+            td.path(),
+            vec![
+                plan_created_event(),
+                PublishEvent {
+                    timestamp: Utc::now(),
+                    event_type: EventType::PackageSkipped {
+                        reason: "resume: state already published".to_string(),
+                    },
+                    package: "a@1.0.0".to_string(),
+                },
+            ],
+        );
+        let state = make_state(vec![pkg_progress("a", "1.0.0", PackageState::Published)]);
+        let receipt = receipt(vec![]);
+
+        verify_finalization_consistency(&td.path().join(EVENTS_FILE), &state, &receipt, None)
+            .expect("trusted resume skip should not force receipt drift");
+    }
+
+    #[test]
+    fn drift_finalization_requires_reconciliation_report_for_reconciled_events() {
+        let td = tempdir().expect("tempdir");
+        write_events(
+            td.path(),
+            vec![
+                plan_created_event(),
+                PublishEvent {
+                    timestamp: Utc::now(),
+                    event_type: EventType::PublishReconciled {
+                        outcome: shipper_types::ReconciliationOutcome::Published {
+                            attempts: 1,
+                            elapsed_ms: 10,
+                        },
+                    },
+                    package: "a@1.0.0".to_string(),
+                },
+            ],
+        );
+        let state = make_state(vec![pkg_progress("a", "1.0.0", PackageState::Published)]);
+        let receipt = receipt(vec![package_receipt("a", "1.0.0", PackageState::Published)]);
+
+        let err =
+            verify_finalization_consistency(&td.path().join(EVENTS_FILE), &state, &receipt, None)
+                .expect_err("missing reconciliation report should fail finalization");
+
+        assert!(
+            err.to_string()
+                .contains("reconciliation.json was not produced"),
+            "{err:#}"
+        );
+    }
+
+    #[test]
+    fn drift_finalization_rejects_receipt_state_mismatch() {
+        let td = tempdir().expect("tempdir");
+        write_events(
+            td.path(),
+            vec![plan_created_event(), published_event("a", "1.0.0")],
+        );
+        let state = make_state(vec![pkg_progress("a", "1.0.0", PackageState::Published)]);
+        let receipt = receipt(vec![package_receipt(
+            "a",
+            "1.0.0",
+            PackageState::Skipped {
+                reason: "manual mismatch".to_string(),
+            },
+        )]);
+
+        let err =
+            verify_finalization_consistency(&td.path().join(EVENTS_FILE), &state, &receipt, None)
+                .expect_err("receipt/state drift should fail finalization");
+
+        assert!(
+            err.to_string()
+                .contains("receipt drift: receipt says skipped; state.json says published"),
+            "{err:#}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- fail publish finalization before writing `receipt.json` when state, event-derived state, receipt, or reconciliation evidence drift
- emit missing `PackagePublished` events for registry-truth publish paths that already moved state to published
- record trusted terminal resume skips so event projection explains already-published resume state

## Validation
- `cargo test -p shipper-core state --lib --locked`
- `cargo test -p shipper-core publish --lib --locked`
- `cargo test -p shipper-core drift --lib --locked`
- `cargo clippy -p shipper-core --all-targets --locked -- -D warnings`
- `cargo xtask policy-report`
- `cargo fmt --all -- --check`
- `git diff --check`

## Notes
- `cargo test -p shipper-core --lib --locked` reached 2033 passed and 1 failing git-cleanliness test; that test passes in isolation and appears to be an existing parallel environment race around `SHIPPER_GIT_BIN`, unrelated to this diff. A single-threaded rerun was stopped after it exceeded the local validation timeout.