### PR TITLE
docs(spec): define receipt-driven remediation lane

### DIFF
--- a/.shipper-meta/goals/active.toml
+++ b/.shipper-meta/goals/active.toml
@@ -1,33 +1,32 @@
-id = "shipper-release-auth-evidence"
-title = "Release auth evidence and Trusted Publishing"
-status = "complete"
+id = "shipper-receipt-driven-remediation"
+title = "Receipt-driven remediation"
+status = "active"
 owner = "EffortlessMetrics"
-created = "2026-05-18"
+created = "2026-05-19"
 
 objective = """
-Make Shipper's release authentication posture evidence-backed: Doctor,
-preflight, publish/resume, events, receipts, release workflows, and support
-tiers should distinguish Trusted Publishing, token fallback, missing auth, and
-externally unproven crates.io registration without exposing token values.
+Make Shipper's Remediate pillar spec-addressable and evidence-backed:
+yank containment, reverse-topological yank planning, fix-forward planning,
+remediation artifacts, support-tier claims, and future guarded execution must
+link to proof instead of stale issue prose.
 """
 
 end_state = [
-  "The active goal points to the accepted auth evidence spec and plan.",
-  "Observed auth mode is visible in release evidence without token values or token-provenance overclaims.",
-  "Trusted Publishing workflow proof records whether short-lived token minting succeeded or fallback was used.",
-  "Support tiers distinguish advisory diagnostics from a proven Trusted Publishing default.",
+  "The active goal points to the accepted remediation spec and plan.",
+  "Existing remediation behavior is mapped to proof commands before support-tier promotion.",
+  "Remediation JSON/artifact surfaces are either versioned or explicitly advisory.",
+  "Full mechanical remediation remains planned until dry-run artifacts and guarded execution are proven.",
 ]
 
 [[work_item]]
-id = "auth-evidence-source-of-truth"
-status = "complete"
+id = "remediation-source-of-truth"
+status = "active"
 proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
