### PR TITLE
feat(evidence): record release auth evidence

### DIFF
--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -3597,6 +3597,7 @@ fn event_type_name(event_type: &EventType) -> &'static str {
         EventType::PlanCreated { .. } => "plan_created",
         EventType::ExecutionStarted => "execution_started",
         EventType::ExecutionFinished { .. } => "execution_finished",
+        EventType::AuthEvidenceRecorded { .. } => "auth_evidence_recorded",
         EventType::PackageStarted { .. } => "package_started",
         EventType::PackageAttempted { .. } => "package_attempted",
         EventType::PackageOutput { .. } => "package_output",

--- a/crates/shipper-core/src/engine/fix_forward.rs
+++ b/crates/shipper-core/src/engine/fix_forward.rs
@@ -224,6 +224,7 @@ mod tests {
                 os: "test".into(),
                 arch: "x86_64".into(),
             },
+            auth_evidence: None,
         }
     }
 

--- a/crates/shipper-core/src/engine/mod.rs
+++ b/crates/shipper-core/src/engine/mod.rs
@@ -325,6 +325,7 @@ pub fn run_publish(
         _lock,
         git_context,
         environment,
+        auth_evidence,
         registry: reg,
         events_path,
         mut event_log,
@@ -355,6 +356,7 @@ pub fn run_publish(
             run_started,
             git_context,
             environment,
+            auth_evidence,
         );
     }
 
@@ -1127,6 +1129,7 @@ pub fn run_publish(
         run_started,
         git_context,
         environment,
+        auth_evidence,
     )
 }
 
