### PR TITLE
plans: activate trusted publishing default proof

### DIFF
--- a/.shipper-meta/goals/active.toml
+++ b/.shipper-meta/goals/active.toml
@@ -1,31 +1,31 @@
-id = "shipper-idempotent-workspace-publish"
-title = "Idempotent workspace publish proof"
-status = "complete"
+id = "shipper-trusted-publishing-default-proof"
+title = "Trusted Publishing default proof"
+status = "active"
 owner = "EffortlessMetrics"
 created = "2026-05-19"
 
 objective = """
-Make Shipper's publish command a spec-addressable safe retry surface:
-publishing must be version-idempotent against registry truth, skipped-existing
-packages must be explicit, mixed existing/missing workspaces must remain safe,
-and JSON/receipt evidence must tell operators and agents whether rerun/resume
-is safe.
+Make Shipper's Trusted Publishing default claim proof-backed instead of
+aspirational: release evidence must prove whether the short-lived-token path is
+available, whether fallback was used, which external crates.io registration gap
+remains, and why support tiers should or should not promote the default claim.
 """
 
 end_state = [
-  "The active goal points to the accepted idempotent workspace publish spec and plan.",
-  "Focused tests prove all-existing and mixed existing/missing publish behavior.",
-  "Publish JSON and receipts expose package outcomes and artifact paths without overclaiming source-diff truth.",
-  "Support tiers promote idempotent workspace publish only after the proof commands exist.",
+  "The active goal points to the accepted release-auth evidence spec and plan.",
+  "The completed idempotent workspace publish goal is archived.",
+  "The release-auth plan separates existing fallback proof from future Trusted Publishing default proof.",
+  "Support tiers keep Trusted Publishing default planned/advisory until short-lived-token proof exists.",
+  "Any external crates.io registration blocker is recorded as evidence, not hidden prose.",
 ]
 
 [[work_item]]
-id = "idempotent-source-of-truth"
-status = "complete"
+id = "trusted-publishing-default-source-of-truth"
+status = "active"
 proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
