### PR TITLE
feat(remediate): execute reviewed remediation plans

### DIFF
--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -564,50 +564,72 @@ EXAMPLES:
         #[arg(long, value_name = "PATH")]
         from_receipt: Option<PathBuf>,
     },
-    /// Generate a receipt-driven remediation dry-run artifact.
+    /// Generate or execute a receipt-driven remediation plan.
     ///
-    /// Reads a prior `receipt.json`, targets a specific bad crate version,
-    /// computes the affected reverse-topological yank order and
-    /// publish-directional fix-forward suggestions, then writes
-    /// `<state_dir>/remediation-plan.json` for operator review.
+    /// In `--dry-run` mode, reads a prior `receipt.json`, targets a
+    /// specific bad crate version, computes the affected reverse-topological
+    /// yank order and publish-directional fix-forward suggestions, then
+    /// writes `<state_dir>/remediation-plan.json` for operator review.
     ///
-    /// **Dry-run only.** This command does NOT invoke `cargo yank`, edit
-    /// manifests, or publish fix-forward successors.
+    /// In `--execute-plan` mode, reads a reviewed remediation plan and invokes
+    /// only the containment yanks in the recorded order. It does not edit
+    /// manifests or publish fix-forward successors.
     #[command(
         name = "remediate",
         long_about = "\
-Generate a receipt-driven remediation dry-run artifact.
+Generate or execute a receipt-driven remediation plan.
 
-Reads a prior `receipt.json`, targets a specific bad crate version, computes
-the affected reverse-topological yank order and publish-directional
-fix-forward suggestions, then writes `<state-dir>/remediation-plan.json` for
-operator review and agent consumption.
+In `--dry-run` mode, reads a prior `receipt.json`, targets a specific bad
+crate version, computes the affected reverse-topological yank order and
+publish-directional fix-forward suggestions, then writes
+`<state-dir>/remediation-plan.json` for operator review and agent consumption.
 
-This is planning only. It does NOT invoke `cargo yank`, edit manifests, or
-publish fix-forward successors.
+In `--execute-plan` mode, consumes that reviewed artifact and executes only the
+recorded containment yanks. It does NOT edit manifests or publish fix-forward
+successors.
 
 EXAMPLES:
     shipper remediate --dry-run --from-receipt .shipper/receipt.json --crate bad-crate --target-version 0.4.0 --reason \"CVE-2026-0001\"
+    shipper remediate --execute-plan .shipper/remediation-plan.json
 "
     )]
     Remediate {
         /// Path to the receipt to derive the remediation plan from. Defaults
         /// to `<state_dir>/receipt.json` when omitted.
-        #[arg(long, value_name = "PATH")]
+        #[arg(long, value_name = "PATH", conflicts_with = "execute_plan")]
         from_receipt: Option<PathBuf>,
         /// Bad crate name to contain and fix-forward.
-        #[arg(long = "crate", value_name = "NAME")]
-        crate_name: String,
+        #[arg(
+            long = "crate",
+            value_name = "NAME",
+            required_unless_present = "execute_plan",
+            conflicts_with = "execute_plan"
+        )]
+        crate_name: Option<String>,
         /// Bad crate version in the source receipt.
-        #[arg(long = "target-version", value_name = "VERSION")]
-        target_version: String,
+        #[arg(
+            long = "target-version",
+            value_name = "VERSION",
+            required_unless_present = "execute_plan",
+            conflicts_with = "execute_plan"
+        )]
+        target_version: Option<String>,
         /// Operator-supplied reason recorded in the artifact and command list.
-        #[arg(long, value_name = "REASON")]
-        reason: String,
+        #[arg(
+            long,
+            value_name = "REASON",
+            required_unless_present = "execute_plan",
+            conflicts_with = "execute_plan"
+        )]
+        reason: Option<String>,
         /// Required for now: generate the remediation artifact without
         /// executing yanks, editing manifests, or publishing successors.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "execute_plan")]
         dry_run: bool,
+        /// Execute a reviewed remediation plan artifact. Runs only the
+        /// recorded containment yanks and halts on the first failed yank.
+        #[arg(long = "execute-plan", value_name = "PATH")]
+        execute_plan: Option<PathBuf>,
     },
     /// Configuration file management.
     #[command(subcommand)]