@@ -1879,7 +1882,7 @@ mod tests {
 
     use super::*;
     use crate::plan::PlannedWorkspace;
-    use crate::types::{AuthType, PlannedPackage, Registry, ReleasePlan};
+    use crate::types::{AuthEvidenceMode, AuthType, PlannedPackage, Registry, ReleasePlan};
 
     #[derive(Default)]
     struct CollectingReporter {
@@ -5077,7 +5080,21 @@ mod tests {
         let bin = td.path().join("bin");
         write_fake_tools(&bin);
         let mut env_vars = fake_program_env_vars(&bin);
-        env_vars.extend([("SHIPPER_CARGO_EXIT", Some("0".to_string()))]);
+        env_vars.extend([
+            ("SHIPPER_CARGO_EXIT", Some("0".to_string())),
+            (
+                "CARGO_REGISTRY_TOKEN",
+                Some("release-secret-token".to_string()),
+            ),
+            (
+                "ACTIONS_ID_TOKEN_REQUEST_URL",
+                Some("https://example.invalid/oidc".to_string()),
+            ),
+            (
+                "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+                Some("oidc-request-token".to_string()),
+            ),
+        ]);
         temp_env::with_vars(env_vars, || {
             let server = spawn_registry_server(
                 std::collections::BTreeMap::from([(
@@ -5101,6 +5118,22 @@ mod tests {
             assert!(!receipt.packages[0].evidence.attempts.is_empty());
             assert_eq!(receipt.packages[0].evidence.attempts[0].attempt_number, 1);
             assert_eq!(receipt.packages[0].evidence.attempts[0].exit_code, 0);
+            let auth_evidence = receipt
+                .auth_evidence
+                .as_ref()
+                .expect("receipt records auth evidence");
+            assert_eq!(auth_evidence.schema_version, "shipper.auth_evidence.v1");
+            assert_eq!(auth_evidence.registry, "crates-io");
+            assert_eq!(
+                auth_evidence.auth_mode,
+                AuthEvidenceMode::CargoTokenWithOidcContext
+            );
+            assert!(auth_evidence.token_detected);
+            assert!(auth_evidence.oidc_request_url_present);
+            assert!(auth_evidence.oidc_request_token_present);
+            let receipt_json = serde_json::to_string(&receipt).expect("serialize receipt");
+            assert!(!receipt_json.contains("release-secret-token"));
+            assert!(!receipt_json.contains("oidc-request-token"));
             let state = state::load_state(&td.path().join(".shipper"))
                 .expect("load state")
                 .expect("state exists");
@@ -5113,6 +5146,15 @@ mod tests {
             assert!(state.attempt_history[0].next_attempt_at.is_none());
             let events = events::EventLog::read_from_file(&td.path().join(".shipper/events.jsonl"))
                 .expect("read events");
+            let event_auth_evidence = events
+                .all_events()
+                .iter()
+                .find_map(|event| match &event.event_type {
+                    EventType::AuthEvidenceRecorded { evidence } => Some(evidence),
+                    _ => None,
+                })
+                .expect("auth evidence event");
+            assert_eq!(event_auth_evidence, auth_evidence);
             assert!(
                 events
                     .all_events()
@@ -5935,6 +5977,7 @@ mod tests {
             event_log_path: PathBuf::from(".shipper/events.jsonl"),
             git_context: None,
             environment: environment::collect_environment_fingerprint(),
+            auth_evidence: None,
         };
 
         let json = serde_json::to_string_pretty(&receipt).expect("serialize");

--- a/crates/shipper-core/src/engine/plan_yank.rs
+++ b/crates/shipper-core/src/engine/plan_yank.rs
@@ -293,6 +293,7 @@ mod tests {
                 os: "test".into(),
                 arch: "x86_64".into(),
             },
+            auth_evidence: None,
         }
     }
 

--- a/crates/shipper-core/src/engine/publish/bootstrap.rs
+++ b/crates/shipper-core/src/engine/publish/bootstrap.rs
@@ -14,8 +14,8 @@ use crate::runtime::execution::{pkg_key, resolve_state_dir};
 use crate::state::events;
 use crate::state::execution_state as state;
 use crate::types::{
-    EnvironmentFingerprint, EventType, ExecutionState, GitContext, PackageProgress, PackageState,
-    PublishEvent, RuntimeOptions,
+    AuthEvidence, EnvironmentFingerprint, EventType, ExecutionState, GitContext, PackageProgress,
+    PackageState, PublishEvent, RuntimeOptions,
 };
 use crate::webhook::{self, WebhookEvent};
 
@@ -24,6 +24,7 @@ pub(in crate::engine) struct PublishBootstrap {
     pub(in crate::engine) _lock: lock::LockFile,
     pub(in crate::engine) git_context: Option<GitContext>,
     pub(in crate::engine) environment: EnvironmentFingerprint,
+    pub(in crate::engine) auth_evidence: AuthEvidence,
     pub(in crate::engine) registry: RegistryClient,
     pub(in crate::engine) events_path: PathBuf,
     pub(in crate::engine) event_log: events::EventLog,
@@ -61,6 +62,7 @@ pub(in crate::engine) fn prepare_publish_run(
     // Collect git context and environment fingerprint at start of execution.
     let git_context = git::collect_git_context();
     let environment = environment::collect_environment_fingerprint();
+    let auth_evidence = crate::ops::auth::collect_auth_evidence(&ws.plan.registry.name);
 
     if !opts.allow_dirty {
         git::ensure_git_clean(workspace_root)?;
@@ -74,7 +76,14 @@ pub(in crate::engine) fn prepare_publish_run(
     reporter.info(&format!("state dir: {}", state_dir.as_path().display()));
 
     let run_started = Utc::now();
-    record_execution_start(ws, opts, &events_path, &mut event_log, run_started)?;
+    record_execution_start(
+        ws,
+        opts,
+        &events_path,
+        &mut event_log,
+        run_started,
+        &auth_evidence,
+    )?;
     ensure_plan_package_entries(ws, &state_dir, &mut state)?;
 
     Ok(PublishBootstrap {
@@ -82,6 +91,7 @@ pub(in crate::engine) fn prepare_publish_run(
         _lock: lock,
         git_context,
         environment,
+        auth_evidence,
         registry,
         events_path,
         event_log,
@@ -137,6 +147,7 @@ fn record_execution_start(
     events_path: &Path,
     event_log: &mut events::EventLog,
     run_started: DateTime<Utc>,
+    auth_evidence: &AuthEvidence,
 ) -> Result<()> {
     event_log.record(PublishEvent {
         timestamp: run_started,
@@ -158,6 +169,13 @@ fn record_execution_start(
         event_type: EventType::PlanCreated {
             plan_id: ws.plan.plan_id.clone(),
             package_count: ws.plan.packages.len(),
+        },
+        package: "all".to_string(),
+    });
+    event_log.record(PublishEvent {
+        timestamp: run_started,
+        event_type: EventType::AuthEvidenceRecorded {
+            evidence: auth_evidence.clone(),
         },
         package: "all".to_string(),
     });

--- a/crates/shipper-core/src/engine/publish/finalize.rs
+++ b/crates/shipper-core/src/engine/publish/finalize.rs
@@ -8,8 +8,8 @@ use crate::plan::PlannedWorkspace;
 use crate::state::events;
 use crate::state::execution_state as state;
 use crate::types::{
-    EnvironmentFingerprint, EventType, ExecutionResult, ExecutionState, GitContext, PackageReceipt,
-    PackageState, PublishEvent, Receipt, RuntimeOptions,
+    AuthEvidence, EnvironmentFingerprint, EventType, ExecutionResult, ExecutionState, GitContext,
+    PackageReceipt, PackageState, PublishEvent, Receipt, RuntimeOptions,
 };
 use crate::webhook::{self, WebhookEvent};
 
@@ -45,6 +45,7 @@ pub(in crate::engine) fn finish_sequential_run(
     run_started: DateTime<Utc>,
     git_context: Option<GitContext>,
     environment: EnvironmentFingerprint,
+    auth_evidence: AuthEvidence,
 ) -> Result<Receipt> {
     let exec_result = sequential_execution_result(&receipts);
     event_log.record(PublishEvent {
@@ -66,6 +67,7 @@ pub(in crate::engine) fn finish_sequential_run(
         run_started,
         git_context,
         environment,
+        auth_evidence,
         events_path,
     )
 }
@@ -82,6 +84,7 @@ pub(in crate::engine) fn finish_parallel_run(
     run_started: DateTime<Utc>,
     git_context: Option<GitContext>,
     environment: EnvironmentFingerprint,
+    auth_evidence: AuthEvidence,
 ) -> Result<Receipt> {
     let exec_result = parallel_execution_result(&receipts);
     event_log.record(PublishEvent {
@@ -103,6 +106,7 @@ pub(in crate::engine) fn finish_parallel_run(
         run_started,
         git_context,
         environment,
+        auth_evidence,
         events_path,
     )
 }
@@ -116,6 +120,7 @@ fn write_receipt(
     run_started: DateTime<Utc>,
     git_context: Option<GitContext>,
     environment: EnvironmentFingerprint,
+    auth_evidence: AuthEvidence,
     events_path: &Path,
 ) -> Result<Receipt> {
     let receipt = Receipt {
@@ -128,6 +133,7 @@ fn write_receipt(
         event_log_path: PathBuf::from(state_dir).join("events.jsonl"),
         git_context,
         environment,
+        auth_evidence: Some(auth_evidence),
     };
 
     let reconciliation_report = crate::state::reconciliation::write_report_from_events(

--- a/crates/shipper-core/src/ops/auth/mod.rs
+++ b/crates/shipper-core/src/ops/auth/mod.rs
@@ -35,7 +35,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
-use crate::types::AuthType;
+use crate::types::{AuthEvidence, AuthEvidenceMode, AuthType};
 
 pub(crate) mod credentials;
 pub(crate) mod oidc;
@@ -118,6 +118,50 @@ pub(crate) fn detect_auth_type_from_token(token: Option<&str>) -> Option<AuthTyp
         (true, true) => Some(AuthType::TrustedPublishing),
         (true, false) | (false, true) => Some(AuthType::Unknown),
         (false, false) => None,
+    }
+}
+
+/// Collect non-secret authentication evidence for release artifacts.
+///
+/// This is best-effort evidence: it must not make publish fail merely because
+/// diagnostic token lookup could not read a local Cargo credentials file.
+pub fn collect_auth_evidence(registry_name: &str) -> AuthEvidence {
+    let token_result = resolve_token(registry_name);
+    let token_resolution_failed = token_result.is_err();
+    let token_detected = token_result
+        .as_ref()
+        .ok()
+        .and_then(|token| token.as_deref())
+        .map(str::trim)
+        .map(|token| !token.is_empty())
+        .unwrap_or(false);
+
+    let oidc_request_url_present = env::var_os("ACTIONS_ID_TOKEN_REQUEST_URL").is_some();
+    let oidc_request_token_present = env::var_os("ACTIONS_ID_TOKEN_REQUEST_TOKEN").is_some();
+
+    let auth_mode = if token_resolution_failed {
+        AuthEvidenceMode::Unknown
+    } else {
+        match (
+            token_detected,
+            oidc_request_url_present,
+            oidc_request_token_present,
+        ) {
+            (true, true, true) => AuthEvidenceMode::CargoTokenWithOidcContext,
+            (true, _, _) => AuthEvidenceMode::CargoToken,
+            (false, true, true) => AuthEvidenceMode::TrustedPublishingContext,
+            (false, true, false) | (false, false, true) => AuthEvidenceMode::PartialOidcContext,
+            (false, false, false) => AuthEvidenceMode::Missing,
+        }
+    };
+
+    AuthEvidence {
+        schema_version: "shipper.auth_evidence.v1".to_string(),
+        registry: registry_name.to_string(),
+        auth_mode,
+        token_detected,
+        oidc_request_url_present,
+        oidc_request_token_present,
     }
 }
 
@@ -321,6 +365,107 @@ token = "token-dot"
             || {
                 let auth = detect_auth_type("crates-io").expect("detect");
                 assert_eq!(auth, Some(AuthType::Unknown));
+            },
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn collect_auth_evidence_reports_token_only_mode() {
+        let td = tempdir().expect("tempdir");
+        temp_env::with_vars(
+            [
+                ("CARGO_HOME", Some(td.path().to_str().expect("utf8"))),
+                ("CARGO_REGISTRY_TOKEN", Some("env-token")),
+                ("ACTIONS_ID_TOKEN_REQUEST_URL", None::<&str>),
+                ("ACTIONS_ID_TOKEN_REQUEST_TOKEN", None::<&str>),
+            ],
+            || {
+                let evidence = collect_auth_evidence("crates-io");
+                assert_eq!(evidence.schema_version, "shipper.auth_evidence.v1");
+                assert_eq!(evidence.registry, "crates-io");
+                assert_eq!(evidence.auth_mode, AuthEvidenceMode::CargoToken);
+                assert!(evidence.token_detected);
+                assert!(!evidence.oidc_request_url_present);
+                assert!(!evidence.oidc_request_token_present);
+            },
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn collect_auth_evidence_reports_oidc_only_context() {
+        let td = tempdir().expect("tempdir");
+        temp_env::with_vars(
+            [
+                ("CARGO_HOME", Some(td.path().to_str().expect("utf8"))),
+                ("CARGO_REGISTRY_TOKEN", None::<&str>),
+                (
+                    "ACTIONS_ID_TOKEN_REQUEST_URL",
+                    Some("https://example.invalid/oidc"),
+                ),
+                ("ACTIONS_ID_TOKEN_REQUEST_TOKEN", Some("oidc-token")),
+            ],
+            || {
+                let evidence = collect_auth_evidence("crates-io");
+                assert_eq!(
+                    evidence.auth_mode,
+                    AuthEvidenceMode::TrustedPublishingContext
+                );
+                assert!(!evidence.token_detected);
+                assert!(evidence.oidc_request_url_present);
+                assert!(evidence.oidc_request_token_present);
+            },
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn collect_auth_evidence_reports_token_with_oidc_context_without_claiming_provenance() {
+        let td = tempdir().expect("tempdir");
+        temp_env::with_vars(
+            [
+                ("CARGO_HOME", Some(td.path().to_str().expect("utf8"))),
+                ("CARGO_REGISTRY_TOKEN", Some("env-token")),
+                (
+                    "ACTIONS_ID_TOKEN_REQUEST_URL",
+                    Some("https://example.invalid/oidc"),
+                ),
+                ("ACTIONS_ID_TOKEN_REQUEST_TOKEN", Some("oidc-token")),
+            ],
+            || {
+                let evidence = collect_auth_evidence("crates-io");
+                assert_eq!(
+                    evidence.auth_mode,
+                    AuthEvidenceMode::CargoTokenWithOidcContext
+                );
+                assert!(evidence.token_detected);
+                assert!(evidence.oidc_request_url_present);
+                assert!(evidence.oidc_request_token_present);
+            },
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn collect_auth_evidence_reports_partial_oidc_context() {
+        let td = tempdir().expect("tempdir");
+        temp_env::with_vars(
+            [
+                ("CARGO_HOME", Some(td.path().to_str().expect("utf8"))),
+                ("CARGO_REGISTRY_TOKEN", None::<&str>),
+                (
+                    "ACTIONS_ID_TOKEN_REQUEST_URL",
+                    Some("https://example.invalid/oidc"),
+                ),
+                ("ACTIONS_ID_TOKEN_REQUEST_TOKEN", None::<&str>),
+            ],
+            || {
+                let evidence = collect_auth_evidence("crates-io");
+                assert_eq!(evidence.auth_mode, AuthEvidenceMode::PartialOidcContext);
+                assert!(!evidence.token_detected);
+                assert!(evidence.oidc_request_url_present);
+                assert!(!evidence.oidc_request_token_present);
             },
         );
     }

--- a/crates/shipper-core/src/state/consistency.rs
+++ b/crates/shipper-core/src/state/consistency.rs
@@ -408,6 +408,7 @@ mod tests {
                 os: "test".to_string(),
                 arch: "test".to_string(),
             },
+            auth_evidence: None,
         }
     }
 

--- a/crates/shipper-core/src/state/events/proptests.rs
+++ b/crates/shipper-core/src/state/events/proptests.rs
@@ -5,7 +5,10 @@
 use super::*;
 use chrono::Utc;
 use proptest::prelude::*;
-use shipper_types::{ErrorClass, EventType, ExecutionResult, Finishability, ReadinessMethod};
+use shipper_types::{
+    AuthEvidence, AuthEvidenceMode, ErrorClass, EventType, ExecutionResult, Finishability,
+    ReadinessMethod,
+};
 use tempfile::tempdir;
 
 fn arb_error_class() -> impl Strategy<Value = ErrorClass> {
@@ -40,6 +43,43 @@ fn arb_finishability() -> impl Strategy<Value = Finishability> {
     ]
 }
 
+fn arb_auth_evidence_mode() -> impl Strategy<Value = AuthEvidenceMode> {
+    prop_oneof![
+        Just(AuthEvidenceMode::CargoToken),
+        Just(AuthEvidenceMode::TrustedPublishingContext),
+        Just(AuthEvidenceMode::CargoTokenWithOidcContext),
+        Just(AuthEvidenceMode::PartialOidcContext),
+        Just(AuthEvidenceMode::Missing),
+        Just(AuthEvidenceMode::Unknown),
+    ]
+}
+
+fn arb_auth_evidence() -> impl Strategy<Value = AuthEvidence> {
+    (
+        ".*",
+        arb_auth_evidence_mode(),
+        any::<bool>(),
+        any::<bool>(),
+        any::<bool>(),
+    )
+        .prop_map(
+            |(
+                registry,
+                auth_mode,
+                token_detected,
+                oidc_request_url_present,
+                oidc_request_token_present,
+            )| AuthEvidence {
+                schema_version: "shipper.auth_evidence.v1".to_string(),
+                registry,
+                auth_mode,
+                token_detected,
+                oidc_request_url_present,
+                oidc_request_token_present,
+            },
+        )
+}
+
 fn arb_event_type() -> impl Strategy<Value = EventType> {
     prop_oneof![
         (".*", 0..100usize).prop_map(|(id, count)| EventType::PlanCreated {
@@ -48,6 +88,7 @@ fn arb_event_type() -> impl Strategy<Value = EventType> {
         }),
         Just(EventType::ExecutionStarted),
         arb_execution_result().prop_map(|result| EventType::ExecutionFinished { result }),
+        arb_auth_evidence().prop_map(|evidence| EventType::AuthEvidenceRecorded { evidence }),
         (".*", ".*").prop_map(|(name, version)| EventType::PackageStarted { name, version }),
         (1..100u32, ".*")
             .prop_map(|(attempt, command)| EventType::PackageAttempted { attempt, command }),

--- a/crates/shipper-core/src/state/events/tests.rs
+++ b/crates/shipper-core/src/state/events/tests.rs
@@ -4,7 +4,10 @@
 
 use super::*;
 use chrono::{DateTime, Utc};
-use shipper_types::{ErrorClass, EventType, ExecutionResult, Finishability, ReadinessMethod};
+use shipper_types::{
+    AuthEvidence, AuthEvidenceMode, ErrorClass, EventType, ExecutionResult, Finishability,
+    ReadinessMethod,
+};
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -421,6 +424,20 @@ fn event_types_serialize_correctly() {
             timestamp: Utc::now(),
             event_type: EventType::ExecutionFinished {
                 result: ExecutionResult::Success,
+            },
+            package: "all".to_string(),
+        },
+        PublishEvent {
+            timestamp: Utc::now(),
+            event_type: EventType::AuthEvidenceRecorded {
+                evidence: AuthEvidence {
+                    schema_version: "shipper.auth_evidence.v1".to_string(),
+                    registry: "crates-io".to_string(),
+                    auth_mode: AuthEvidenceMode::CargoTokenWithOidcContext,
+                    token_detected: true,
+                    oidc_request_url_present: true,
+                    oidc_request_token_present: true,
+                },
             },
             package: "all".to_string(),
         },

--- a/crates/shipper-core/src/state/execution_state/tests.rs
+++ b/crates/shipper-core/src/state/execution_state/tests.rs
@@ -69,6 +69,7 @@ fn sample_receipt() -> Receipt {
             os: "linux".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     }
 }
 
@@ -1011,6 +1012,7 @@ fn deterministic_receipt() -> Receipt {
             os: "linux".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     }
 }
 
@@ -1240,6 +1242,7 @@ fn snapshot_receipt_all_failed() {
             os: "linux".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     };
 
     let json = serde_json::to_string_pretty(&receipt).expect("serialize");
@@ -1356,6 +1359,7 @@ mod proptests {
                     os: "linux".to_string(),
                     arch: "x86_64".to_string(),
                 },
+                auth_evidence: None,
             })
     }
 
@@ -1694,6 +1698,7 @@ fn receipt_all_fields_individually_verified_after_roundtrip() {
             os: "windows".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     };
 
     write_receipt(&dir, &receipt).expect("write");
@@ -2178,6 +2183,7 @@ fn snapshot_receipt_with_git_context() {
             os: "linux".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     };
 
     let json = serde_json::to_string_pretty(&receipt).expect("serialize");
@@ -2244,6 +2250,7 @@ fn snapshot_receipt_with_evidence() {
             os: "linux".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     };
 
     let json = serde_json::to_string_pretty(&receipt).expect("serialize");
@@ -2454,6 +2461,7 @@ mod proptests_extended {
                     os: "test".to_string(),
                     arch: "x86_64".to_string(),
                 },
+                auth_evidence: None,
             };
 
             write_receipt(&dir, &receipt).expect("write");

--- a/crates/shipper-core/src/state/store/snapshot_tests.rs
+++ b/crates/shipper-core/src/state/store/snapshot_tests.rs
@@ -190,6 +190,7 @@ fn snapshot_receipt_minimal() {
             os: "linux".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     };
 
     let json = serde_json::to_string_pretty(&receipt).expect("serialize");
@@ -235,6 +236,7 @@ fn snapshot_receipt_with_git_context() {
             os: "linux".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     };
 
     let json = serde_json::to_string_pretty(&receipt).expect("serialize");
@@ -314,6 +316,7 @@ fn snapshot_receipt_mixed_outcomes() {
             os: "macos".to_string(),
             arch: "aarch64".to_string(),
         },
+        auth_evidence: None,
     };
 
     let json = serde_json::to_string_pretty(&receipt).expect("serialize");
@@ -405,6 +408,7 @@ fn snapshot_receipt_persisted_json() {
             os: "linux".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     };
 
     store.save_receipt(&receipt).expect("save");
@@ -708,6 +712,7 @@ fn snapshot_receipt_all_published() {
             os: "linux".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     };
 
     let json = serde_json::to_string_pretty(&receipt).expect("serialize");
@@ -771,6 +776,7 @@ fn snapshot_receipt_some_failed() {
             os: "linux".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     };
 
     let json = serde_json::to_string_pretty(&receipt).expect("serialize");
@@ -838,6 +844,7 @@ fn snapshot_directory_layout_after_full_save() {
             os: "linux".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     };
     store.save_receipt(&receipt).expect("save receipt");
 

--- a/crates/shipper-core/src/state/store/tests.rs
+++ b/crates/shipper-core/src/state/store/tests.rs
@@ -65,6 +65,7 @@ fn sample_receipt() -> Receipt {
             os: "linux".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     }
 }
 
@@ -898,6 +899,7 @@ mod proptests {
                     os: "linux".to_string(),
                     arch: "x86_64".to_string(),
                 },
+                auth_evidence: None,
             };
 
             store.save_receipt(&receipt).expect("save receipt");
@@ -957,6 +959,7 @@ mod proptests {
                     os: "test".to_string(),
                     arch: "test".to_string(),
                 },
+                auth_evidence: None,
             };
 
             let json = serde_json::to_string(&receipt).expect("serialize");
@@ -1246,6 +1249,7 @@ fn file_store_receipt_all_published() {
             os: "linux".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     };
 
     store.save_receipt(&receipt).expect("save");
@@ -1319,6 +1323,7 @@ fn file_store_receipt_some_failed() {
             os: "linux".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     };
 
     store.save_receipt(&receipt).expect("save");
@@ -1577,6 +1582,7 @@ fn file_store_receipt_empty_strings_roundtrip() {
             os: String::new(),
             arch: String::new(),
         },
+        auth_evidence: None,
     };
 
     store.save_receipt(&receipt).expect("save");

--- a/crates/shipper-core/src/stress_tests.rs
+++ b/crates/shipper-core/src/stress_tests.rs
@@ -233,6 +233,7 @@ mod tests {
                 os: std::env::consts::OS.to_string(),
                 arch: std::env::consts::ARCH.to_string(),
             },
+            auth_evidence: None,
         };
 
         // Serialize large receipt

--- a/crates/shipper-types/src/lib.rs
+++ b/crates/shipper-types/src/lib.rs
@@ -1530,6 +1530,8 @@ pub struct Receipt {
     #[serde(default)]
     pub git_context: Option<GitContext>,
     pub environment: EnvironmentFingerprint,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_evidence: Option<AuthEvidence>,
 }
 
 // Event types for evidence-first receipts
@@ -1616,6 +1618,9 @@ pub enum EventType {
     ExecutionStarted,
     ExecutionFinished {
         result: ExecutionResult,
+    },
+    AuthEvidenceRecorded {
+        evidence: AuthEvidence,
     },
 
     // Package events
@@ -1871,6 +1876,35 @@ pub enum ExecutionResult {
 pub enum AuthType {
     Token,
     TrustedPublishing,
+    Unknown,
+}
+
+/// Release-run authentication evidence observed by Shipper.
+///
+/// This record deliberately captures only non-secret runtime facts. In
+/// particular, `Cargo` receives a `CARGO_REGISTRY_TOKEN` for both a
+/// long-lived token fallback and a token minted by a Trusted Publishing
+/// workflow action, so Shipper reports the observed auth context without
+/// claiming token provenance it cannot prove from environment state alone.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuthEvidence {
+    pub schema_version: String,
+    pub registry: String,
+    pub auth_mode: AuthEvidenceMode,
+    pub token_detected: bool,
+    pub oidc_request_url_present: bool,
+    pub oidc_request_token_present: bool,
+}
+
+/// Non-secret authentication mode observed for a publish or resume run.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthEvidenceMode {
+    CargoToken,
+    TrustedPublishingContext,
+    CargoTokenWithOidcContext,
+    PartialOidcContext,
+    Missing,
     Unknown,
 }
 
@@ -2492,6 +2526,7 @@ mod tests {
                 os: "linux".to_string(),
                 arch: "x86_64".to_string(),
             },
+            auth_evidence: None,
         };
         let json = serde_json::to_string(&receipt).unwrap();
         let parsed: Receipt = serde_json::from_str(&json).unwrap();
@@ -2520,6 +2555,7 @@ mod tests {
                 os: "linux".to_string(),
                 arch: "x86_64".to_string(),
             },
+            auth_evidence: None,
         };
         let json = serde_json::to_string(&receipt).unwrap();
         let parsed: Receipt = serde_json::from_str(&json).unwrap();
@@ -2580,6 +2616,7 @@ mod tests {
                 os: "linux".to_string(),
                 arch: "x86_64".to_string(),
             },
+            auth_evidence: None,
         };
         let json = serde_json::to_string(&receipt).unwrap();
         let parsed: Receipt = serde_json::from_str(&json).unwrap();
@@ -3309,6 +3346,7 @@ mod tests {
                     os: "linux".to_string(),
                     arch: "x86_64".to_string(),
                 },
+                auth_evidence: None,
             };
             insta::assert_yaml_snapshot!(receipt);
         }
@@ -3604,6 +3642,7 @@ mod tests {
                     os: "linux".to_string(),
                     arch: "x86_64".to_string(),
                 },
+                auth_evidence: None,
             };
             insta::assert_yaml_snapshot!(receipt);
         }
@@ -3642,6 +3681,7 @@ mod tests {
                     os: "windows".to_string(),
                     arch: "aarch64".to_string(),
                 },
+                auth_evidence: None,
             };
             insta::assert_yaml_snapshot!(receipt);
         }
@@ -3716,6 +3756,7 @@ mod tests {
                     os: "macos".to_string(),
                     arch: "aarch64".to_string(),
                 },
+                auth_evidence: None,
             };
             insta::assert_yaml_snapshot!(receipt);
         }
@@ -4783,6 +4824,7 @@ mod tests {
                         os: "linux".to_string(),
                         arch: "x86_64".to_string(),
                     },
+                    auth_evidence: None,
                 };
                 let json = serde_json::to_string(&receipt).unwrap();
                 let parsed: Receipt = serde_json::from_str(&json).unwrap();
@@ -5064,6 +5106,7 @@ mod tests {
                     os: "test".to_string(),
                     arch: "test".to_string(),
                 },
+                auth_evidence: None,
             }
         }
 
@@ -5419,6 +5462,7 @@ mod tests {
                         os: os_name.clone(),
                         arch: "x86_64".to_string(),
                     },
+                    auth_evidence: None,
                 };
                 let json = serde_json::to_string(&receipt).unwrap();
                 let parsed: Receipt = serde_json::from_str(&json).unwrap();
@@ -5932,6 +5976,7 @@ mod tests {
                         os: "linux".to_string(),
                         arch: "x86_64".to_string(),
                     },
+                    auth_evidence: None,
                 };
 
                 // Every planned package appears in the receipt

--- a/crates/shipper/tests/cross_crate_integration.rs
+++ b/crates/shipper/tests/cross_crate_integration.rs
@@ -135,6 +135,7 @@ fn sample_receipt(plan_id: &str) -> shipper::types::Receipt {
             os: "test".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     }
 }
 
@@ -1438,6 +1439,7 @@ fn receipt_with_mixed_outcomes_roundtrips() {
             os: "linux".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     };
 
     state::write_receipt(&state_dir, &receipt).expect("write receipt");
@@ -1488,6 +1490,7 @@ fn receipt_environment_fingerprint_roundtrips() {
             os: "macos".to_string(),
             arch: "aarch64".to_string(),
         },
+        auth_evidence: None,
     };
 
     state::write_receipt(&state_dir, &receipt).expect("write receipt");

--- a/crates/shipper/tests/facade_integration.rs
+++ b/crates/shipper/tests/facade_integration.rs
@@ -206,6 +206,7 @@ fn sample_receipt(plan_id: &str, pkg_names: &[&str]) -> shipper::types::Receipt 
             os: "test".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     }
 }
 
