### PR TITLE
ci(release): record trusted publishing auth evidence

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,6 +300,53 @@ jobs:
         continue-on-error: true
         uses: rust-lang/crates-io-auth-action@v1
 
+      - name: Record release auth evidence
+        if: always()
+        env:
+          SHIPPER_RELEASE_AUTH_ACTION_OUTCOME: ${{ steps.auth.outcome }}
+          SHIPPER_RELEASE_AUTH_TOKEN_MINTED: ${{ steps.auth.outputs.token != '' }}
+          SHIPPER_RELEASE_AUTH_FALLBACK_CONFIGURED: ${{ secrets.CARGO_REGISTRY_TOKEN != '' }}
+          SHIPPER_RELEASE_AUTH_RUN_ID: ${{ github.run_id }}
+          SHIPPER_RELEASE_AUTH_RUN_ATTEMPT: ${{ github.run_attempt }}
+          SHIPPER_RELEASE_AUTH_COMMIT: ${{ github.sha }}
+        run: |
+          mkdir -p .shipper
+          token_minted="${SHIPPER_RELEASE_AUTH_TOKEN_MINTED:-false}"
+          fallback_configured="${SHIPPER_RELEASE_AUTH_FALLBACK_CONFIGURED:-false}"
+          fallback_used=false
+          selected_token_source="missing"
+          if [ "$token_minted" = "true" ]; then
+            selected_token_source="trusted_publishing"
+          elif [ "$fallback_configured" = "true" ]; then
+            selected_token_source="fallback_secret"
+            fallback_used=true
+          fi
+          printf '%s\n' \
+            '{' \
+            '  "schema_version": "shipper.release_auth_evidence.v1",' \
+            '  "workflow": "Release",' \
+            '  "job": "publish-crates-io",' \
+            "  \"run_id\": \"${SHIPPER_RELEASE_AUTH_RUN_ID}\"," \
+            "  \"run_attempt\": \"${SHIPPER_RELEASE_AUTH_RUN_ATTEMPT}\"," \
+            "  \"commit\": \"${SHIPPER_RELEASE_AUTH_COMMIT}\"," \
+            '  "environment": "release",' \
+            '  "auth_action": {' \
+            '    "name": "rust-lang/crates-io-auth-action@v1",' \
+            "    \"outcome\": \"${SHIPPER_RELEASE_AUTH_ACTION_OUTCOME}\"," \
+            "    \"token_minted\": ${token_minted}" \
+            '  },' \
+            '  "fallback": {' \
+            "    \"configured\": ${fallback_configured}," \
+            "    \"used\": ${fallback_used}" \
+            '  },' \
+            "  \"selected_token_source\": \"${selected_token_source}\"," \
+            '  "limits": [' \
+            '    "token values are intentionally omitted",' \
+            '    "crates.io-side trusted-publisher registration is not proven by this artifact"' \
+            '  ]' \
+            '}' \
+            > .shipper/auth-evidence.json
+
       # --- Step 4: preflight ------------------------------------------------
       # `--policy safe` enables ownership checks. For existing crates
       # those checks exercise the minted OIDC token against crates.io;
@@ -508,6 +555,53 @@ jobs:
         continue-on-error: true
         uses: rust-lang/crates-io-auth-action@v1
 