@@ -1532,13 +1554,120 @@ pub fn run() -> Result<()> {
             target_version,
             reason,
             dry_run,
+            execute_plan,
         } => {
+            use shipper_core::cargo;
             use shipper_core::engine::{plan_yank, remediation};
             use shipper_core::runtime::execution::resolve_state_dir;
+            use shipper_core::state::events::{EventLog, events_path};
+
+            if let Some(plan_path) = execute_plan {
+                let plan = remediation::load_plan_from_path(&plan_path)?;
+                let state_dir = resolve_state_dir(&planned.workspace_root, &opts.state_dir);
+                let events_file = events_path(&state_dir);
+                let registry_name = opts
+                    .registries
+                    .first()
+                    .map(|r| r.name.clone())
+                    .unwrap_or_else(|| plan.registry.clone());
+
+                reporter.warn(&format!(
+                    "executing reviewed remediation plan: {} containment yanks for {}@{} (plan_id {})",
+                    plan.yank_order.len(),
+                    plan.target.crate_name,
+                    plan.target.version,
+                    plan.plan_id
+                ));
+                reporter.warn(
+                    "remediate --execute-plan runs yanks only; fix-forward suggestions remain planning output",
+                );
+
+                let mut succeeded = 0usize;
+                for (idx, step) in plan.yank_order.iter().enumerate() {
+                    let event_reason = remediation::REDACTED_OPERATOR_REASON.to_string();
+                    reporter.warn(&format!(
+                        "[{}/{}] yanking {}@{} from {}",
+                        idx + 1,
+                        plan.yank_order.len(),
+                        step.name,
+                        step.version,
+                        registry_name
+                    ));
+
+                    let out = cargo::cargo_yank(
+                        &planned.workspace_root,
+                        step.name.as_str(),
+                        step.version.as_str(),
+                        registry_name.as_str(),
+                        opts.output_lines,
+                        None,
+                    )?;
+
+                    let mut log = EventLog::new();
+                    log.record(PublishEvent {
+                        timestamp: chrono::Utc::now(),
+                        event_type: EventType::PackageYanked {
+                            crate_name: step.name.clone(),
+                            version: step.version.clone(),
+                            reason: event_reason,
+                            exit_code: out.exit_code,
+                        },
+                        package: format!("{}@{}", step.name, step.version),
+                    });
+                    if let Err(err) = log.write_to_file(&events_file) {
+                        reporter.warn(&format!(
+                            "failed to append PackageYanked event to {}: {err:#}",
+                            events_file.display()
+                        ));
+                    }
+
+                    if out.exit_code == 0 {
+                        succeeded += 1;
+                        reporter.info(&format!(
+                            "[{}/{}] yanked {}@{}",
+                            idx + 1,
+                            plan.yank_order.len(),
+                            step.name,
+                            step.version
+                        ));
+                    } else {
+                        reporter.error(&format!(
+                            "[{}/{}] cargo yank exited {} for {}@{}. stderr tail:\n{}",
+                            idx + 1,
+                            plan.yank_order.len(),
+                            out.exit_code,
+                            step.name,
+                            step.version,
+                            out.stderr_tail
+                        ));
+                        anyhow::bail!(
+                            "remediation plan failed at {}@{}; {succeeded}/{} containment yanks succeeded before halt",
+                            step.name,
+                            step.version,
+                            plan.yank_order.len()
+                        );
+                    }
+                }
+
+                reporter.info(&format!(
+                    "remediation containment complete: {succeeded}/{} yanks executed successfully",
+                    plan.yank_order.len()
+                ));
+                return Ok(());
+            }
 
             if !dry_run {
                 bail!("remediate currently supports planning only; rerun with --dry-run");
             }
+            let crate_name = crate_name.ok_or_else(|| {
+                anyhow::anyhow!("--crate is required when --execute-plan is not supplied")
+            })?;
+            let target_version = target_version.ok_or_else(|| {
+                anyhow::anyhow!("--target-version is required when --execute-plan is not supplied")
+            })?;
+            let reason = reason.ok_or_else(|| {
+                anyhow::anyhow!("--reason is required when --execute-plan is not supplied")
+            })?;
 
             let state_dir = resolve_state_dir(&planned.workspace_root, &opts.state_dir);
             let receipt_path = from_receipt

--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -564,50 +564,72 @@ EXAMPLES:
         #[arg(long, value_name = "PATH")]
         from_receipt: Option<PathBuf>,
     },
-    /// Generate a receipt-driven remediation dry-run artifact.
+    /// Generate or execute a receipt-driven remediation plan.
     ///
-    /// Reads a prior `receipt.json`, targets a specific bad crate version,
-    /// computes the affected reverse-topological yank order and
-    /// publish-directional fix-forward suggestions, then writes
-    /// `<state_dir>/remediation-plan.json` for operator review.
+    /// In `--dry-run` mode, reads a prior `receipt.json`, targets a
+    /// specific bad crate version, computes the affected reverse-topological
+    /// yank order and publish-directional fix-forward suggestions, then
+    /// writes `<state_dir>/remediation-plan.json` for operator review.
     ///
-    /// **Dry-run only.** This command does NOT invoke `cargo yank`, edit
-    /// manifests, or publish fix-forward successors.
+    /// In `--execute-plan` mode, reads a reviewed remediation plan and invokes
+    /// only the containment yanks in the recorded order. It does not edit
+    /// manifests or publish fix-forward successors.
     #[command(
         name = "remediate",
         long_about = "\
-Generate a receipt-driven remediation dry-run artifact.
+Generate or execute a receipt-driven remediation plan.
 
-Reads a prior `receipt.json`, targets a specific bad crate version, computes
-the affected reverse-topological yank order and publish-directional
-fix-forward suggestions, then writes `<state-dir>/remediation-plan.json` for
-operator review and agent consumption.
+In `--dry-run` mode, reads a prior `receipt.json`, targets a specific bad
+crate version, computes the affected reverse-topological yank order and
+publish-directional fix-forward suggestions, then writes
+`<state-dir>/remediation-plan.json` for operator review and agent consumption.
 
-This is planning only. It does NOT invoke `cargo yank`, edit manifests, or
-publish fix-forward successors.
+In `--execute-plan` mode, consumes that reviewed artifact and executes only the
+recorded containment yanks. It does NOT edit manifests or publish fix-forward
+successors.
 
 EXAMPLES:
     shipper remediate --dry-run --from-receipt .shipper/receipt.json --crate bad-crate --target-version 0.4.0 --reason \"CVE-2026-0001\"
+    shipper remediate --execute-plan .shipper/remediation-plan.json
 "
     )]
     Remediate {
         /// Path to the receipt to derive the remediation plan from. Defaults
         /// to `<state_dir>/receipt.json` when omitted.
-        #[arg(long, value_name = "PATH")]
+        #[arg(long, value_name = "PATH", conflicts_with = "execute_plan")]
         from_receipt: Option<PathBuf>,
         /// Bad crate name to contain and fix-forward.
-        #[arg(long = "crate", value_name = "NAME")]
-        crate_name: String,
+        #[arg(
+            long = "crate",
+            value_name = "NAME",
+            required_unless_present = "execute_plan",
+            conflicts_with = "execute_plan"
+        )]
+        crate_name: Option<String>,
         /// Bad crate version in the source receipt.
-        #[arg(long = "target-version", value_name = "VERSION")]
-        target_version: String,
+        #[arg(
+            long = "target-version",
+            value_name = "VERSION",
+            required_unless_present = "execute_plan",
+            conflicts_with = "execute_plan"
+        )]
+        target_version: Option<String>,
         /// Operator-supplied reason recorded in the artifact and command list.
-        #[arg(long, value_name = "REASON")]
-        reason: String,
+        #[arg(
+            long,
+            value_name = "REASON",
+            required_unless_present = "execute_plan",
+            conflicts_with = "execute_plan"
+        )]
+        reason: Option<String>,
         /// Required for now: generate the remediation artifact without
         /// executing yanks, editing manifests, or publishing successors.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "execute_plan")]
         dry_run: bool,
