### PR TITLE
docs: define release auth evidence lane

### DIFF
--- a/.shipper-meta/goals/active.toml
+++ b/.shipper-meta/goals/active.toml
@@ -1,118 +1,31 @@
-id = "shipper-release-operator-visibility"
-title = "Release operator visibility and survive proof"
-status = "complete"
+id = "shipper-release-auth-evidence"
+title = "Release auth evidence and Trusted Publishing"
+status = "active"
 owner = "EffortlessMetrics"
 created = "2026-05-18"
 
 objective = """
-Use Shipper's existing attempt-history, wait/readiness-event, and status/watch
-foundations to close the remaining release black-box recorder gaps: event-follow
-tail safety, event/state drift checks, state rebuild, and live interruption
-proof.
+Make Shipper's release authentication posture evidence-backed: Doctor,
+preflight, publish/resume, events, receipts, release workflows, and support
+tiers should distinguish Trusted Publishing, token fallback, missing auth, and
+externally unproven crates.io registration without exposing token values.
 """
 
 end_state = [
-  "Inspect-events follow mode handles incomplete tail lines without emitting partial events.",
-  "Publish finalization detects material event/state/receipt drift.",
-  "State can be rebuilt from events for recovery or comparison.",
-  "Live-runner interruption proof exists before the support-tier claim is promoted.",
+  "The active goal points to the accepted auth evidence spec and plan.",
+  "Auth mode and token fallback are visible in release evidence without token values.",
+  "Trusted Publishing workflow proof records whether short-lived token minting succeeded or fallback was used.",
+  "Support tiers distinguish advisory diagnostics from a proven Trusted Publishing default.",
 ]
 
 [[work_item]]
-id = "operator-visibility-source-of-truth"
+id = "auth-evidence-source-of-truth"
 status = "complete"
 proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