+      - name: Record release auth evidence
+        if: always()
+        env:
+          SHIPPER_RELEASE_AUTH_ACTION_OUTCOME: ${{ steps.auth.outcome }}
+          SHIPPER_RELEASE_AUTH_TOKEN_MINTED: ${{ steps.auth.outputs.token != '' }}
+          SHIPPER_RELEASE_AUTH_FALLBACK_CONFIGURED: ${{ secrets.CARGO_REGISTRY_TOKEN != '' }}
+          SHIPPER_RELEASE_AUTH_RUN_ID: ${{ github.run_id }}
+          SHIPPER_RELEASE_AUTH_RUN_ATTEMPT: ${{ github.run_attempt }}
+          SHIPPER_RELEASE_AUTH_COMMIT: ${{ github.sha }}
+        run: |
+          mkdir -p .shipper
+          token_minted="${SHIPPER_RELEASE_AUTH_TOKEN_MINTED:-false}"
+          fallback_configured="${SHIPPER_RELEASE_AUTH_FALLBACK_CONFIGURED:-false}"
+          fallback_used=false
+          selected_token_source="missing"
+          if [ "$token_minted" = "true" ]; then
+            selected_token_source="trusted_publishing"
+          elif [ "$fallback_configured" = "true" ]; then
+            selected_token_source="fallback_secret"
+            fallback_used=true
+          fi
+          printf '%s\n' \
+            '{' \
+            '  "schema_version": "shipper.release_auth_evidence.v1",' \
+            '  "workflow": "Release",' \
+            '  "job": "release-rehearse",' \
+            "  \"run_id\": \"${SHIPPER_RELEASE_AUTH_RUN_ID}\"," \
+            "  \"run_attempt\": \"${SHIPPER_RELEASE_AUTH_RUN_ATTEMPT}\"," \
+            "  \"commit\": \"${SHIPPER_RELEASE_AUTH_COMMIT}\"," \
+            '  "environment": "release",' \
+            '  "auth_action": {' \
+            '    "name": "rust-lang/crates-io-auth-action@v1",' \
+            "    \"outcome\": \"${SHIPPER_RELEASE_AUTH_ACTION_OUTCOME}\"," \
+            "    \"token_minted\": ${token_minted}" \
+            '  },' \
+            '  "fallback": {' \
+            "    \"configured\": ${fallback_configured}," \
+            "    \"used\": ${fallback_used}" \
+            '  },' \
+            "  \"selected_token_source\": \"${selected_token_source}\"," \
+            '  "limits": [' \
+            '    "token values are intentionally omitted",' \
+            '    "crates.io-side trusted-publisher registration is not proven by this artifact"' \
+            '  ]' \
+            '}' \
+            > .shipper/auth-evidence.json
+
       # Preflight against crates.io without publishing. A token isn't strictly
       # required here (ownership checks are best-effort), but supply it if the
       # `release` environment is available for a deeper check.
@@ -604,6 +698,53 @@ jobs:
         # the whole release just because OIDC isn't configured yet.
         continue-on-error: true
         uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Record release auth evidence
+        if: always()
+        env:
+          SHIPPER_RELEASE_AUTH_ACTION_OUTCOME: ${{ steps.auth.outcome }}
+          SHIPPER_RELEASE_AUTH_TOKEN_MINTED: ${{ steps.auth.outputs.token != '' }}
+          SHIPPER_RELEASE_AUTH_FALLBACK_CONFIGURED: ${{ secrets.CARGO_REGISTRY_TOKEN != '' }}
+          SHIPPER_RELEASE_AUTH_RUN_ID: ${{ github.run_id }}
+          SHIPPER_RELEASE_AUTH_RUN_ATTEMPT: ${{ github.run_attempt }}
+          SHIPPER_RELEASE_AUTH_COMMIT: ${{ github.sha }}
+        run: |
+          mkdir -p .shipper
+          token_minted="${SHIPPER_RELEASE_AUTH_TOKEN_MINTED:-false}"
+          fallback_configured="${SHIPPER_RELEASE_AUTH_FALLBACK_CONFIGURED:-false}"
+          fallback_used=false
+          selected_token_source="missing"
+          if [ "$token_minted" = "true" ]; then
+            selected_token_source="trusted_publishing"
+          elif [ "$fallback_configured" = "true" ]; then
+            selected_token_source="fallback_secret"
+            fallback_used=true
+          fi
+          printf '%s\n' \
+            '{' \
+            '  "schema_version": "shipper.release_auth_evidence.v1",' \
+            '  "workflow": "Release",' \
+            '  "job": "release-resume",' \
+            "  \"run_id\": \"${SHIPPER_RELEASE_AUTH_RUN_ID}\"," \
+            "  \"run_attempt\": \"${SHIPPER_RELEASE_AUTH_RUN_ATTEMPT}\"," \
+            "  \"commit\": \"${SHIPPER_RELEASE_AUTH_COMMIT}\"," \
+            '  "environment": "release",' \
+            '  "auth_action": {' \
+            '    "name": "rust-lang/crates-io-auth-action@v1",' \
+            "    \"outcome\": \"${SHIPPER_RELEASE_AUTH_ACTION_OUTCOME}\"," \
+            "    \"token_minted\": ${token_minted}" \
+            '  },' \
+            '  "fallback": {' \
+            "    \"configured\": ${fallback_configured}," \
+            "    \"used\": ${fallback_used}" \
+            '  },' \
+            "  \"selected_token_source\": \"${selected_token_source}\"," \
+            '  "limits": [' \
+            '    "token values are intentionally omitted",' \
+            '    "crates.io-side trusted-publisher registration is not proven by this artifact"' \
+            '  ]' \
+            '}' \
+            > .shipper/auth-evidence.json
 
       - name: shipper resume
         env:

