### PR TITLE
docs(readme): adopt centered product signal header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,28 @@
 <p align="center">
-  <img src="assets/logo/shipper-container-plain.svg" alt="Shipper logo" width="128">
+  <img src="assets/logo/shipper-container-plain.svg" alt="Shipper logo" width="128" />
 </p>
 
 <h1 align="center">shipper</h1>
 
 <p align="center">
-  <a href="https://github.com/EffortlessMetrics/shipper/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/EffortlessMetrics/shipper/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="https://codecov.io/gh/EffortlessMetrics/shipper"><img alt="Codecov" src="https://codecov.io/gh/EffortlessMetrics/shipper/branch/main/graph/badge.svg"></a>
-  <a href="docs/ci/ripr.md"><img alt="ripr" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/EffortlessMetrics/shipper/main/badges/ripr.json"></a>
-  <a href="docs/ci/ripr.md"><img alt="ripr+" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/EffortlessMetrics/shipper/main/badges/ripr-plus.json"></a>
-  <a href="https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field"><img alt="MSRV" src="https://img.shields.io/badge/MSRV-1.95-blue.svg"></a>
-  <a href="#license"><img alt="License" src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg"></a>
+  <em>Idempotent, resumable publishing for Rust workspaces.</em>
 </p>
 
 <p align="center">
-  <em>Idempotent, resumable publishing for Rust workspaces.</em>
+  <a href="https://github.com/EffortlessMetrics/shipper/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/EffortlessMetrics/shipper/actions/workflows/ci.yml/badge.svg?branch=main" /></a>
+  <a href="https://codecov.io/gh/EffortlessMetrics/shipper"><img alt="Codecov" src="https://codecov.io/gh/EffortlessMetrics/shipper/branch/main/graph/badge.svg" /></a>
+  <a href="docs/ci/ripr.md"><img alt="ripr+" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/EffortlessMetrics/shipper/main/badges/ripr-plus.json" /></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/EffortlessMetrics/shipper/releases"><img alt="GitHub release" src="https://img.shields.io/github/v/release/EffortlessMetrics/shipper?sort=semver&label=release" /></a>
+  <a href="https://crates.io/crates/shipper"><img alt="crates.io downloads" src="https://img.shields.io/crates/d/shipper.svg?label=crates.io%20downloads" /></a>
+  <a href="https://docs.rs/shipper"><img alt="docs.rs" src="https://docs.rs/shipper/badge.svg" /></a>
+</p>
+
+<p align="center">
+  <a href="https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field"><img alt="MSRV" src="https://img.shields.io/badge/MSRV-1.95-blue.svg" /></a>
+  <a href="#license"><img alt="License: MIT OR Apache-2.0" src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg" /></a>
 </p>
 
 Shipper publishes missing `name@version` pairs in dependency order, skips versions already on the registry, verifies visibility, records evidence, and resumes cleanly after interruption.


### PR DESCRIPTION
### Motivation

- Align the README hero with the EffortlessMetrics house-style so the repository reads like a product front door rather than a plain project page. 
- Surface the most relevant public signals (CI / coverage / ripr+ and release / crates.io / docs.rs) in a compact, legible stacked band to communicate release confidence. 
- Reduce top-of-readme noise by showing only the stronger `ripr+` endpoint in the top evidence row rather than both `ripr` and `ripr+`.

### Description

- Reworked the README hero to use a centered house-style structure with the existing SVG logo, centered title, and centered tagline. 
- Converted the flat badge row into stacked centered HTML rows: quality/evidence row (CI, Codecov, `ripr+`), release/package/docs row (GitHub releases, crates.io downloads for `shipper`, docs.rs), and platform/license row (MSRV, license). 
- Normalized a few HTML elements (self-closing image tags) and removed the redundant top-band `ripr` badge so the top band shows `ripr+` only. 
- Kept the existing logo asset and product copy; no badge endpoint files, logo variants, or docs additions were added in this change.

### Testing

- Ran documentation contract checks with `cargo xtask check-doc-contracts --mode advisory` and the run completed with no findings. 
- Ran file policy and unified policy checks with `cargo xtask check-file-policy --mode blocking-allowlist` and `cargo xtask policy-report` and they completed successfully. 
- Ran formatting and diff checks with `cargo fmt --all -- --check` and `git diff --check` and they reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cca6bd464833393de1274d3fd049f)