+        /// Execute a reviewed remediation plan artifact. Runs only the
+        /// recorded containment yanks and halts on the first failed yank.
+        #[arg(long = "execute-plan", value_name = "PATH")]
+        execute_plan: Option<PathBuf>,
     },
     /// Configuration file management.
     #[command(subcommand)]
@@ -1532,13 +1554,148 @@ pub fn run() -> Result<()> {
             target_version,
             reason,
             dry_run,
+            execute_plan,
         } => {
+            use shipper_core::cargo;
             use shipper_core::engine::{plan_yank, remediation};
             use shipper_core::runtime::execution::resolve_state_dir;
+            use shipper_core::state::events::{EventLog, events_path};
+
+            if let Some(plan_path) = execute_plan {
+                let state_dir = resolve_state_dir(&planned.workspace_root, &opts.state_dir);
+                let expected_plan_path =
+                    shipper_core::state::execution_state::remediation_plan_path(&state_dir);
+                let requested_plan_path = plan_path.canonicalize().with_context(|| {
+                    format!(
+                        "failed to resolve remediation plan path {}; execute reviewed plans from <state-dir>/remediation-plan.json",
+                        plan_path.display()
+                    )
+                })?;
+                let expected_plan_path = expected_plan_path.canonicalize().with_context(|| {
+                    format!(
+                        "failed to resolve expected remediation plan {}; run `shipper remediate --dry-run` first or pass --state-dir",
+                        expected_plan_path.display()
+                    )
+                })?;
+                if requested_plan_path != expected_plan_path {
+                    anyhow::bail!(
+                        "refusing to execute remediation plan outside the configured state dir; expected {}",
+                        expected_plan_path.display()
+                    );
+                }
+
+                let plan = remediation::load_plan_from_path(&expected_plan_path)?;
+                let events_file = events_path(&state_dir);
+                let registry_name = opts
+                    .registries
+                    .first()
+                    .map(|r| r.name.clone())
+                    .unwrap_or_else(|| "crates-io".to_string());
+                if plan.registry != registry_name {
+                    anyhow::bail!(
+                        "remediation plan registry '{}' does not match configured registry '{}'",
+                        plan.registry,
+                        registry_name
+                    );
+                }
+
+                reporter.warn(&format!(
+                    "executing reviewed remediation plan: {} containment yanks for {}@{} (plan_id {})",
+                    plan.yank_order.len(),
+                    plan.target.crate_name,
+                    plan.target.version,
+                    plan.plan_id
+                ));
+                reporter.warn(
+                    "remediate --execute-plan runs yanks only; fix-forward suggestions remain planning output",
+                );
+
+                let mut succeeded = 0usize;
+                for (idx, step) in plan.yank_order.iter().enumerate() {
+                    let event_reason = remediation::REDACTED_OPERATOR_REASON.to_string();
+                    reporter.warn(&format!(
+                        "[{}/{}] yanking {}@{} from {}",
+                        idx + 1,
+                        plan.yank_order.len(),
+                        step.name,
+                        step.version,
+                        registry_name
+                    ));
+
+                    let out = cargo::cargo_yank(
+                        &planned.workspace_root,
+                        step.name.as_str(),
+                        step.version.as_str(),
+                        registry_name.as_str(),
+                        opts.output_lines,
+                        None,
+                    )?;
+
+                    let mut log = EventLog::new();
+                    log.record(PublishEvent {
+                        timestamp: chrono::Utc::now(),
+                        event_type: EventType::PackageYanked {
+                            crate_name: step.name.clone(),
+                            version: step.version.clone(),
+                            reason: event_reason,
+                            exit_code: out.exit_code,
+                        },
+                        package: format!("{}@{}", step.name, step.version),
+                    });
+                    if let Err(err) = log.write_to_file(&events_file) {
+                        reporter.warn(&format!(
+                            "failed to append PackageYanked event to {}: {err:#}",
+                            events_file.display()
+                        ));
+                    }
+
+                    if out.exit_code == 0 {
+                        succeeded += 1;
+                        reporter.info(&format!(
+                            "[{}/{}] yanked {}@{}",
+                            idx + 1,
+                            plan.yank_order.len(),
+                            step.name,
+                            step.version
+                        ));
+                    } else {
+                        reporter.error(&format!(
+                            "[{}/{}] cargo yank exited {} for {}@{}. stderr tail:\n{}",
+                            idx + 1,
+                            plan.yank_order.len(),
+                            out.exit_code,
+                            step.name,
+                            step.version,
+                            out.stderr_tail
+                        ));
+                        anyhow::bail!(
+                            "remediation plan failed at {}@{}; {succeeded}/{} containment yanks succeeded before halt",
+                            step.name,
+                            step.version,
+                            plan.yank_order.len()
+                        );
+                    }
+                }
+
+                reporter.info(&format!(
+                    "remediation containment complete: {succeeded}/{} yanks executed successfully",
+                    plan.yank_order.len()
+                ));
+                return Ok(());
+            }
 
             if !dry_run {
                 bail!("remediate currently supports planning only; rerun with --dry-run");
             }
+            let crate_name = crate_name.ok_or_else(|| {
+                anyhow::anyhow!("--crate is required when --execute-plan is not supplied")
+            })?;
+            let target_version = target_version.ok_or_else(|| {
+                anyhow::anyhow!("--target-version is required when --execute-plan is not supplied")
+            })?;
+            let reason = reason.ok_or_else(|| {
+                anyhow::anyhow!("--reason is required when --execute-plan is not supplied")
+            })?;
 
             let state_dir = resolve_state_dir(&planned.workspace_root, &opts.state_dir);
             let receipt_path = from_receipt

--- a/crates/shipper-cli/tests/e2e_expanded.rs
+++ b/crates/shipper-cli/tests/e2e_expanded.rs
@@ -2,7 +2,7 @@
 //! clean, completion, CI subcommands, error output, and snapshot stability.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::thread;
 
 use assert_cmd::Command;
@@ -339,6 +339,104 @@ fn write_remediation_receipt(path: &Path) {
 }
 "#,
     );