-spec = "docs/specs/SHIPPER-SPEC-0007-idempotent-workspace-publish.md"
-plan = "plans/0.4.0/idempotent-workspace-publish.md"
-issue = "109"
+spec = "docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md"
+plan = "plans/0.4.0/release-auth-evidence-and-trusted-publishing.md"
+issue = "105"
 commands = [
   "python -c \"import pathlib,tomllib; tomllib.loads(pathlib.Path('.shipper-meta/goals/active.toml').read_text()); print('active goal TOML parses')\"",
   "cargo xtask check-doc-contracts --mode advisory",
@@ -36,39 +36,28 @@ commands = [
 ]
 
 [[work_item]]
-id = "idempotent-publish-regression-suite"
-status = "complete"
+id = "trusted-publishing-registration-proof"
+status = "planned"
 proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
-spec = "docs/specs/SHIPPER-SPEC-0007-idempotent-workspace-publish.md"
-plan = "plans/0.4.0/idempotent-workspace-publish.md"
-issue = "109"
+spec = "docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md"
+plan = "plans/0.4.0/release-auth-evidence-and-trusted-publishing.md"
+issue = "105"
 commands = [
-  "cargo test -p shipper-cli --test bdd_publish --locked",
-  "cargo test -p shipper-cli --test e2e_publish --locked",
+  "release auth rehearsal or release-readiness workflow artifact proving selected_token_source = trusted_publishing",
+  "cargo xtask check-workflow-surfaces --mode advisory",
+  "cargo xtask check-process-policy --mode advisory",
+  "cargo xtask check-network-policy --mode advisory",
   "cargo xtask policy-report",
-  "cargo fmt --all -- --check",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "publish-rerun-posture-evidence"
-status = "complete"
+id = "trusted-publishing-default-promotion"
+status = "planned"
 proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
-spec = "docs/specs/SHIPPER-SPEC-0007-idempotent-workspace-publish.md"
-plan = "plans/0.4.0/idempotent-workspace-publish.md"
-issue = "109"
-commands = [
-  "cargo test -p shipper-cli --test e2e_publish --locked",
-  "cargo xtask policy-report",
-]
-
-[[work_item]]
-id = "idempotent-support-tier-promotion"
-status = "complete"
-proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
-spec = "docs/specs/SHIPPER-SPEC-0007-idempotent-workspace-publish.md"
-plan = "plans/0.4.0/idempotent-workspace-publish.md"
-issue = "109"
+spec = "docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md"
+plan = "plans/0.4.0/release-auth-evidence-and-trusted-publishing.md"
+issue = "105"
 commands = [
   "cargo xtask check-doc-contracts --mode advisory",
   "cargo xtask policy-report",

--- a/.shipper-meta/goals/archive/shipper-idempotent-workspace-publish.toml
+++ b/.shipper-meta/goals/archive/shipper-idempotent-workspace-publish.toml
@@ -1,0 +1,78 @@
+id = "shipper-idempotent-workspace-publish"
+title = "Idempotent workspace publish proof"
+status = "complete"
+owner = "EffortlessMetrics"
+created = "2026-05-19"
+completed = "2026-05-19"
+
+objective = """
+Make Shipper's publish command a spec-addressable safe retry surface:
+publishing must be version-idempotent against registry truth, skipped-existing
+packages must be explicit, mixed existing/missing workspaces must remain safe,
+and JSON/receipt evidence must tell operators and agents whether rerun/resume
+is safe.
+"""
+
+end_state = [
+  "The active goal points to the accepted idempotent workspace publish spec and plan.",
+  "Focused tests prove all-existing and mixed existing/missing publish behavior.",
+  "Publish JSON and receipts expose package outcomes and artifact paths without overclaiming source-diff truth.",
+  "Support tiers promote idempotent workspace publish only after the proof commands exist.",
+]
+
+[[work_item]]
+id = "idempotent-source-of-truth"
+status = "complete"
+proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
+spec = "docs/specs/SHIPPER-SPEC-0007-idempotent-workspace-publish.md"
+plan = "plans/0.4.0/idempotent-workspace-publish.md"
+issue = "109"
+commands = [
+  "python -c \"import pathlib,tomllib; tomllib.loads(pathlib.Path('.shipper-meta/goals/active.toml').read_text()); print('active goal TOML parses')\"",
+  "cargo xtask check-doc-contracts --mode advisory",
+  "cargo xtask check-file-policy --mode blocking-allowlist",
+  "cargo xtask policy-report",
+  "cargo fmt --all -- --check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "idempotent-publish-regression-suite"
+status = "complete"
+proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
+spec = "docs/specs/SHIPPER-SPEC-0007-idempotent-workspace-publish.md"
+plan = "plans/0.4.0/idempotent-workspace-publish.md"
+issue = "109"
+commands = [
+  "cargo test -p shipper-cli --test bdd_publish --locked",
+  "cargo test -p shipper-cli --test e2e_publish --locked",
+  "cargo xtask policy-report",
+  "cargo fmt --all -- --check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "publish-rerun-posture-evidence"
+status = "complete"
+proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
+spec = "docs/specs/SHIPPER-SPEC-0007-idempotent-workspace-publish.md"
+plan = "plans/0.4.0/idempotent-workspace-publish.md"
+issue = "109"
+commands = [
+  "cargo test -p shipper-cli --test e2e_publish --locked",
+  "cargo xtask policy-report",
+]
+
+[[work_item]]
+id = "idempotent-support-tier-promotion"
+status = "complete"
+proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
+spec = "docs/specs/SHIPPER-SPEC-0007-idempotent-workspace-publish.md"
+plan = "plans/0.4.0/idempotent-workspace-publish.md"
+issue = "109"
+commands = [
+  "cargo xtask check-doc-contracts --mode advisory",
+  "cargo xtask policy-report",
+  "cargo fmt --all -- --check",
+  "git diff --check",
+]

--- a/docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
+++ b/docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
@@ -9,7 +9,7 @@ Linked specs: docs/specs/SHIPPER-SPEC-0001-source-of-truth-stack.md; docs/specs/
 Linked ADRs: docs/adr/SHIPPER-ADR-0001-claims-become-checkable-state.md
 Linked plan: plans/0.4.0/release-auth-evidence-and-trusted-publishing.md
 Linked issues: #96; #105; #109
-Linked PRs: #338; #340; #342
+Linked PRs: #338; #340; #342; #360
 Support-tier impact: docs/status/SUPPORT_TIERS.md
 Policy impact: policy ledgers remain authoritative for workflow, process, network, and file receipts
 Proof commands: cargo xtask check-doc-contracts --mode advisory; cargo xtask policy-report; cargo fmt --all -- --check

--- a/plans/0.4.0/release-auth-evidence-and-trusted-publishing.md
+++ b/plans/0.4.0/release-auth-evidence-and-trusted-publishing.md
@@ -9,7 +9,7 @@ Linked specs: docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-pub
 Linked ADRs: docs/adr/SHIPPER-ADR-0001-claims-become-checkable-state.md
 Linked plan: plans/0.4.0/release-operator-visibility-and-survive-proof.md
 Linked issues: #96; #105; #109
-Linked PRs: #338; #340; #342
+Linked PRs: #338; #340; #342; #360
 Support-tier impact: docs/status/SUPPORT_TIERS.md
 Policy impact: no new policy exceptions
 Proof commands: cargo xtask check-doc-contracts --mode advisory; cargo xtask policy-report; cargo fmt --all -- --check

--- a/plans/0.4.0/release-auth-evidence-and-trusted-publishing.md
+++ b/plans/0.4.0/release-auth-evidence-and-trusted-publishing.md
@@ -224,3 +224,127 @@ planned/advisory.
 #### Rollback
 
 Demote any claim whose proof artifact is missing or weak.
+
+### PR 5 - Trusted Publishing default proof activation
+
+Linked spec: docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
+Blocks: PR 6
+Blocked by: PR 4
+
+#### Goal
+
+Move the active goal from completed idempotent publish proof to the remaining
+Trusted Publishing default proof gap, and archive the completed goal.
+
+#### Production Delta
+
+No product runtime behavior change.
+
+#### Non-Goals
+
+Trusted Publishing promotion, crates.io-side registration changes, release
+publication, release tagging, and workflow credential changes.
+
+#### Acceptance
+
+- `.shipper-meta/goals/active.toml` points to this accepted spec and plan.
+- The completed idempotent workspace publish goal is archived under
+  `.shipper-meta/goals/archive/`.
+- Support tiers continue to say that Trusted Publishing default is
+  planned/advisory until short-lived-token proof exists.
+- The plan distinguishes the existing fallback proof artifact from the future
+  default proof artifact.
+
+#### Proof Commands
+
+- `python -c "import pathlib,tomllib; tomllib.loads(pathlib.Path('.shipper-meta/goals/active.toml').read_text()); print('active goal TOML parses')"`
+- `cargo xtask check-doc-contracts --mode advisory`
+- `cargo xtask check-file-policy --mode blocking-allowlist`
+- `cargo xtask policy-report`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+#### Rollback
+
+Restore the completed idempotent active goal if the Trusted Publishing default
+proof lane is deferred before follow-up work depends on it.
+
+### PR 6 - Trusted Publishing default proof artifact
+
+Linked spec: docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
+Blocks: PR 7
+Blocked by: PR 5 and external crates.io trusted-publisher registration
+
+#### Goal
+
+Produce release evidence proving whether the short-lived-token path is the
+normal release auth path and whether fallback remained unused.
+
+#### Production Delta
+
+Release rehearsal or release-readiness evidence only.
+
+#### Non-Goals
+
+Removing fallback, publishing without explicit release approval, hiding fallback
+configuration, or claiming crates.io registration from repo files alone.
+
+#### Acceptance
+
+- The evidence artifact records `selected_token_source = "trusted_publishing"`
+  for the rehearsed release path, or records the exact external blocker.
+- Fallback configured/used state is explicit.
+- The artifact names workflow, run ID, commit, environment, and limits.
+- Token values are omitted.
+- Any crates.io-side registration gap remains explicit.
+
+#### Proof Commands
+
+- release auth rehearsal or release-readiness workflow artifact
+- `cargo xtask check-workflow-surfaces --mode advisory`
+- `cargo xtask check-process-policy --mode advisory`
+- `cargo xtask check-network-policy --mode advisory`
+- `cargo xtask policy-report`
+- `git diff --check`
+
+#### Rollback
+
+Demote or leave unpromoted the Trusted Publishing default claim if the artifact
+proves fallback, missing registration, or any unknown auth path.
+
+### PR 7 - Trusted Publishing default support-tier promotion
+
+Linked spec: docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
+Blocks:
+Blocked by: PR 6
+
+#### Goal
+
+Promote the Trusted Publishing default claim only if the release evidence proves
+the short-lived-token path.
+
+#### Production Delta
+
+Documentation/status only.
+
+#### Non-Goals
+
+Runtime changes, workflow changes, release publication, or release tagging.
+
+#### Acceptance
+
+- `docs/status/SUPPORT_TIERS.md` names the exact proof artifact and commands.
+- The promoted claim remains limited to the rehearsed/proven release path.
+- Token fallback remains documented as explicit incident-response behavior if
+  it remains configured.
+
+#### Proof Commands
+
+- `cargo xtask check-doc-contracts --mode advisory`
+- `cargo xtask policy-report`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+#### Rollback
+
+Demote the claim if the proof artifact is missing, weak, or proves fallback.


### PR DESCRIPTION
## Summary
- archive the completed idempotent workspace publish active goal
- set the active goal to the remaining Trusted Publishing default-proof lane
- extend the release-auth plan with default-proof activation, proof artifact, and support-tier promotion steps

## Scope
- source-of-truth and plan metadata only
- no runtime behavior changes
- no Trusted Publishing promotion; support tiers remain planned/advisory until short-lived-token proof exists
- no release, tag, or credential workflow change

## Validation
- active goal TOML parses
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask policy-report
- cargo fmt --all -- --check
- git diff --check