--- a/.shipper-meta/goals/active.toml
+++ b/.shipper-meta/goals/active.toml
@@ -65,6 +65,9 @@ plan = "plans/0.4.0/release-auth-evidence-and-trusted-publishing.md"
 issue = "105"
 commands = [
   "release auth rehearsal or release-readiness workflow artifact",
+  "cargo xtask check-workflow-surfaces --mode advisory",
+  "cargo xtask check-process-policy --mode advisory",
+  "cargo xtask check-network-policy --mode advisory",
   "cargo xtask policy-report",
   "git diff --check",
 ]

--- a/docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
+++ b/docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
@@ -91,6 +91,36 @@ Future implementation proof must cover:
   or fell back explicitly
 - Support-tier promotion only after the proof command or artifact exists
 
+## Workflow Auth Evidence Artifact
+
+The release workflow must write `.shipper/auth-evidence.json` before any
+release-mode `.shipper/` upload that follows Trusted Publishing token minting.
+The artifact is intentionally workflow-scoped evidence, not a runtime Shipper
+receipt field.
+
+Required fields:
+
+- `schema_version = "shipper.release_auth_evidence.v1"`
+- `workflow`
+- `job`
+- `run_id`
+- `run_attempt`
+- `commit`
+- `environment`
+- `auth_action.name = "rust-lang/crates-io-auth-action@v1"`
+- `auth_action.outcome`
+- `auth_action.token_minted`
+- `fallback.configured`
+- `fallback.used`
+- `selected_token_source`
+- `limits`
+
+`selected_token_source` may be `trusted_publishing`, `fallback_secret`, or
+`missing`. Token values must never be written. The artifact may prove that the
+GitHub-side token mint step succeeded or that fallback was selected; it must not
+claim crates.io-side trusted-publisher registration for every publishable crate
+unless a later rehearsal or release artifact proves that separately.
+
 ## Acceptance Examples
 
 - A release workflow has `id-token: write`, `environment: release`, the crates.io

--- a/plans/0.4.0/release-auth-evidence-and-trusted-publishing.md
+++ b/plans/0.4.0/release-auth-evidence-and-trusted-publishing.md
@@ -137,7 +137,9 @@ whether fallback was used.
 
 #### Production Delta
 
-Release workflow/rehearsal evidence only.
+Release workflow/rehearsal evidence only. The release workflow writes
+`.shipper/auth-evidence.json` after each Trusted Publishing token mint step and
+before the following `.shipper/` artifact upload.
 
 #### Non-Goals
 
@@ -152,10 +154,16 @@ not rehearsed.
 - Artifact names the workflow, run ID, commit, and environment.
 - Failed Trusted Publishing registration remains an actionable setup gap, not a
   generic auth failure.
+- Artifact limits state that token values are omitted and crates.io-side
+  trusted-publisher registration is externally unproven unless separately
+  rehearsed.
 
 #### Proof Commands
 
 - release auth rehearsal or release-readiness workflow artifact
+- `cargo xtask check-workflow-surfaces --mode advisory`
+- `cargo xtask check-process-policy --mode advisory`
+- `cargo xtask check-network-policy --mode advisory`
 - `cargo xtask policy-report`
 - `git diff --check`
 


### PR DESCRIPTION
## Summary

- record non-secret `.shipper/auth-evidence.json` after the Trusted Publishing token step in publish, rehearse, and resume release jobs
- capture auth action outcome, token-minted boolean, fallback configured/used booleans, run metadata, and explicit evidence limits
- document the workflow artifact contract in the auth evidence spec/plan and add the workflow policy checks to the active goal

## Safety

- token values are never written to the artifact
- existing `steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN` fallback behavior is unchanged
- this does not publish crates, remove fallback, or promote Trusted Publishing support-tier claims
- the artifact does not claim crates.io-side trusted-publisher registration; it records that as externally unproven unless a rehearsal/release proves it later

## Validation

- `python -c "import pathlib,tomllib; tomllib.loads(pathlib.Path('.shipper-meta/goals/active.toml').read_text()); print('active goal TOML parses')"`
- `cargo xtask check-workflow-surfaces --mode advisory`
- `cargo xtask check-process-policy --mode advisory`
- `cargo xtask check-network-policy --mode advisory`
- `cargo xtask check-doc-contracts --mode advisory`
- `cargo xtask check-file-policy --mode blocking-allowlist`
- `cargo xtask policy-report`
- `cargo fmt --all -- --check`
- `git diff --check`