+}
+
+fn write_fake_yank_cargo(path: &Path, fail_yanks: bool) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let fake = path.join("fake-cargo.cmd");
+        let yank_exit = if fail_yanks {
+            "echo fake yank failure for %~2 1>&2\r\n  exit /b 55"
+        } else {
+            "exit /b 0"
+        };
+        write_file(
+            &fake,
+            &format!(
+                r#"@echo off
+setlocal enabledelayedexpansion
+echo %*>>"%SHIPPER_FAKE_CARGO_LOG%"
+if "%~1"=="yank" (
+  {yank_exit}
+)
+echo unexpected cargo command %* 1>&2
+exit /b 64
+"#,
+            ),
+        );
+        fake
+    }
+
+    #[cfg(not(windows))]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let fake = path.join("fake-cargo");
+        let yank_exit = if fail_yanks {
+            "printf '%s\\n' \"fake yank failure for $2\" >&2\n    exit 55"
+        } else {
+            "exit 0"
+        };
+        write_file(
+            &fake,
+            &format!(
+                r#"#!/usr/bin/env sh
+printf '%s\n' "$*" >> "$SHIPPER_FAKE_CARGO_LOG"
+if [ "$1" = "yank" ]; then
+  {yank_exit}
+fi
+printf '%s\n' "unexpected cargo command $*" >&2
+exit 64
+"#,
+            ),
+        );
+        let mut perms = fs::metadata(&fake).expect("meta").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&fake, perms).expect("chmod");
+        fake
+    }
+}
+
+fn write_remediation_dry_run_artifact(
+    root: &Path,
+    state_dir: &Path,
+    receipt_path: &Path,
+) -> PathBuf {
+    let output = shipper_cmd()
+        .arg("--manifest-path")
+        .arg(root.join("Cargo.toml"))
+        .arg("--state-dir")
+        .arg(state_dir)
+        .args([
+            "remediate",
+            "--dry-run",
+            "--from-receipt",
+            receipt_path.to_str().expect("utf8 path"),
+            "--crate",
+            "core-lib",
+            "--target-version",
+            "0.2.0",
+            "--reason",
+            "plain-text incident token secret123",
+        ])
+        .output()
+        .expect("failed to run remediation dry-run");
+
+    assert!(
+        output.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    state_dir.join("remediation-plan.json")
+}
+
+fn read_jsonl(path: &Path) -> Vec<serde_json::Value> {
+    fs::read_to_string(path)
+        .expect("read jsonl")
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("event JSON line parses"))
+        .collect()
 }
 
 /// Create a workspace with a publish = false crate mixed in.