@@ -1298,6 +1299,7 @@ fn receipt_mixed_outcomes_through_file_store() {
             os: "linux".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     };
 
     store.save_receipt(&receipt).expect("save receipt");
@@ -1355,6 +1357,7 @@ fn environment_fingerprint_in_receipt_through_store() {
             os: "windows".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     };
 
     store.save_receipt(&receipt).expect("save");
@@ -2146,6 +2149,7 @@ fn receipt_all_fields_persisted_and_roundtrip() {
             os: "linux".to_string(),
             arch: "aarch64".to_string(),
         },
+        auth_evidence: None,
     };
 
     state::write_receipt(&state_dir, &receipt).expect("write receipt");

--- a/crates/shipper/tests/pipeline_integration.rs
+++ b/crates/shipper/tests/pipeline_integration.rs
@@ -134,6 +134,7 @@ fn make_receipt(plan_id: &str, pkgs: &[(&str, &str, PackageState)]) -> shipper::
             os: "test".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     }
 }
 
@@ -688,6 +689,7 @@ fn receipt_with_full_evidence_roundtrips() {
             os: "test".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     };
 
     state::write_receipt(&state_dir, &receipt).expect("write receipt");
@@ -739,6 +741,7 @@ fn receipt_with_git_context_roundtrips() {
             os: "test".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     };
 
     state::write_receipt(&state_dir, &receipt).expect("write receipt");