-spec = "docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md"
-plan = "plans/0.4.0/release-operator-visibility-and-survive-proof.md"
-issue = "109"
-commands = [
-  "cargo xtask check-doc-contracts --mode advisory",
-  "cargo xtask policy-report",
-  "cargo xtask check-file-policy --mode blocking-allowlist",
-  "cargo fmt --all -- --check",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "inspect-events-follow-incomplete-tail"
-status = "complete"
-proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
-spec = "docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md"
-plan = "plans/0.4.0/release-operator-visibility-and-survive-proof.md"
-issue = "109"
-linked_pr = "#331"
-completed = "2026-05-18"
-commands = [
-  "cargo test -p shipper-cli inspect_events --lib --locked",
-  "cargo test -p shipper-cli --test cli_e2e --locked",
-  "cargo xtask policy-report",
-  "cargo fmt --all -- --check",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "events-state-receipt-drift-checks"
-status = "complete"
-proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
-spec = "docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md"
-plan = "plans/0.4.0/release-operator-visibility-and-survive-proof.md"
-issue = "109"
-linked_pr = "#333"
-completed = "2026-05-18"
-commands = [
-  "cargo test -p shipper-core drift --lib --locked",
-  "cargo test -p shipper-core state --lib --locked",
-  "cargo xtask policy-report",
-  "cargo fmt --all -- --check",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "rebuild-state-from-events"
-status = "complete"
-proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
-spec = "docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md"
-plan = "plans/0.4.0/release-operator-visibility-and-survive-proof.md"
-issue = "109"
-linked_pr = "#310"
-completed = "2026-05-17"
-commands = [
-  "cargo test -p shipper-core rebuild --lib --locked",
-  "cargo xtask policy-report",
-  "cargo fmt --all -- --check",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "live-runner-interruption-rehearsal"
-status = "complete"
-proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
-spec = "docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md"
-plan = "plans/0.4.0/release-operator-visibility-and-survive-proof.md"
-issue = "109"
-linked_pr = "#335"
-completed = "2026-05-18"
-commands = [
-  "GitHub Actions Live runner interruption rehearsal run 26051581056",
-  "cargo test -p shipper-cli --test e2e_rehearse -- --nocapture",
-  "cargo xtask policy-report",
-  "cargo fmt --all -- --check",
-  "git diff --check",
-]
-artifacts = [
-  "https://github.com/EffortlessMetrics/shipper/actions/runs/26051581056",
-  "shipper-live-interruption-seed-26051581056",
-  "shipper-live-interruption-resume-26051581056",
-]
-
-[[work_item]]
-id = "support-tier-promotion"
-status = "complete"
-proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
-spec = "docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md"
-plan = "plans/0.4.0/release-operator-visibility-and-survive-proof.md"
-issue = "109"
-linked_pr = "#336"
+spec = "docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md"
+plan = "plans/0.4.0/release-auth-evidence-and-trusted-publishing.md"
+issue = "105"
+linked_pr = "#338"
 completed = "2026-05-18"
 commands = [
   "cargo xtask check-doc-contracts --mode advisory",
@@ -121,8 +34,45 @@ commands = [
   "cargo fmt --all -- --check",
   "git diff --check",
 ]
-artifacts = [
-  "https://github.com/EffortlessMetrics/shipper/actions/runs/26051581056",
-  "shipper-live-interruption-seed-26051581056",
-  "shipper-live-interruption-resume-26051581056",
+
+[[work_item]]
+id = "auth-mode-release-evidence"
+status = "active"
+proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
+spec = "docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md"
+plan = "plans/0.4.0/release-auth-evidence-and-trusted-publishing.md"
+issue = "105"
+commands = [
+  "cargo test -p shipper-core run_preflight_warns_when_token_auth_overrides_oidc --lib --locked",
+  "cargo test -p shipper-output-sanitizer --locked",
+  "cargo xtask policy-report",
+  "cargo fmt --all -- --check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "trusted-publishing-proof-artifact"
+status = "planned"
+proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
+spec = "docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md"
+plan = "plans/0.4.0/release-auth-evidence-and-trusted-publishing.md"
+issue = "105"
+commands = [
+  "release auth rehearsal or release-readiness workflow artifact",
+  "cargo xtask policy-report",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "auth-support-tier-promotion"
+status = "planned"
+proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
+spec = "docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md"
+plan = "plans/0.4.0/release-auth-evidence-and-trusted-publishing.md"
+issue = "105"
+commands = [
+  "cargo xtask check-doc-contracts --mode advisory",
+  "cargo xtask policy-report",
+  "cargo fmt --all -- --check",
+  "git diff --check",
 ]

--- a/docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
+++ b/docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
@@ -1,0 +1,161 @@
+# SHIPPER-SPEC-0006: Release Auth Evidence and Trusted Publishing
+
+Status: proposed
+Owner: EffortlessMetrics
+Created: 2026-05-18
+Milestone: 0.4.0
+Linked proposal: docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md
+Linked specs: docs/specs/SHIPPER-SPEC-0001-source-of-truth-stack.md; docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md; docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md
+Linked ADRs: docs/adr/SHIPPER-ADR-0001-claims-become-checkable-state.md
+Linked plan: plans/0.4.0/release-auth-evidence-and-trusted-publishing.md
+Linked issues: #96; #105; #109
+Linked PRs: #338
+Support-tier impact: docs/status/SUPPORT_TIERS.md
+Policy impact: policy ledgers remain authoritative for workflow, process, network, and file receipts
+Proof commands: cargo xtask check-doc-contracts --mode advisory; cargo xtask policy-report; cargo fmt --all -- --check
+
+## Problem
+
+Shipper's Harden competency is partially implemented: the release workflow can
+mint a crates.io token through Trusted Publishing, Doctor validates visible
+workflow prerequisites, preflight warns when token auth wins over an OIDC
+context, and token fallback warnings exist. The remaining product gap is not
+another generic auth warning. It is durable release evidence that tells an
+operator or agent which auth path was actually available, which path was used,
+whether a long-lived token fallback remained configured, and what proof exists.
+
+Trusted Publishing also has an external boundary Shipper must not overclaim:
+crates.io-side trusted-publisher registration is configured outside this repo.
+Shipper can validate visible GitHub workflow prerequisites and observe token
+exchange or publish outcomes, but it cannot truthfully claim every crate is
+registered until a rehearsal or release proves that fact.
+
+## Behavior Contract
+
+Release auth evidence must preserve these rules:
+
+- Doctor may validate visible workflow prerequisites: `id-token: write`, release
+  environment binding, `rust-lang/crates-io-auth-action@v1`, and explicit token
+  fallback.
+- Doctor must state that crates.io-side trusted-publisher registration is
+  external unless a rehearsal or release artifact proves it.
+- Preflight must keep OIDC context and token fallback warnings visible when
+  Cargo token auth wins.
+- Publish, resume, and receipt evidence must eventually expose the auth mode
+  Shipper used or observed without logging token values.
+- Long-lived token fallback must be explicit evidence, not hidden compatibility
+  behavior.
+- Unknown or externally unproven facts must be represented as unknown,
+  advisory, or planned, not omitted.
+- Support-tier claims may not call Trusted Publishing the default until proof
+  shows the release path prefers the short-lived token and records fallback
+  state accurately.
+- All evidence must pass through the existing output sanitizer and token values
+  must never appear in human output, JSON output, events, receipts, workflow
+  logs, or policy artifacts.
+- Token non-disclosure is enforced by the `shipper-output-sanitizer` crate and
+  by command-specific redaction tests for the evidence surfaces that carry auth
+  state.
+
+## Non-Goals
+
+- Implementing crates.io trusted-publisher registration.
+- Claiming crates.io-side registration can be proven from repo files alone.
+- Removing long-lived token fallback before release rehearsal proves the
+  short-lived-token path for every publishable crate.
+- Adding receipt signing, SBOM generation, or SLSA provenance in this spec.
+- Publishing crates, tagging a release, or changing release versions.
+- Changing registry reconciliation behavior.
+
+## Required Evidence
+
+Source-of-truth proof for this spec:
+
+- `cargo xtask check-doc-contracts --mode advisory`
+- `cargo xtask check-file-policy --mode blocking-allowlist`
+- `cargo xtask policy-report`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+Future implementation proof must cover:
+
+- Doctor output for complete, incomplete, and missing Trusted Publishing
+  workflow prerequisites
+- Preflight output when OIDC context exists but token auth is still used
+- Receipt or release evidence that records auth mode and fallback presence
+  without token values
+- Workflow proof that the Trusted Publishing token mint path ran successfully
+  or fell back explicitly
+- Support-tier promotion only after the proof command or artifact exists
+
+## Acceptance Examples
+
+- A release workflow has `id-token: write`, `environment: release`, the crates.io
+  auth action, and a fallback secret. Doctor reports the prerequisites as
+  visible and the fallback as explicit advisory evidence.
+- A workflow exposes only one GitHub OIDC request variable. Doctor reports a
+  blocked incomplete OIDC environment and suggests the next action.
+- Preflight runs with both OIDC context and `CARGO_REGISTRY_TOKEN`. It records
+  that token auth won and warns that fallback is still configured.
+- A release receipt records `auth_mode = "trusted_publishing"` or
+  `auth_mode = "token_fallback"` without storing the token.
+- A support-tier row remains advisory if the proof only validates repo-visible
+  workflow files and does not prove crates.io-side registration.
+
+## Test Mapping
+
+Expected implementation proof:
+
+- `cargo test -p shipper-cli --test cli_e2e doctor_command_detects_trusted_publishing_auth --locked`
+- `cargo test -p shipper-cli --test cli_e2e doctor_command_warns_when_token_fallback_is_configured --locked`
+- `cargo test -p shipper-core run_preflight_warns_when_token_auth_overrides_oidc --lib --locked`
+- `cargo test -p shipper-output-sanitizer --locked`
+- focused receipt/event tests for auth-mode evidence when that runtime field is
+  added
+- `cargo xtask check-doc-contracts --mode advisory`
+- `cargo xtask policy-report`
+
+## Implementation Mapping
+
+The implementation plan belongs in
+`plans/0.4.0/release-auth-evidence-and-trusted-publishing.md`.
+
+The lane should land in narrow PRs:
+
+- source-of-truth activation
+- auth mode and token fallback evidence in release artifacts
+- Trusted Publishing rehearsal/default proof
+- support-tier promotion only after proof exists
+- optional migration guide refresh if the proof changes operator steps
+
+## CI Proof
+
+CI should prove unit, integration, BDD, policy, and doc-contract gates for each
+implementation PR. A future Trusted Publishing default claim also requires a
+workflow artifact proving the short-lived-token path or an explicitly recorded
+fallback path; green CI without that artifact is not sufficient.
+
+## Promotion Rule
+
+Support-tier claims may move only when the named proof exists:
+
+- Doctor Trusted Publishing diagnostics remain advisory while they only inspect
+  visible repo/workflow state.
+- Long-lived token fallback warnings remain advisory until release receipts or
+  preflight artifacts record fallback state consistently.
+- Trusted Publishing default remains planned/advisory until release workflow
+  proof shows the short-lived-token path was used for every publishable crate in
+  a release-readiness rehearsal or dogfood release, fallback state is recorded,
+  and no crate required fallback for successful publication.
+- Until the crates.io-side registration proof question is resolved, any claim
+  that Shipper crates are registered for Trusted Publishing requires explicit
+  per-crate rehearsal or release evidence. The default claim must remain
+  planned/advisory without that artifact.
+
+## Open Questions
+
+- Should auth mode be represented as a new receipt field, a preflight proof
+  field, an event, or all three?
+- Which artifact format should record the per-crate crates.io-side registration
+  proof before dogfood release: release-readiness table, workflow artifact,
+  receipt field, or all three?

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -5,7 +5,7 @@ Owner: EffortlessMetrics
 Created: 2026-05-13
 Milestone: 0.4.0
 Linked proposal: docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md
-Linked specs: docs/specs/SHIPPER-SPEC-0001-source-of-truth-stack.md; docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md; docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md
+Linked specs: docs/specs/SHIPPER-SPEC-0001-source-of-truth-stack.md; docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md; docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md; docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
 Linked ADRs:
 Linked plan:
 Linked issues: #109, #195
@@ -55,9 +55,9 @@ make stronger claims than this file supports.
 | Resume JSON command envelope | stable | `cargo test -p shipper-cli --test bdd_resume given_pending_state_when_resume_json_then_stdout_is_command_envelope`; `shipper resume --format json` emits `shipper.resume.v1` with safety summary, package counts, artifact paths, and nested receipt evidence for the targeted registry | cli/integrations |
 | Resume after synthetic publish interruption | stable/internal | `cargo test -p shipper-cli --test e2e_rehearse -- --nocapture`; CI `BDD Tests` job; proves persisted `state.json`/`events.jsonl` let `shipper resume` complete without duplicate publishes against fake Cargo and a mock registry | engine |
 | Resume under live runner interruption | stable/internal | GitHub Actions `Live runner interruption rehearsal` run 26051581056 uploaded `shipper-live-interruption-seed-26051581056` and `shipper-live-interruption-resume-26051581056`; `cargo test -p shipper-cli --test e2e_rehearse -- --nocapture`; proves real runner artifact handoff and safe resume against fake Cargo/mock registry proof surfaces, not crates.io publication | engine |
-| Trusted Publishing prerequisite diagnostics | advisory | `shipper doctor`; `cargo test -p shipper-cli --test cli_e2e doctor_command_detects_trusted_publishing_auth`; validates visible GitHub OIDC env and release workflow prerequisites without claiming crates.io-side registration proof | release/ci |
-| Long-lived token fallback warnings | advisory | `cargo test -p shipper-core run_preflight_warns_when_token_auth_overrides_oidc --lib`; `cargo test -p shipper-cli --test cli_e2e doctor_command_warns_when_token_fallback_is_configured`; warns when Cargo token auth wins while Trusted Publishing signals or fallback config are present | release/ci |
-| Trusted Publishing default | planned/advisory | Future Trusted Publishing spec and #96 | release/ci |
+| Trusted Publishing prerequisite diagnostics | advisory | `docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md`; `shipper doctor`; `cargo test -p shipper-cli --test cli_e2e doctor_command_detects_trusted_publishing_auth`; inspects visible GitHub OIDC env and release workflow prerequisites without claiming crates.io-side registration proof | release/ci |
+| Long-lived token fallback warnings | advisory | `docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md`; `cargo test -p shipper-core run_preflight_warns_when_token_auth_overrides_oidc --lib`; `cargo test -p shipper-cli --test cli_e2e doctor_command_warns_when_token_fallback_is_configured`; warns when Cargo token auth wins while Trusted Publishing signals or fallback config are present | release/ci |
+| Trusted Publishing default | planned/advisory | `docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md`; `plans/0.4.0/release-auth-evidence-and-trusted-publishing.md`; promote only after release evidence proves the short-lived-token path is the normal path and token fallback state is explicit | release/ci |
 
 ## Rules
 

--- a/plans/0.4.0/release-auth-evidence-and-trusted-publishing.md
+++ b/plans/0.4.0/release-auth-evidence-and-trusted-publishing.md
@@ -1,0 +1,197 @@
+# Plan: Release Auth Evidence and Trusted Publishing
+
+Status: proposed
+Owner: EffortlessMetrics
+Created: 2026-05-18
+Milestone: 0.4.0
+Linked proposal: docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md
+Linked specs: docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
+Linked ADRs: docs/adr/SHIPPER-ADR-0001-claims-become-checkable-state.md
+Linked plan: plans/0.4.0/release-operator-visibility-and-survive-proof.md
+Linked issues: #96; #105; #109
+Linked PRs: #338
+Support-tier impact: docs/status/SUPPORT_TIERS.md
+Policy impact: no new policy exceptions
+Proof commands: cargo xtask check-doc-contracts --mode advisory; cargo xtask policy-report; cargo fmt --all -- --check
+
+## End State
+
+Shipper release auth is visible, bounded, and evidence-backed:
+
+- Doctor tells operators which Trusted Publishing prerequisites are visible and
+  which remain externally unproven.
+- Preflight, publish, resume, events, and receipts expose whether the release
+  used Trusted Publishing, token fallback, or an unknown/auth-missing path.
+- Long-lived token fallback remains available for bootstrap and incident
+  response, but is never hidden.
+- Support tiers distinguish advisory diagnostics from a proven Trusted
+  Publishing default.
+- No auth evidence stores token values.
+
+Existing foundations, including Doctor JSON diagnostics, preflight OIDC
+warnings, release workflow OIDC wiring, and token sanitizer coverage, are
+treated as already landed baseline.
+
+## PR Sequence
+
+### PR 1 - Source-of-truth activation
+
+Linked spec: docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
+Blocks: PR 2
+Blocked by:
+
+#### Goal
+
+Define the behavior contract, implementation plan, active goal, and
+support-tier guardrails for release auth evidence and Trusted Publishing.
+
+#### Production Delta
+
+No product runtime behavior change.
+
+#### Non-Goals
+
+Runtime behavior, release workflow changes, support-tier promotion, crates.io
+publishing, release tagging, receipt signing, and SBOM generation.
+
+#### Acceptance
+
+- Spec and plan exist and link to each other.
+- `.shipper-meta/goals/active.toml` points to release auth evidence as the
+  current lane.
+- Support tiers remain advisory/planned and do not claim Trusted Publishing is
+  the default.
+
+#### Proof Commands
+
+- `python -c "import pathlib,tomllib; tomllib.loads(pathlib.Path('.shipper-meta/goals/active.toml').read_text()); print('active goal TOML parses')"`
+- `cargo xtask check-doc-contracts --mode advisory`
+- `cargo xtask check-file-policy --mode blocking-allowlist`
+- `cargo xtask policy-report`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+#### Rollback
+
+Revert this spec, plan, active goal, and support-tier references if the auth
+lane is superseded before runtime work depends on it.
+
+### PR 2 - Auth mode evidence
+
+Linked spec: docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
+Blocks: PR 3
+Blocked by: PR 1
+
+#### Goal
+
+Record auth mode and token fallback presence in release evidence without
+exposing token values.
+
+#### Production Delta
+
+Preflight, publish/resume evidence, events, or receipts only, depending on the
+smallest existing data path that can truthfully carry the fact.
+
+#### Non-Goals
+
+Trusted Publishing default promotion, crates.io-side registration proof,
+release workflow rewrites, and receipt signing.
+
+#### Acceptance
+
+- Evidence distinguishes Trusted Publishing, token fallback, missing auth, and
+  unknown auth paths.
+- Token fallback remains visible when it is configured or used.
+- Token values never appear in human output, JSON output, events, receipts, or
+  snapshots.
+- Unknown crates.io-side registration remains explicit.
+
+#### Proof Commands
+
+- `cargo test -p shipper-core run_preflight_warns_when_token_auth_overrides_oidc --lib --locked`
+- `cargo test -p shipper-output-sanitizer --locked`
+- focused receipt/event tests for auth-mode evidence
+- `cargo xtask policy-report`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+#### Rollback
+
+Remove auth-mode evidence fields if they overclaim or leak sensitive values.
+
+### PR 3 - Trusted Publishing proof artifact
+
+Linked spec: docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
+Blocks: PR 4
+Blocked by: PR 2
+
+#### Goal
+
+Produce a workflow or release-readiness artifact that proves whether the
+Trusted Publishing token mint path works for Shipper's release environment and
+whether fallback was used.
+
+#### Production Delta
+
+Release workflow/rehearsal evidence only.
+
+#### Non-Goals
+
+Publishing crates unless this runs as part of an approved release proof,
+removing fallback, or claiming crates.io-side registration for crates that were
+not rehearsed.
+
+#### Acceptance
+
+- Artifact records whether `rust-lang/crates-io-auth-action@v1` succeeded.
+- Artifact records whether token fallback was used.
+- Artifact names the workflow, run ID, commit, and environment.
+- Failed Trusted Publishing registration remains an actionable setup gap, not a
+  generic auth failure.
+
+#### Proof Commands
+
+- release auth rehearsal or release-readiness workflow artifact
+- `cargo xtask policy-report`
+- `git diff --check`
+
+#### Rollback
+
+Demote any Trusted Publishing claim if the artifact is missing or proves only
+fallback behavior.
+
+### PR 4 - Support-tier promotion
+
+Linked spec: docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
+Blocks:
+Blocked by: PR 3
+
+#### Goal
+
+Promote only claims proven by auth-mode evidence and workflow artifacts.
+
+#### Production Delta
+
+Documentation/status only.
+
+#### Non-Goals
+
+Runtime changes and release workflow changes.
+
+#### Acceptance
+
+- Support tiers name exact proof commands and artifacts.
+- Trusted Publishing default remains planned/advisory unless short-lived-token
+  use is proven as the normal path.
+- README and product claims do not exceed proven evidence.
+
+#### Proof Commands
+
+- `cargo xtask check-doc-contracts --mode advisory`
+- `cargo xtask policy-report`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+#### Rollback
+
+Demote any claim whose proof artifact is missing or weak.


### PR DESCRIPTION
Summary:
- Add SHIPPER-SPEC-0006 for release auth evidence and Trusted Publishing guardrails.
- Add the 0.4.0 implementation plan for auth-mode evidence, proof artifacts, and support-tier promotion.
- Move .shipper-meta/goals/active.toml to the next active lane and keep Trusted Publishing default planned/advisory.

Validation:
- python active goal TOML parse
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask policy-report
- cargo fmt --all -- --check
- git diff --check