@@ -1807,6 +1905,184 @@ fn remediate_dry_run_writes_remediation_plan_artifact() {
             .any(|note| note
                 .as_str()
                 .is_some_and(|text| text.contains("Dry-run only")))
+    );
+}
+
+#[test]
+fn remediate_guarded_execution_executes_reviewed_plan_with_fake_cargo() {
+    let td = tempdir().expect("tempdir");
+    create_multi_crate_workspace(td.path());
+    let receipt_path = td.path().join("receipt.json");
+    let state_dir = td.path().join(".shipper");
+    write_remediation_receipt(&receipt_path);
+    let artifact = write_remediation_dry_run_artifact(td.path(), &state_dir, &receipt_path);
+    let fake_cargo = write_fake_yank_cargo(td.path(), false);
+    let fake_log = td.path().join("fake-cargo.log");
+
+    let output = shipper_cmd()
+        .arg("--manifest-path")
+        .arg(td.path().join("Cargo.toml"))
+        .arg("--state-dir")
+        .arg(&state_dir)
+        .args(["remediate", "--execute-plan"])
+        .arg(&artifact)
+        .env("SHIPPER_CARGO_BIN", &fake_cargo)
+        .env("SHIPPER_FAKE_CARGO_LOG", &fake_log)
+        .output()
+        .expect("failed to run remediation guarded execution");
+
+    assert!(
+        output.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let calls = fs::read_to_string(&fake_log).expect("read fake cargo log");
+    assert!(
+        calls.contains("yank top-app") && calls.contains("--version=0.4.0"),
+        "top-app yank should run first: {calls}"
+    );
+    assert!(
+        calls.contains("yank core-lib") && calls.contains("--version=0.2.0"),
+        "core-lib yank should run: {calls}"
+    );
+    assert!(
+        calls.find("top-app").expect("top-app call")
+            < calls.find("core-lib").expect("core-lib call"),
+        "containment yanks should run dependents first: {calls}"
+    );
+
+    let events = read_jsonl(&state_dir.join("events.jsonl"));
+    assert_eq!(events.len(), 2, "expected one event per yank: {events:#?}");
+    assert_eq!(
+        events[0]
+            .pointer("/event_type/type")
+            .and_then(|v| v.as_str()),
+        Some("package_yanked")
+    );
+    assert_eq!(
+        events[0]
+            .pointer("/event_type/crate_name")
+            .and_then(|v| v.as_str()),
+        Some("top-app")
+    );
+    assert_eq!(
+        events[1]
+            .pointer("/event_type/crate_name")
+            .and_then(|v| v.as_str()),
+        Some("core-lib")
+    );
+    assert_eq!(
+        events[1]
+            .pointer("/event_type/exit_code")
+            .and_then(|v| v.as_i64()),
+        Some(0)
+    );
+}
+
+#[test]
+fn remediate_guarded_execution_halts_on_failed_yank() {
+    let td = tempdir().expect("tempdir");
+    create_multi_crate_workspace(td.path());
+    let receipt_path = td.path().join("receipt.json");
+    let state_dir = td.path().join(".shipper");
+    write_remediation_receipt(&receipt_path);
+    let artifact = write_remediation_dry_run_artifact(td.path(), &state_dir, &receipt_path);
+    let fake_cargo = write_fake_yank_cargo(td.path(), true);
+    let fake_log = td.path().join("fake-cargo.log");
+
+    let output = shipper_cmd()
+        .arg("--manifest-path")
+        .arg(td.path().join("Cargo.toml"))
+        .arg("--state-dir")
+        .arg(&state_dir)
+        .args(["remediate", "--execute-plan"])
+        .arg(&artifact)
+        .env("SHIPPER_CARGO_BIN", &fake_cargo)
+        .env("SHIPPER_FAKE_CARGO_LOG", &fake_log)
+        .output()
+        .expect("failed to run remediation guarded execution");
+
+    assert!(
+        !output.status.success(),
+        "execution should fail on the first failed yank"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("remediation plan failed at top-app@0.4.0"),
+        "stderr should name failed step: {stderr}"
+    );
+    let calls = fs::read_to_string(&fake_log).expect("read fake cargo log");
+    assert!(
+        calls.contains("yank top-app") && calls.contains("--version=0.4.0"),
+        "first yank should be attempted: {calls}"
+    );
+    assert!(
+        !calls.contains("core-lib"),
+        "execution should halt before later yanks: {calls}"
+    );
+
+    let events = read_jsonl(&state_dir.join("events.jsonl"));
+    assert_eq!(events.len(), 1, "expected only the failed yank event");
+    assert_eq!(
+        events[0]
+            .pointer("/event_type/crate_name")
+            .and_then(|v| v.as_str()),
+        Some("top-app")
+    );
+    assert_eq!(
+        events[0]
+            .pointer("/event_type/exit_code")
+            .and_then(|v| v.as_i64()),
+        Some(55)
+    );
+}
+
+#[test]
+fn remediate_guarded_execution_redacts_event_reason() {
+    let td = tempdir().expect("tempdir");
+    create_multi_crate_workspace(td.path());
+    let receipt_path = td.path().join("receipt.json");
+    let state_dir = td.path().join(".shipper");
+    write_remediation_receipt(&receipt_path);
+    let artifact = write_remediation_dry_run_artifact(td.path(), &state_dir, &receipt_path);
+    let raw = fs::read_to_string(&artifact).expect("read remediation artifact");
+    fs::write(
+        &artifact,
+        raw.replace(
+            "[OPERATOR_REASON_REDACTED]",
+            "operator secret token secret123",
+        ),
+    )
+    .expect("rewrite artifact");
+    let fake_cargo = write_fake_yank_cargo(td.path(), false);
+    let fake_log = td.path().join("fake-cargo.log");
+
+    let output = shipper_cmd()
+        .arg("--manifest-path")
+        .arg(td.path().join("Cargo.toml"))
+        .arg("--state-dir")
+        .arg(&state_dir)
+        .args(["remediate", "--execute-plan"])
+        .arg(&artifact)
+        .env("SHIPPER_CARGO_BIN", &fake_cargo)
+        .env("SHIPPER_FAKE_CARGO_LOG", &fake_log)
+        .output()
+        .expect("failed to run remediation guarded execution");
+
+    assert!(
+        output.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let events_raw = fs::read_to_string(state_dir.join("events.jsonl")).expect("read events");
+    assert!(
+        !events_raw.contains("secret123"),
+        "event evidence should not persist reviewed-plan reason text"
+    );
+    assert!(
+        events_raw.contains("[OPERATOR_REASON_REDACTED]"),
+        "event evidence should carry the redacted reason placeholder"
     );
 }
 

--- a/crates/shipper-cli/tests/e2e_expanded.rs
+++ b/crates/shipper-cli/tests/e2e_expanded.rs
@@ -2,7 +2,7 @@
 //! clean, completion, CI subcommands, error output, and snapshot stability.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::thread;
 
 use assert_cmd::Command;
@@ -339,6 +339,104 @@ fn write_remediation_receipt(path: &Path) {
 }
 "#,
     );
+}
+
+fn write_fake_yank_cargo(path: &Path, fail_yanks: bool) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let fake = path.join("fake-cargo.cmd");
+        let yank_exit = if fail_yanks {
+            "echo fake yank failure for %~2 1>&2\r\n  exit /b 55"
+        } else {
+            "exit /b 0"
+        };
+        write_file(
+            &fake,
+            &format!(
+                r#"@echo off
+setlocal enabledelayedexpansion
+echo %*>>"%SHIPPER_FAKE_CARGO_LOG%"
+if "%~1"=="yank" (
+  {yank_exit}
+)
+echo unexpected cargo command %* 1>&2
+exit /b 64
+"#,
+            ),
+        );
+        fake
+    }
+
+    #[cfg(not(windows))]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let fake = path.join("fake-cargo");
+        let yank_exit = if fail_yanks {
+            "printf '%s\\n' \"fake yank failure for $2\" >&2\n    exit 55"
+        } else {
+            "exit 0"
+        };
+        write_file(
+            &fake,
+            &format!(
+                r#"#!/usr/bin/env sh
+printf '%s\n' "$*" >> "$SHIPPER_FAKE_CARGO_LOG"
+if [ "$1" = "yank" ]; then
+  {yank_exit}
+fi
+printf '%s\n' "unexpected cargo command $*" >&2
+exit 64
+"#,
+            ),
+        );
+        let mut perms = fs::metadata(&fake).expect("meta").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&fake, perms).expect("chmod");
+        fake
+    }
+}
+
+fn write_remediation_dry_run_artifact(
+    root: &Path,
+    state_dir: &Path,
+    receipt_path: &Path,
+) -> PathBuf {
+    let output = shipper_cmd()
+        .arg("--manifest-path")
+        .arg(root.join("Cargo.toml"))
+        .arg("--state-dir")
+        .arg(state_dir)
+        .args([
+            "remediate",
+            "--dry-run",
+            "--from-receipt",
+            receipt_path.to_str().expect("utf8 path"),
+            "--crate",
+            "core-lib",
+            "--target-version",
+            "0.2.0",
+            "--reason",
+            "plain-text incident token secret123",
+        ])
+        .output()
+        .expect("failed to run remediation dry-run");
+
+    assert!(
+        output.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    state_dir.join("remediation-plan.json")
+}
+
+fn read_jsonl(path: &Path) -> Vec<serde_json::Value> {
+    fs::read_to_string(path)
+        .expect("read jsonl")
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("event JSON line parses"))
+        .collect()
 }
 
 /// Create a workspace with a publish = false crate mixed in.