-spec = "docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md"
-plan = "plans/0.4.0/release-auth-evidence-and-trusted-publishing.md"
-issue = "105"
-linked_pr = "#338"
-completed = "2026-05-18"
+spec = "docs/specs/SHIPPER-SPEC-0008-receipt-driven-remediation.md"
+plan = "plans/0.4.0/receipt-driven-remediation.md"
+issue = "104"
 commands = [
+  "python -c \"import pathlib,tomllib; tomllib.loads(pathlib.Path('.shipper-meta/goals/active.toml').read_text()); print('active goal TOML parses')\"",
   "cargo xtask check-doc-contracts --mode advisory",
   "cargo xtask check-file-policy --mode blocking-allowlist",
   "cargo xtask policy-report",
@@ -36,54 +35,46 @@ commands = [
 ]
 
 [[work_item]]
-id = "auth-mode-release-evidence"
-status = "complete"
+id = "remediation-existing-proof-map"
+status = "ready"
 proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
-spec = "docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md"
-plan = "plans/0.4.0/release-auth-evidence-and-trusted-publishing.md"
-issue = "105"
-linked_pr = "#340"
-completed = "2026-05-18"
+spec = "docs/specs/SHIPPER-SPEC-0008-receipt-driven-remediation.md"
+plan = "plans/0.4.0/receipt-driven-remediation.md"
+issue = "104"
 commands = [
-  "cargo test -p shipper-core run_preflight_warns_when_token_auth_overrides_oidc --lib --locked",
-  "cargo test -p shipper-core collect_auth_evidence --lib --locked",
-  "cargo test -p shipper-core run_publish_receipt_contains_evidence_after_success --lib --locked",
-  "cargo test -p shipper-core event_types_serialize_correctly --lib --locked",
-  "cargo test -p shipper-output-sanitizer --locked",
-  "cargo test -p shipper-cli --test e2e_publish publish_json_format_writes_command_envelope_to_stdout --locked",
+  "cargo test -p shipper-core plan_yank --lib --locked",
+  "cargo test -p shipper-core fix_forward --lib --locked",
+  "cargo test -p shipper-core cargo_yank --lib --locked",
+  "cargo test -p shipper-cli --test e2e_expanded --locked",
   "cargo xtask policy-report",
   "cargo fmt --all -- --check",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "trusted-publishing-proof-artifact"
-status = "complete"
+id = "remediation-json-contract"
+status = "planned"
 proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
-spec = "docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md"
-plan = "plans/0.4.0/release-auth-evidence-and-trusted-publishing.md"
-issue = "105"
-linked_pr = "#342"
-completed = "2026-05-19"
+spec = "docs/specs/SHIPPER-SPEC-0008-receipt-driven-remediation.md"
+plan = "plans/0.4.0/receipt-driven-remediation.md"
+issue = "104"
 commands = [
-  "Release workflow run 26072938626, artifact shipper-rehearse-26072938626, file .shipper/auth-evidence.json",
-  "cargo xtask check-workflow-surfaces --mode advisory",
-  "cargo xtask check-process-policy --mode advisory",
-  "cargo xtask check-network-policy --mode advisory",
+  "focused JSON output tests for the chosen remediation command surface",
+  "cargo xtask check-doc-contracts --mode advisory",
   "cargo xtask policy-report",
+  "cargo fmt --all -- --check",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "auth-support-tier-promotion"
-status = "complete"
+id = "remediation-dry-run-artifact"
+status = "planned"
 proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
-spec = "docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md"
-plan = "plans/0.4.0/release-auth-evidence-and-trusted-publishing.md"
-issue = "105"
-completed = "2026-05-19"
+spec = "docs/specs/SHIPPER-SPEC-0008-receipt-driven-remediation.md"
+plan = "plans/0.4.0/receipt-driven-remediation.md"
+issue = "104"
 commands = [
-  "cargo xtask check-doc-contracts --mode advisory",
+  "focused CLI/integration tests for artifact generation",
   "cargo xtask policy-report",
   "cargo fmt --all -- --check",
   "git diff --check",

--- a/docs/specs/SHIPPER-SPEC-0008-receipt-driven-remediation.md
+++ b/docs/specs/SHIPPER-SPEC-0008-receipt-driven-remediation.md
@@ -1,0 +1,145 @@
+# SHIPPER-SPEC-0008: Receipt-Driven Remediation
+
+Status: proposed
+Owner: EffortlessMetrics
+Created: 2026-05-19
+Milestone: 0.4.0
+Linked proposal: docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md
+Linked specs: docs/specs/SHIPPER-SPEC-0001-source-of-truth-stack.md; docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md
+Linked ADRs: docs/adr/SHIPPER-ADR-0001-claims-become-checkable-state.md
+Linked plan: plans/0.4.0/receipt-driven-remediation.md
+Linked issues: #98; #104; #109
+Linked PRs:
+Support-tier impact: docs/status/SUPPORT_TIERS.md
+Policy impact: policy ledgers remain authoritative for workflow, process, network, and file receipts
+Proof commands: cargo xtask check-doc-contracts --mode advisory; cargo xtask policy-report; cargo fmt --all -- --check
+
+## Problem
+
+Shipper's release-closure promise does not end when crates are published. A
+bad partial release or later-discovered compromised crate leaves operators with
+manual containment work: identify affected crate versions, choose yank order,
+decide whether to fix-forward, and preserve an audit trail.
+
+Current code and docs already contain several Remediate foundations: `shipper
+yank`, `shipper plan-yank`, `shipper fix-forward`, compromised receipt fields,
+`PackageYanked` events, a cargo-yank wrapper, and a how-to guide. The remaining
+source-of-truth gap is that these behaviors are not yet tied into a spec,
+support-tier claim, active goal, and proof sequence.
+
+## Behavior Contract
+
+Receipt-driven remediation must preserve these rules:
+
+- Remediation starts from a prior `receipt.json`; Shipper must not infer a bad
+  release from chat, issue text, or stdout alone.
+- Yanking is containment, not undo. It prevents new dependency resolves but does
+  not remove already-downloaded bytes or existing lockfile pins.
+- A remediation plan must identify the source receipt, target registry, target
+  crate versions, operator reason, affected packages, and command sequence.
+- Yank planning must be deterministic and reverse topological: dependents
+  before dependencies.
+- Fix-forward planning must be deterministic and publish-directional:
+  dependencies before dependents.
+- Compromise markers in receipts must be explicit operator annotations.
+- Execution that invokes `cargo yank` must record event evidence and avoid
+  logging token values.
+- JSON output, when present, must use a schema-versioned command or plan
+  envelope before it is promoted as a stable integration surface.
+- Support-tier claims must distinguish implemented primitives, planning-only
+  remediation, guarded execution, and full mechanical recovery.
+
+## Non-Goals
+
+- Claiming yanking deletes crates.io versions or invalidates existing lockfiles.
+- Editing Cargo.toml versions automatically.
+- Publishing fix-forward successors automatically.
+- Adding crates.io team management.
+- Replacing registry reconciliation or publish ordering behavior.
+- Promoting remediation as stable before proof commands and artifacts are named.
+
+## Required Evidence
+
+Source-of-truth proof for this spec:
+
+- `cargo xtask check-doc-contracts --mode advisory`
+- `cargo xtask check-file-policy --mode blocking-allowlist`
+- `cargo xtask policy-report`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+Future implementation and promotion proof must cover:
+
+- CLI help and snapshots for `yank`, `plan-yank`, and `fix-forward`
+- `cargo yank` wrapper tests that prove command construction, registry
+  selection, exit-code handling, and token redaction
+- plan-yank tests for all-published, compromised-only, and starting-crate graph
+  modes
+- fix-forward tests for compromised receipts and empty-compromise receipts
+- event evidence for `PackageYanked`
+- JSON contract proof before declaring remediation plan JSON stable
+- support-tier rows that name exact tests, commands, and artifacts
+
+## Acceptance Examples
+
+- Given a receipt with packages published in topological order `core`, `api`,
+  `cli`, a yank plan for all published packages emits `cli`, `api`, `core`.
+- Given the same receipt and a compromised marker only on `api`, a
+  compromised-only yank plan emits `api`.
+- Given a starting crate `core`, graph mode includes the crates that
+  transitively depend on `core`, ordered dependents first.
+- Given a compromised receipt, fix-forward output tells the operator which
+  successor versions to create without editing manifests or publishing.
+- Given a direct `shipper yank --mark-compromised`, the matching receipt entry
+  gains compromise metadata and the event log records `PackageYanked`.
+
+## Test Mapping
+
+Expected proof:
+
+- `cargo test -p shipper-core plan_yank --lib --locked`
+- `cargo test -p shipper-core fix_forward --lib --locked`
+- `cargo test -p shipper-core cargo_yank --lib --locked`
+- `cargo test -p shipper-types package_yanked --lib --locked`
+- `cargo test -p shipper-cli --test e2e_expanded --locked`
+- `cargo xtask check-doc-contracts --mode advisory`
+- `cargo xtask policy-report`
+
+## Implementation Mapping
+
+The implementation plan belongs in
+`plans/0.4.0/receipt-driven-remediation.md`.
+
+The lane should land in narrow PRs:
+
+- source-of-truth activation
+- proof mapping and support-tier baseline for existing remediation surfaces
+- remediation plan JSON contract if the current JSON shape is stable enough
+- evidence artifact wiring for `.shipper/remediation-plan.json`
+- guarded execution hardening only after planning proof is stable
+
+## CI Proof
+
+CI should prove unit, integration, policy, and doc-contract gates for each PR.
+Remediation execution tests must use fake Cargo and mock registries; live
+crates.io yanks are release-operator actions and must not run in PR CI.
+
+## Promotion Rule
+
+Support-tier claims may move only when the named proof exists:
+
+- `shipper yank` can be stable only for the bounded containment primitive if
+  command, event, receipt, and redaction proof exists.
+- `shipper plan-yank` can be stable only after deterministic plan tests and
+  docs prove the yank-order contract.
+- `shipper fix-forward` stays advisory until it has a documented JSON contract
+  or explicitly remains a human-readable planning aid.
+- Full mechanical remediation stays planned until dry-run artifacts and guarded
+  execution proof exist.
+
+## Open Questions
+
+- Should `.shipper/remediation-plan.json` be produced by `plan-yank`,
+  `fix-forward`, or a future `remediate --dry-run` command?
+- Should receipt history lookup be a separate command before guarded yank
+  execution is promoted?

--- a/docs/status/SUPPORT_TIERS.md
+++ b/docs/status/SUPPORT_TIERS.md
@@ -5,7 +5,7 @@ Owner: EffortlessMetrics
 Created: 2026-05-13
 Milestone: 0.4.0
 Linked proposal: docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md
-Linked specs: docs/specs/SHIPPER-SPEC-0001-source-of-truth-stack.md; docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md; docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md; docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
+Linked specs: docs/specs/SHIPPER-SPEC-0001-source-of-truth-stack.md; docs/specs/SHIPPER-SPEC-0004-json-evidence-contracts.md; docs/specs/SHIPPER-SPEC-0005-release-operator-visibility-and-survive-proof.md; docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md; docs/specs/SHIPPER-SPEC-0008-receipt-driven-remediation.md
 Linked ADRs:
 Linked plan:
 Linked issues: #109, #195
@@ -61,6 +61,7 @@ make stronger claims than this file supports.
 | Release auth workflow proof artifact | stable/internal | GitHub Actions `Release` workflow run `26072938626` uploaded `shipper-rehearse-26072938626` with `.shipper/auth-evidence.json`; the artifact records `shipper.release_auth_evidence.v1`, `auth_action.outcome = "failure"`, `fallback.configured = true`, `fallback.used = true`, and `selected_token_source = "fallback_secret"` without token values; proves current fallback evidence only, not Trusted Publishing default | release/ci |
 | Long-lived token fallback warnings | advisory | `docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md`; `cargo test -p shipper-core run_preflight_warns_when_token_auth_overrides_oidc --lib`; `cargo test -p shipper-cli --test cli_e2e doctor_command_warns_when_token_fallback_is_configured`; warns when Cargo token auth wins while Trusted Publishing signals or fallback config are present | release/ci |
 | Trusted Publishing default | planned/advisory | `docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md`; `plans/0.4.0/release-auth-evidence-and-trusted-publishing.md`; promote only after release evidence proves the short-lived-token path is the normal path and token fallback state is explicit | release/ci |
+| Receipt-driven remediation | planned/advisory | `docs/specs/SHIPPER-SPEC-0008-receipt-driven-remediation.md`; `plans/0.4.0/receipt-driven-remediation.md`; current code includes `yank`, `plan-yank`, and `fix-forward` surfaces, but support-tier promotion waits for a proof-map PR that names exact tests, JSON/artifact status, and guarded-execution boundaries | engine/cli |
 
 ## Rules
 

--- a/plans/0.4.0/receipt-driven-remediation.md
+++ b/plans/0.4.0/receipt-driven-remediation.md
@@ -1,0 +1,225 @@
+# Plan: Receipt-Driven Remediation
+
+Status: proposed
+Owner: EffortlessMetrics
+Created: 2026-05-19
+Milestone: 0.4.0
+Linked proposal: docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md
+Linked specs: docs/specs/SHIPPER-SPEC-0008-receipt-driven-remediation.md
+Linked ADRs: docs/adr/SHIPPER-ADR-0001-claims-become-checkable-state.md
+Linked plan: plans/0.4.0/release-readiness-proof.md
+Linked issues: #98; #104; #109
+Linked PRs:
+Support-tier impact: docs/status/SUPPORT_TIERS.md
+Policy impact: no new policy exceptions
+Proof commands: cargo xtask check-doc-contracts --mode advisory; cargo xtask policy-report; cargo fmt --all -- --check
+
+## End State
+
+Shipper remediation is spec-addressable and evidence-backed:
+
+- existing `yank`, `plan-yank`, and `fix-forward` behavior is mapped to proof
+  commands before any support-tier promotion
+- operators can distinguish containment, fix-forward planning, and future
+  guarded execution
+- remediation artifacts are named before release claims depend on them
+- no PR claims yanking is undo
+- support tiers keep full mechanical remediation planned until dry-run artifacts
+  and guarded execution are proven
+
+## PR Sequence
+
+### PR 1 - Source-of-truth activation
+
+Linked spec: docs/specs/SHIPPER-SPEC-0008-receipt-driven-remediation.md
+Blocks: PR 2
+Blocked by:
+
+#### Goal
+
+Define the Remediate behavior contract, implementation plan, active goal, and
+support-tier guardrails.
+
+#### Production Delta
+
+No product runtime behavior change.
+
+#### Non-Goals
+
+Runtime behavior, JSON schema changes, support-tier promotion, live yanks,
+release tagging, and publish/release workflow changes.
+
+#### Acceptance
+
+- Spec and plan exist and link to each other.
+- `.shipper-meta/goals/active.toml` points to receipt-driven remediation as the
+  current lane.
+- Support tiers name remediation only as a planned/advisory surface until proof
+  commands are mapped.
+
+#### Proof Commands
+
+- `python -c "import pathlib,tomllib; tomllib.loads(pathlib.Path('.shipper-meta/goals/active.toml').read_text()); print('active goal TOML parses')"`
+- `cargo xtask check-doc-contracts --mode advisory`
+- `cargo xtask check-file-policy --mode blocking-allowlist`
+- `cargo xtask policy-report`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+#### Rollback
+
+Revert this spec, plan, active goal, and support-tier row if the remediation
+lane is superseded before follow-up proof work depends on it.
+
+### PR 2 - Existing remediation proof map
+
+Linked spec: docs/specs/SHIPPER-SPEC-0008-receipt-driven-remediation.md
+Blocks: PR 3
+Blocked by: PR 1
+
+#### Goal
+
+Map already-landed remediation behavior to proof commands and support-tier
+claims without changing runtime behavior.
+
+#### Production Delta
+
+Documentation/status only.
+
+#### Non-Goals
+
+New commands, new JSON shape, guarded execution changes, and live yanks.
+
+#### Acceptance
+
+- Support tiers name exact proofs for the bounded remediation surfaces that are
+  already implemented.
+- Stale issue language is not used as authoritative state.
+- Any unproven surface remains advisory or planned.
+
+#### Proof Commands
+
+- `cargo test -p shipper-core plan_yank --lib --locked`
+- `cargo test -p shipper-core fix_forward --lib --locked`
+- `cargo test -p shipper-core cargo_yank --lib --locked`
+- `cargo test -p shipper-cli --test e2e_expanded --locked`
+- `cargo xtask policy-report`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+#### Rollback
+
+Demote any remediation support-tier row whose proof command does not cover the
+claim.
+
+### PR 3 - Remediation plan JSON contract
+
+Linked spec: docs/specs/SHIPPER-SPEC-0008-receipt-driven-remediation.md
+Blocks: PR 4
+Blocked by: PR 2
+
+#### Goal
+
+Decide whether current `plan-yank` or `fix-forward` JSON is stable enough to
+be a command-owned integration contract, or keep it explicitly advisory.
+
+#### Production Delta
+
+Schema/docs/tests only unless a small compatibility field is required.
+
+#### Non-Goals
+
+Executing yanks or publishing fix-forward successors.
+
+#### Acceptance
+
+- Stable fields are named and versioned, or the surface is explicitly advisory.
+- `.shipper/remediation-plan.json` ownership is decided or deferred.
+- Unknown and operator-supplied facts are explicit.
+
+#### Proof Commands
+
+- focused JSON output tests for the chosen command surface
+- `cargo xtask check-doc-contracts --mode advisory`
+- `cargo xtask policy-report`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+#### Rollback
+
+Demote JSON contract claims if the shape is not stable enough.
+
+### PR 4 - Remediation dry-run artifact
+
+Linked spec: docs/specs/SHIPPER-SPEC-0008-receipt-driven-remediation.md
+Blocks: PR 5
+Blocked by: PR 3
+
+#### Goal
+
+Produce a durable remediation dry-run artifact under `.shipper/` for operator
+review and agent consumption.
+
+#### Production Delta
+
+Remediation planning output and artifact writing only.
+
+#### Non-Goals
+
+Live yanks, manifest edits, or fix-forward publish execution.
+
+#### Acceptance
+
+- Dry-run artifact names source receipt, target crate/version, affected
+  packages, yank order, fix-forward suggestions, risk notes, and command list.
+- Artifact contains no token values.
+- Human output points to the artifact path.
+
+#### Proof Commands
+
+- focused CLI/integration tests for artifact generation
+- `cargo xtask policy-report`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+#### Rollback
+
+Remove artifact emission if it overclaims or duplicates unstable JSON output.
+
+### PR 5 - Guarded execution proof
+
+Linked spec: docs/specs/SHIPPER-SPEC-0008-receipt-driven-remediation.md
+Blocks:
+Blocked by: PR 4
+
+#### Goal
+
+Prove guarded yank execution against fake Cargo/mock registry surfaces before
+any stronger remediation claim is promoted.
+
+#### Production Delta
+
+Execution hardening and tests only.
+
+#### Non-Goals
+
+Publishing fix-forward successors automatically or running live crates.io yanks
+in PR CI.
+
+#### Acceptance
+
+- Execution reads a reviewed plan.
+- Each yank emits event evidence.
+- Retry/backoff and redaction behavior match release safety rules.
+- Failures leave actionable state.
+
+#### Proof Commands
+
+- focused fake-Cargo execution tests
+- `cargo xtask policy-report`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+#### Rollback
+
+Disable guarded execution paths if fake-registry proof is weak or misleading.


### PR DESCRIPTION
## Summary

- add `SHIPPER-SPEC-0008` for receipt-driven remediation
- add the 0.4.0 remediation plan and make it the active goal
- add a conservative support-tier row that keeps remediation planned/advisory until proof is mapped

## Scope

This is source-of-truth activation only. It does not change runtime behavior, yank execution, JSON shapes, release workflow behavior, or release artifacts.

## Why

Current code already has `yank`, `plan-yank`, `fix-forward`, compromised receipt fields, `PackageYanked` events, and remediation docs. The missing lane piece is a spec-addressable contract that maps those surfaces to proof before support-tier promotion.

## Validation

- `python -c "import pathlib,tomllib; tomllib.loads(pathlib.Path('.shipper-meta/goals/active.toml').read_text()); print('active goal TOML parses')"`
- `cargo xtask check-doc-contracts --mode advisory`
- `cargo xtask check-file-policy --mode blocking-allowlist`
- `cargo xtask policy-report`
- `cargo fmt --all -- --check`
- `git diff --check`