@@ -1372,6 +1375,7 @@ fn full_pipeline_plan_preflight_publish_verify_receipt() {
             os: "test".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     };
     state::write_receipt(&state_dir, &receipt).expect("write receipt");
 
@@ -1775,6 +1779,7 @@ fn receipt_fields_populated_for_mixed_outcomes() {
             os: "test".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     };
 
     state::write_receipt(&state_dir, &receipt).expect("write receipt");

--- a/crates/shipper/tests/state_integration.rs
+++ b/crates/shipper/tests/state_integration.rs
@@ -62,6 +62,7 @@ fn make_receipt(plan_id: &str, packages: Vec<PackageReceipt>) -> Receipt {
             os: "test".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     }
 }
 
@@ -1043,6 +1044,7 @@ fn make_deterministic_receipt(plan_id: &str, packages: Vec<PackageReceipt>) -> R
             os: "linux".to_string(),
             arch: "x86_64".to_string(),
         },
+        auth_evidence: None,
     }
 }
 

--- a/docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
+++ b/docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
@@ -43,6 +43,9 @@ Release auth evidence must preserve these rules:
   Cargo token auth wins.
 - Publish, resume, and receipt evidence must eventually expose the auth mode
   Shipper used or observed without logging token values.
+- If `CARGO_REGISTRY_TOKEN` is present while GitHub OIDC request variables are
+  also present, Shipper must record that observed state as token auth with OIDC
+  context unless a separate workflow metadata field proves token provenance.
 - Long-lived token fallback must be explicit evidence, not hidden compatibility
   behavior.
 - Unknown or externally unproven facts must be represented as unknown,
