### PR TITLE
merge: sync shipper-swarm review invariants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ In `state.json`, package status is at `.packages[].state.state`, not `.packages[
 
 [**MISSION.md**](MISSION.md) is the north star — mission, vision, audience, and the nine convictions that produce every design decision. Read it before scoping non-trivial work.
 
-Cargo 1.90 stabilized multi-package workspace publishing. Shipper's value is what Cargo still doesn't do, organized as nine competencies: **Prove, Survive, Reconcile, Narrate, Remediate, Harden, Profile, Integrate, Ergonomics**. See [ROADMAP.md](ROADMAP.md) and master tracking issue [#109](https://github.com/EffortlessMetrics/shipper/issues/109). The biggest open gap is **Reconcile** ([#102](https://github.com/EffortlessMetrics/shipper/issues/102) / [#99](https://github.com/EffortlessMetrics/shipper/issues/99)): when `cargo publish` exits ambiguously, Shipper currently blind-retries instead of reconciling against the registry.
+Cargo 1.90 stabilized multi-package workspace publishing. Shipper's value is what Cargo still doesn't do, organized as nine competencies: **Prove, Survive, Reconcile, Narrate, Remediate, Harden, Profile, Integrate, Ergonomics**. See [ROADMAP.md](ROADMAP.md) and master tracking issue [#109](https://github.com/EffortlessMetrics/shipper/issues/109). **Reconcile is now stable:** ambiguous `cargo publish` outcomes must reconcile against registry truth and stop on `StillUnknown` instead of blind-retrying. The current open proof lane is Trusted Publishing default evidence; keep fallback/default claims bounded by `.shipper-meta/goals/active.toml` and [docs/status/SUPPORT_TIERS.md](docs/status/SUPPORT_TIERS.md).
 
 ## Conventions
 

--- a/docs/agent-context/review-invariants.md
+++ b/docs/agent-context/review-invariants.md
@@ -9,7 +9,7 @@ This file captures invariants for both human and Droid review of shipper PRs. Th
 - **Three-crate product shape.** Behavior work lives in `shipper-core`. CLI work (clap derive, help text, progress rendering) lives in `shipper-cli`. The `shipper` crate is an install façade plus curated re-export; it changes rarely.
 - **Events are authoritative.** `events.jsonl` is the source of truth for what happened. `state.json` is a projection. `receipt.json` is a summary derived at end-of-run. When the three disagree, events win — and a drift is a bug.
 - **Tokens are opaque strings, never logged.** Token resolution follows `CARGO_REGISTRY_TOKEN` → `CARGO_REGISTRIES_<NAME>_TOKEN` → `$CARGO_HOME/credentials.toml`. The `shipper-output-sanitizer` crate sanitizes cargo and shell output before persistence or logging.
-- **`Reconcile` is the largest open safety gap.** Ambiguous `cargo publish` outcomes should reconcile against the registry, not blind-retry. Reviews of publish-path code should check the retry classification and the ambiguity handling.
+- **Registry-truth reconciliation is stable and must not regress.** Ambiguous `cargo publish` outcomes reconcile against registry truth before Shipper retries or resumes. Reviews of publish-path code should check retry classification, `Published` / `NotPublished` / `StillUnknown` handling, and safe-stop behavior instead of treating ambiguity as a blind retry path.
 
 ## CI invariants
 


### PR DESCRIPTION
## Summary
- Syncs shipper-swarm PR #48 back to the release-authority repo.
- Updates AGENTS.md and Droid review invariants so Reconcile is treated as stable and regression-sensitive, not an open gap.
- Preserves swarm commit history through a merge commit.

## Merge Method
- Merge commit only.
- Do not squash or rebase this sync PR.

## Validation
- git rev-list --left-right --count origin/main...swarm/main => 0 2
- git merge-base --is-ancestor origin/main swarm/main => yes
- git diff --check