### PR TITLE
docs: define shipper-swarm sync policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,17 @@
 # AGENTS.md
 
+## Repository role
+
+`EffortlessMetrics/shipper` is the release authority for crates.io publishing,
+release evidence, tags, GitHub Releases, release workflow credentials, and
+signing credentials. Routine development happens in
+`EffortlessMetrics/shipper-swarm`.
+
+Syncs from `shipper-swarm/main` into `shipper/main` use merge commits and must
+not be squashed or rebased. Normal feature work, refactors, and tests should
+target `shipper-swarm` unless the user explicitly declares release-authority or
+emergency work in this repo. See [docs/status/SWARM_SYNC.md](docs/status/SWARM_SYNC.md).
+
 Use this file with [CLAUDE.md](./CLAUDE.md) before making changes in this directory.
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
@@ -12,6 +24,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - [**docs/explanation/why-shipper.md**](docs/explanation/why-shipper.md) — the *why*, distilled.
 - [**docs/product.md**](docs/product.md), [**docs/structure.md**](docs/structure.md), [**docs/tech.md**](docs/tech.md) — steering docs.
 - [**docs/INVARIANTS.md**](docs/INVARIANTS.md) — events-as-truth contract.
+- [**docs/status/SWARM_SYNC.md**](docs/status/SWARM_SYNC.md) — source-repo release authority and swarm sync policy.
 
 ## Useful command entry points
 
@@ -116,4 +129,3 @@ Factory Droid runs automated review and security review on same-repo PRs and on 
 - [`docs/agent-context/droid-smoke-tests.md`](docs/agent-context/droid-smoke-tests.md) — how to verify the Droid workflows after a change.
 
 When changing `.github/workflows/droid*.yml`, `.factory/`, or `docs/agent-context/`, follow the smoke-test procedure and update `review-invariants.md` if any invariant changes.
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,28 @@ We follow the [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-
 
 ## Getting Started
 
-1. Fork the repository
+Routine development happens in
+[`EffortlessMetrics/shipper-swarm`](https://github.com/EffortlessMetrics/shipper-swarm).
+This repository remains the release authority for crates.io publishing, release
+evidence, tags, GitHub Releases, and release credentials until that authority is
+explicitly moved.
+
+Use this repository for swarm sync PRs, release-authority docs, release
+workflow changes, release evidence, signing/provenance work, or explicit
+emergency hotfixes. Use `shipper-swarm` for normal feature work, refactors, and
+tests.
+
+See [docs/status/SWARM_SYNC.md](docs/status/SWARM_SYNC.md) for the merge and
+credential boundary policy.
+
+1. Fork the relevant repository
 2. Clone your fork:
    ```bash
+   # routine development
+   git clone https://github.com/YOUR_USERNAME/shipper-swarm.git
+   cd shipper-swarm
+
+   # release-authority work only
    git clone https://github.com/YOUR_USERNAME/shipper.git
    cd shipper
    ```
@@ -168,13 +187,15 @@ cargo test --package shipper
 - **Description**: Explain what and why, not how
 - **Link issues**: Reference any related issues
 - **Small PRs**: Keep changes focused and reviewable
+- **Source repo merge method**: use merge commits for `shipper` PRs. Do not
+  squash or rebase swarm sync PRs.
 
 ### Review Process
 
 1. All PRs require at least one approval
 2. CI must pass (tests, clippy, fmt)
 3. Address review feedback promptly
-4. Squash commits before merge (if requested)
+4. Merge `shipper` PRs with a merge commit, especially swarm sync PRs
 
 ---
 

--- a/docs/status/README.md
+++ b/docs/status/README.md
@@ -9,6 +9,7 @@ owners.
 | Layer | Owns | Does not own |
 |---|---|---|
 | Support tiers | claim -> proof map | detailed implementation |
+| Swarm sync | release-authority repository policy | routine development |
 
 Support-tier documents should answer:
 
@@ -24,6 +25,11 @@ Support-tier documents should answer:
 - README and product docs must not exceed the support-tier map.
 - Policy ledgers explain exceptions and enforcement state behind internal
   claims.
+
+## Documents
+
+- [Support tiers](SUPPORT_TIERS.md)
+- [Shipper swarm sync](SWARM_SYNC.md)
 
 ## Rules
 

--- a/docs/status/SWARM_SYNC.md
+++ b/docs/status/SWARM_SYNC.md
@@ -1,0 +1,78 @@
+# Shipper Swarm Sync
+
+Status: active
+
+`EffortlessMetrics/shipper` remains the release authority for Shipper:
+crates.io publishing, release evidence, tags, GitHub Releases, release
+workflow credentials, and signing credentials stay here until release authority
+is deliberately moved.
+
+Routine development happens in
+[`EffortlessMetrics/shipper-swarm`](https://github.com/EffortlessMetrics/shipper-swarm).
+
+## Repository Roles
+
+| Repository | Role | Normal merge method |
+|---|---|---|
+| `EffortlessMetrics/shipper-swarm` | Active development | Squash merge PRs |
+| `EffortlessMetrics/shipper` | Release authority and provenance | Merge commits |
+
+## What Belongs Here
+
+Use `EffortlessMetrics/shipper` for:
+
+- swarm sync PRs
+- release-authority docs
+- crates.io and GitHub Release workflow changes
+- release evidence and readiness proof updates
+- signing, provenance, or Trusted Publishing changes
+- emergency hotfixes, when explicitly declared
+
+Use `EffortlessMetrics/shipper-swarm` for routine feature work, refactors,
+tests, and normal development PRs.
+
+## Sync Policy
+
+Syncs from `shipper-swarm/main` back to `shipper/main` preserve swarm commit
+history. Do not squash or rebase sync PRs.
+
+Create sync branches from `shipper/main` and merge `shipper-swarm/main` with
+a merge commit:
+
+```bash
+git remote add swarm git@github.com:EffortlessMetrics/shipper-swarm.git
+git fetch origin --prune --tags
+git fetch swarm --prune
+
+git switch -c sync/shipper-swarm-YYYY-MM-DD origin/main
+git merge --no-ff swarm/main -m "merge: sync shipper-swarm development"
+git push -u origin sync/shipper-swarm-YYYY-MM-DD
+```
+
+Open the PR in `EffortlessMetrics/shipper` and merge it with a merge commit.
+Do not use squash merge or rebase merge.
+
+After the sync PR lands, fast-forward `shipper-swarm/main` to the new
+`shipper/main` merge commit before continuing normal swarm development:
+
+```bash
+git fetch origin --prune --tags
+git fetch swarm --prune
+
+git merge-base --is-ancestor swarm/main origin/main
+git push swarm origin/main:main
+```
+
+If the merge-base check fails, stop. Do not force push, squash, or rebase the
+sync commit.
+
+## Credential Boundary
+
+Do not move these into `shipper-swarm` without a separate release-authority
+migration plan:
+
+- `CARGO_REGISTRY_TOKEN`
+- crates.io publish tokens
+- release signing secrets
+- GitHub Release publish credentials
+- Trusted Publishing release authority


### PR DESCRIPTION
## Summary
- add docs/status/SWARM_SYNC.md to define shipper as release authority and shipper-swarm as active development
- document that swarm sync PRs into shipper use merge commits, never squash or rebase
- update AGENTS and CONTRIBUTING so agents and contributors route routine work to shipper-swarm and keep release credentials in shipper

## Validation
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask policy-report
- cargo fmt --all -- --check
- git diff --check