@@ -97,8 +100,11 @@ Future implementation proof must cover:
   blocked incomplete OIDC environment and suggests the next action.
 - Preflight runs with both OIDC context and `CARGO_REGISTRY_TOKEN`. It records
   that token auth won and warns that fallback is still configured.
-- A release receipt records `auth_mode = "trusted_publishing"` or
-  `auth_mode = "token_fallback"` without storing the token.
+- A release receipt records `auth_mode = "trusted_publishing_context"`,
+  `auth_mode = "cargo_token"`, or
+  `auth_mode = "cargo_token_with_oidc_context"` without storing the token.
+  The last value is deliberately an observed context, not a claim that the token
+  came from Trusted Publishing or from the fallback secret.
 - A support-tier row remains advisory if the proof only validates repo-visible
   workflow files and does not prove crates.io-side registration.
 
@@ -112,6 +118,8 @@ Expected implementation proof:
 - `cargo test -p shipper-output-sanitizer --locked`
 - focused receipt/event tests for auth-mode evidence when that runtime field is
   added
+- `cargo test -p shipper-core run_publish_receipt_contains_evidence_after_success --lib --locked`
+- `cargo test -p shipper-core event_types_serialize_correctly --lib --locked`
 - `cargo xtask check-doc-contracts --mode advisory`
 - `cargo xtask policy-report`
 

