### PR TITLE
plans: record trusted publishing proof blocker

### DIFF
--- a/.shipper-meta/goals/active.toml
+++ b/.shipper-meta/goals/active.toml
@@ -21,7 +21,7 @@ end_state = [
 
 [[work_item]]
 id = "trusted-publishing-default-source-of-truth"
-status = "active"
+status = "complete"
 proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
 spec = "docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md"
 plan = "plans/0.4.0/release-auth-evidence-and-trusted-publishing.md"
@@ -37,11 +37,15 @@ commands = [
 
 [[work_item]]
 id = "trusted-publishing-registration-proof"
-status = "planned"
+status = "blocked"
 proposal = "docs/proposals/SHIPPER-PROP-0001-source-of-truth-and-release-evidence.md"
 spec = "docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md"
 plan = "plans/0.4.0/release-auth-evidence-and-trusted-publishing.md"
 issue = "105"
+blocked_by = [
+  "External crates.io trusted-publisher registration is not proven for EffortlessMetrics/shipper; release workflow run 26072938626 recorded selected_token_source = \"fallback_secret\" and the setup gap `No Trusted Publishing config found for repository EffortlessMetrics/shipper`.",
+]
+next_action = "After crates.io trusted-publisher registration is configured, run a release auth rehearsal and record the resulting `.shipper/auth-evidence.json` artifact."
 commands = [
   "release auth rehearsal or release-readiness workflow artifact proving selected_token_source = trusted_publishing",
   "cargo xtask check-workflow-surfaces --mode advisory",

--- a/plans/0.4.0/release-auth-evidence-and-trusted-publishing.md
+++ b/plans/0.4.0/release-auth-evidence-and-trusted-publishing.md
@@ -255,6 +255,12 @@ publication, release tagging, and workflow credential changes.
 - The plan distinguishes the existing fallback proof artifact from the future
   default proof artifact.
 
+#### Result
+
+Complete in #360. The active goal now points to this release-auth spec and plan,
+the idempotent workspace publish goal is archived, and Trusted Publishing
+default remains planned/advisory until short-lived-token proof exists.
+
 #### Proof Commands
 
 - `python -c "import pathlib,tomllib; tomllib.loads(pathlib.Path('.shipper-meta/goals/active.toml').read_text()); print('active goal TOML parses')"`
@@ -297,6 +303,14 @@ configuration, or claiming crates.io registration from repo files alone.
 - The artifact names workflow, run ID, commit, environment, and limits.
 - Token values are omitted.
 - Any crates.io-side registration gap remains explicit.
+
+#### Current Blocker
+
+Blocked on external crates.io trusted-publisher registration evidence. The
+latest recorded release auth proof is workflow run `26072938626`, which uploaded
+`.shipper/auth-evidence.json` with `selected_token_source =
+"fallback_secret"` and the setup gap `No Trusted Publishing config found for
+repository EffortlessMetrics/shipper`.
 
 #### Proof Commands
 


### PR DESCRIPTION
## Summary
- mark the Trusted Publishing source-of-truth activation work item complete after #360
- record the remaining Trusted Publishing proof as blocked on external crates.io trusted-publisher registration evidence
- add the same blocker to the release-auth plan so agents do not promote the default claim from fallback-only proof

## Scope
- source-of-truth and plan metadata only
- no runtime behavior changes
- no release workflow changes, tags, or publishing
- no support-tier promotion

## Validation
- python -c "import pathlib,tomllib; tomllib.loads(pathlib.Path('.shipper-meta/goals/active.toml').read_text()); print('active goal TOML parses')"
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask policy-report
- cargo fmt --all -- --check
- git diff --check