@@ -1807,6 +1905,263 @@ fn remediate_dry_run_writes_remediation_plan_artifact() {
             .any(|note| note
                 .as_str()
                 .is_some_and(|text| text.contains("Dry-run only")))
+    );
+}
+
+#[test]
+fn remediate_guarded_execution_executes_reviewed_plan_with_fake_cargo() {
+    let td = tempdir().expect("tempdir");
+    create_multi_crate_workspace(td.path());
+    let receipt_path = td.path().join("receipt.json");
+    let state_dir = td.path().join(".shipper");
+    write_remediation_receipt(&receipt_path);
+    let artifact = write_remediation_dry_run_artifact(td.path(), &state_dir, &receipt_path);
+    let fake_cargo = write_fake_yank_cargo(td.path(), false);
+    let fake_log = td.path().join("fake-cargo.log");
+
+    let output = shipper_cmd()
+        .arg("--manifest-path")
+        .arg(td.path().join("Cargo.toml"))
+        .arg("--state-dir")
+        .arg(&state_dir)
+        .args(["remediate", "--execute-plan"])
+        .arg(&artifact)
+        .env("SHIPPER_CARGO_BIN", &fake_cargo)
+        .env("SHIPPER_FAKE_CARGO_LOG", &fake_log)
+        .output()
+        .expect("failed to run remediation guarded execution");
+
+    assert!(
+        output.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let calls = fs::read_to_string(&fake_log).expect("read fake cargo log");
+    assert!(
+        calls.contains("yank top-app") && calls.contains("--version=0.4.0"),
+        "top-app yank should run first: {calls}"
+    );
+    assert!(
+        calls.contains("yank core-lib") && calls.contains("--version=0.2.0"),
+        "core-lib yank should run: {calls}"
+    );
+    assert!(
+        calls.find("top-app").expect("top-app call")
+            < calls.find("core-lib").expect("core-lib call"),
+        "containment yanks should run dependents first: {calls}"
+    );
+
+    let events = read_jsonl(&state_dir.join("events.jsonl"));
+    assert_eq!(events.len(), 2, "expected one event per yank: {events:#?}");
+    assert_eq!(
+        events[0]
+            .pointer("/event_type/type")
+            .and_then(|v| v.as_str()),
+        Some("package_yanked")
+    );
+    assert_eq!(
+        events[0]
+            .pointer("/event_type/crate_name")
+            .and_then(|v| v.as_str()),
+        Some("top-app")
+    );
+    assert_eq!(
+        events[1]
+            .pointer("/event_type/crate_name")
+            .and_then(|v| v.as_str()),
+        Some("core-lib")
+    );
+    assert_eq!(
+        events[1]
+            .pointer("/event_type/exit_code")
+            .and_then(|v| v.as_i64()),
+        Some(0)
+    );
+}
+
+#[test]
+fn remediate_guarded_execution_halts_on_failed_yank() {
+    let td = tempdir().expect("tempdir");
+    create_multi_crate_workspace(td.path());
+    let receipt_path = td.path().join("receipt.json");
+    let state_dir = td.path().join(".shipper");
+    write_remediation_receipt(&receipt_path);
+    let artifact = write_remediation_dry_run_artifact(td.path(), &state_dir, &receipt_path);
+    let fake_cargo = write_fake_yank_cargo(td.path(), true);
+    let fake_log = td.path().join("fake-cargo.log");
+
+    let output = shipper_cmd()
+        .arg("--manifest-path")
+        .arg(td.path().join("Cargo.toml"))
+        .arg("--state-dir")
+        .arg(&state_dir)
+        .args(["remediate", "--execute-plan"])
+        .arg(&artifact)
+        .env("SHIPPER_CARGO_BIN", &fake_cargo)
+        .env("SHIPPER_FAKE_CARGO_LOG", &fake_log)
+        .output()
+        .expect("failed to run remediation guarded execution");
+
+    assert!(
+        !output.status.success(),
+        "execution should fail on the first failed yank"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("remediation plan failed at top-app@0.4.0"),
+        "stderr should name failed step: {stderr}"
+    );
+    let calls = fs::read_to_string(&fake_log).expect("read fake cargo log");
+    assert!(
+        calls.contains("yank top-app") && calls.contains("--version=0.4.0"),
+        "first yank should be attempted: {calls}"
+    );
+    assert!(
+        !calls.contains("core-lib"),
+        "execution should halt before later yanks: {calls}"
+    );
+
+    let events = read_jsonl(&state_dir.join("events.jsonl"));
+    assert_eq!(events.len(), 1, "expected only the failed yank event");
+    assert_eq!(
+        events[0]
+            .pointer("/event_type/crate_name")
+            .and_then(|v| v.as_str()),
+        Some("top-app")
+    );
+    assert_eq!(
+        events[0]
+            .pointer("/event_type/exit_code")
+            .and_then(|v| v.as_i64()),
+        Some(55)
+    );
+}
+
+#[test]
+fn remediate_guarded_execution_redacts_event_reason() {
+    let td = tempdir().expect("tempdir");
+    create_multi_crate_workspace(td.path());
+    let receipt_path = td.path().join("receipt.json");
+    let state_dir = td.path().join(".shipper");
+    write_remediation_receipt(&receipt_path);
+    let artifact = write_remediation_dry_run_artifact(td.path(), &state_dir, &receipt_path);
+    let raw = fs::read_to_string(&artifact).expect("read remediation artifact");
+    fs::write(
+        &artifact,
+        raw.replace(
+            "[OPERATOR_REASON_REDACTED]",
+            "operator secret token secret123",
+        ),
+    )
+    .expect("rewrite artifact");
+    let fake_cargo = write_fake_yank_cargo(td.path(), false);
+    let fake_log = td.path().join("fake-cargo.log");
+
+    let output = shipper_cmd()
+        .arg("--manifest-path")
+        .arg(td.path().join("Cargo.toml"))
+        .arg("--state-dir")
+        .arg(&state_dir)
+        .args(["remediate", "--execute-plan"])
+        .arg(&artifact)
+        .env("SHIPPER_CARGO_BIN", &fake_cargo)
+        .env("SHIPPER_FAKE_CARGO_LOG", &fake_log)
+        .output()
+        .expect("failed to run remediation guarded execution");
+
+    assert!(
+        output.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let events_raw = fs::read_to_string(state_dir.join("events.jsonl")).expect("read events");
+    assert!(
+        !events_raw.contains("secret123"),
+        "event evidence should not persist reviewed-plan reason text"
+    );
+    assert!(
+        events_raw.contains("[OPERATOR_REASON_REDACTED]"),
+        "event evidence should carry the redacted reason placeholder"
+    );
+}
+
+#[test]
+fn remediate_guarded_execution_requires_state_dir_plan() {
+    let td = tempdir().expect("tempdir");
+    create_multi_crate_workspace(td.path());
+    let receipt_path = td.path().join("receipt.json");
+    let state_dir = td.path().join(".shipper");
+    write_remediation_receipt(&receipt_path);
+    let artifact = write_remediation_dry_run_artifact(td.path(), &state_dir, &receipt_path);
+    let outside_plan = td.path().join("outside-remediation-plan.json");
+    fs::copy(&artifact, &outside_plan).expect("copy plan outside state dir");
+
+    let output = shipper_cmd()
+        .arg("--manifest-path")
+        .arg(td.path().join("Cargo.toml"))
+        .arg("--state-dir")
+        .arg(&state_dir)
+        .args(["remediate", "--execute-plan"])
+        .arg(&outside_plan)
+        .output()
+        .expect("failed to run remediation guarded execution");
+
+    assert!(
+        !output.status.success(),
+        "execution should reject plans outside the configured state dir"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("refusing to execute remediation plan outside the configured state dir"),
+        "stderr should explain state-dir plan restriction: {stderr}"
+    );
+}
+
+#[test]
+fn remediate_guarded_execution_rejects_registry_mismatch() {
+    let td = tempdir().expect("tempdir");
+    create_multi_crate_workspace(td.path());
+    let receipt_path = td.path().join("receipt.json");
+    let state_dir = td.path().join(".shipper");
+    write_remediation_receipt(&receipt_path);
+    let artifact = write_remediation_dry_run_artifact(td.path(), &state_dir, &receipt_path);
+    let raw = fs::read_to_string(&artifact).expect("read remediation artifact");
+    fs::write(
+        &artifact,
+        raw.replace(
+            r#""registry": "crates-io""#,
+            r#""registry": "evil-registry""#,
+        ),
+    )
+    .expect("rewrite artifact");
+    let fake_cargo = write_fake_yank_cargo(td.path(), false);
+    let fake_log = td.path().join("fake-cargo.log");
+
+    let output = shipper_cmd()
+        .arg("--manifest-path")
+        .arg(td.path().join("Cargo.toml"))
+        .arg("--state-dir")
+        .arg(&state_dir)
+        .args(["remediate", "--execute-plan"])
+        .arg(&artifact)
+        .env("SHIPPER_CARGO_BIN", &fake_cargo)
+        .env("SHIPPER_FAKE_CARGO_LOG", &fake_log)
+        .output()
+        .expect("failed to run remediation guarded execution");
+
+    assert!(
+        !output.status.success(),
+        "execution should reject plan registry mismatch"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("does not match configured registry"),
+        "stderr should explain registry mismatch: {stderr}"
+    );
+    assert!(
+        !fake_log.exists(),
+        "registry mismatch should fail before invoking Cargo"
     );
 }
 

--- a/crates/shipper-cli/tests/snapshots/cli_snapshots__help_text.snap
+++ b/crates/shipper-cli/tests/snapshots/cli_snapshots__help_text.snap
@@ -21,7 +21,7 @@ Commands:
   yank             Yank a crate@version from the registry — containment, not undo
   plan-yank        Generate a reverse-topological yank plan from a receipt (#98 PR 2)
   fix-forward      Generate a fix-forward supersession plan from a compromised receipt (#98 PR 3)
-  remediate        Generate a receipt-driven remediation dry-run artifact
+  remediate        Generate or execute a receipt-driven remediation plan
   config           Configuration file management
   completion       Generate shell completion scripts for the specified shell
   help             Print this message or the help of the given subcommand(s)

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_remediate.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_remediate.snap
@@ -1,22 +1,25 @@
 ---
 source: crates/shipper-cli/tests/e2e_expanded.rs
+assertion_line: 1706
 expression: trim_trailing_line_ws(&normalize_stderr(&stdout))
 ---
-Generate a receipt-driven remediation dry-run artifact.
+Generate or execute a receipt-driven remediation plan.
 
-Reads a prior `receipt.json`, targets a specific bad crate version, computes
-the affected reverse-topological yank order and publish-directional
-fix-forward suggestions, then writes `<state-dir>/remediation-plan.json` for
-operator review and agent consumption.
+In `--dry-run` mode, reads a prior `receipt.json`, targets a specific bad
+crate version, computes the affected reverse-topological yank order and
+publish-directional fix-forward suggestions, then writes
+`<state-dir>/remediation-plan.json` for operator review and agent consumption.
 
-This is planning only. It does NOT invoke `cargo yank`, edit manifests, or
-publish fix-forward successors.
+In `--execute-plan` mode, consumes that reviewed artifact and executes only the
+recorded containment yanks. It does NOT edit manifests or publish fix-forward
+successors.
 
 EXAMPLES:
     shipper remediate --dry-run --from-receipt .shipper/receipt.json --crate bad-crate --target-version 0.4.0 --reason "CVE-2026-0001"
+    shipper remediate --execute-plan .shipper/remediation-plan.json
 
 
-Usage: shipper-cli remediate [OPTIONS] --crate <NAME> --target-version <VERSION> --reason <REASON>
+Usage: shipper-cli remediate [OPTIONS]
 
 Options:
       --from-receipt <PATH>
@@ -50,6 +53,9 @@ Options:
 
       --dry-run
           Required for now: generate the remediation artifact without executing yanks, editing manifests, or publishing successors
+
+      --execute-plan <PATH>
+          Execute a reviewed remediation plan artifact. Runs only the recorded containment yanks and halts on the first failed yank
 
       --package <PACKAGES>
           Restrict to specific packages (repeatable). If omitted, publishes all publishable workspace members

--- a/crates/shipper-cli/tests/snapshots/e2e_expanded__help_root.snap
+++ b/crates/shipper-cli/tests/snapshots/e2e_expanded__help_root.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/shipper-cli/tests/e2e_expanded.rs
+assertion_line: 3303
 expression: normalize_stderr(&stdout)
 ---
 Resumable, backoff-aware crates.io publishing for workspaces
@@ -21,7 +22,7 @@ Commands:
   yank             Yank a crate@version from the registry — containment, not undo
   plan-yank        Generate a reverse-topological yank plan from a receipt (#98 PR 2)
   fix-forward      Generate a fix-forward supersession plan from a compromised receipt (#98 PR 3)
-  remediate        Generate a receipt-driven remediation dry-run artifact
+  remediate        Generate or execute a receipt-driven remediation plan
   config           Configuration file management
   completion       Generate shell completion scripts for the specified shell
   help             Print this message or the help of the given subcommand(s)

--- a/crates/shipper-core/src/engine/remediation.rs
+++ b/crates/shipper-core/src/engine/remediation.rs
@@ -207,6 +207,60 @@ pub fn write_dry_run_artifact(state_dir: &Path, plan: &RemediationPlan) -> Resul
     Ok(path)
 }
 
+pub fn load_plan_from_path(path: &Path) -> Result<RemediationPlan> {
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("failed to open remediation plan {}", path.display()))?;
+    let plan: RemediationPlan = serde_json::from_reader(file)
+        .with_context(|| format!("failed to parse remediation plan {}", path.display()))?;
+    if plan.schema_version != REMEDIATION_PLAN_SCHEMA_VERSION {
+        bail!(
+            "unsupported remediation plan schema_version '{}'; expected '{}'",
+            plan.schema_version,
+            REMEDIATION_PLAN_SCHEMA_VERSION
+        );
+    }
+    validate_identifier("registry", &plan.registry)?;
+    validate_crate_name("target crate", &plan.target.crate_name)?;
+    validate_version("target version", &plan.target.version)?;
+    for (idx, step) in plan.yank_order.iter().enumerate() {
+        validate_crate_name(&format!("yank_order[{idx}].name"), &step.name)?;
+        validate_version(&format!("yank_order[{idx}].version"), &step.version)?;
+    }
+    Ok(plan)
+}
+
+fn validate_identifier(field: &str, value: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        bail!("{field} must not be empty");
+    }
+    if value.starts_with('-')
+        || value
+            .chars()
+            .any(|c| !(c.is_ascii_alphanumeric() || c == '-' || c == '_'))
+    {
+        bail!("{field} contains unsupported characters");
+    }
+    Ok(())
+}
+
+fn validate_crate_name(field: &str, value: &str) -> Result<()> {
+    validate_identifier(field, value)
+}
+
+fn validate_version(field: &str, value: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        bail!("{field} must not be empty");
+    }
+    if value.starts_with('-')
+        || value
+            .chars()
+            .any(|c| !(c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '+'))
+    {
+        bail!("{field} contains unsupported characters");
+    }
+    Ok(())
+}
+
 pub fn render_text(plan: &RemediationPlan, artifact_path: &Path) -> String {
     let mut out = String::new();
     out.push_str("Remediation dry-run plan\n");

--- a/crates/shipper-core/src/engine/remediation.rs
+++ b/crates/shipper-core/src/engine/remediation.rs
@@ -207,6 +207,21 @@ pub fn write_dry_run_artifact(state_dir: &Path, plan: &RemediationPlan) -> Resul
     Ok(path)
 }
 
+pub fn load_plan_from_path(path: &Path) -> Result<RemediationPlan> {
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("failed to open remediation plan {}", path.display()))?;
+    let plan: RemediationPlan = serde_json::from_reader(file)
+        .with_context(|| format!("failed to parse remediation plan {}", path.display()))?;
+    if plan.schema_version != REMEDIATION_PLAN_SCHEMA_VERSION {
+        bail!(
+            "unsupported remediation plan schema_version '{}'; expected '{}'",
+            plan.schema_version,
+            REMEDIATION_PLAN_SCHEMA_VERSION
+        );
+    }
+    Ok(plan)
+}
+
 pub fn render_text(plan: &RemediationPlan, artifact_path: &Path) -> String {
     let mut out = String::new();
     out.push_str("Remediation dry-run plan\n");


### PR DESCRIPTION
## Summary

- add `shipper remediate --execute-plan <PATH>` to consume reviewed `shipper.remediation_plan.v1` artifacts
- execute only the recorded containment yanks, emit `PackageYanked` events, and halt on the first failed yank
- keep event evidence reason text redacted and leave fix-forward suggestions as planning output
- update remediation help snapshots for the new execution mode

## Validation

- `cargo test -p shipper-cli --test e2e_expanded --locked remediate_guarded_execution_executes_reviewed_plan_with_fake_cargo`
- `cargo test -p shipper-cli --test e2e_expanded --locked remediate_guarded_execution_halts_on_failed_yank`
- `cargo test -p shipper-cli --test e2e_expanded --locked remediate_guarded_execution_redacts_event_reason`
- `cargo test -p shipper-core remediation --lib --locked`
- `cargo test -p shipper-cli --test e2e_expanded --locked`
- `cargo clippy -p shipper-core -p shipper-cli --all-targets --locked -- -D warnings`
- `cargo xtask check-doc-contracts --mode advisory`
- `cargo xtask check-file-policy --mode blocking-allowlist`
- `cargo xtask policy-report`
- `cargo fmt --all -- --check`
- `git diff --check`

## Notes

This PR keeps support-tier and active-goal promotion out of the runtime change. Those can move in a follow-up status PR after this proof lands.