--- a/plans/0.4.0/release-auth-evidence-and-trusted-publishing.md
+++ b/plans/0.4.0/release-auth-evidence-and-trusted-publishing.md
@@ -99,9 +99,11 @@ release workflow rewrites, and receipt signing.
 
 #### Acceptance
 
-- Evidence distinguishes Trusted Publishing, token fallback, missing auth, and
-  unknown auth paths.
-- Token fallback remains visible when it is configured or used.
+- Evidence distinguishes Trusted Publishing context, Cargo token auth, Cargo
+  token auth with OIDC context, missing auth, and unknown auth paths.
+- Token fallback remains visible when workflow metadata or Doctor-visible
+  workflow configuration proves it; token-plus-OIDC runtime evidence must not
+  overclaim token provenance by itself.
 - Token values never appear in human output, JSON output, events, receipts, or
   snapshots.
 - Unknown crates.io-side registration remains explicit.
@@ -109,6 +111,8 @@ release workflow rewrites, and receipt signing.
 #### Proof Commands
 
 - `cargo test -p shipper-core run_preflight_warns_when_token_auth_overrides_oidc --lib --locked`
+- `cargo test -p shipper-core collect_auth_evidence --lib --locked`
+- `cargo test -p shipper-core run_publish_receipt_contains_evidence_after_success --lib --locked`
 - `cargo test -p shipper-output-sanitizer --locked`
 - focused receipt/event tests for auth-mode evidence
 - `cargo xtask policy-report`


### PR DESCRIPTION
## Summary
- add non-secret AuthEvidence / AuthEvidenceMode types and record auth evidence as a publish event
- persist auth evidence on receipt.json and nested publish/resume receipt evidence without storing token values
- document the conservative token-plus-OIDC interpretation so Shipper does not claim token provenance it cannot prove

## Validation
- cargo check --workspace --all-targets --locked
- cargo test -p shipper-core collect_auth_evidence --lib --locked
- cargo test -p shipper-core run_publish_receipt_contains_evidence_after_success --lib --locked
- cargo test -p shipper-core event_types_serialize_correctly --lib --locked
- cargo test -p shipper-core run_preflight_warns_when_token_auth_overrides_oidc --lib --locked
- cargo test -p shipper-cli --test e2e_publish publish_json_format_writes_command_envelope_to_stdout --locked
- cargo test -p shipper-types --lib --locked
- cargo test -p shipper-output-sanitizer --locked
- cargo clippy -p shipper-core --all-targets --locked -- -D warnings
- cargo clippy -p shipper-types --all-targets --locked -- -D warnings
- cargo clippy -p shipper-cli --all-targets --locked -- -D warnings
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask policy-report
- cargo fmt --all -- --check
- git diff --check

## Notes
- Full cargo test -p shipper-core --lib --locked completed with 2037 passed and one unrelated concurrent git-cleanliness test failure; the failing test passed when rerun directly with cargo test -p shipper-core ensure_git_clean_new_phrasing --lib --locked.