### PR TITLE
merge: sync shipper-swarm evidence docs

### DIFF
--- a/docs/how-to/inspect-state-and-receipts.md
+++ b/docs/how-to/inspect-state-and-receipts.md
@@ -1,6 +1,9 @@
 # How to inspect Shipper state, events, and receipts
 
-After a Shipper run, three files in `.shipper/` tell the story. Different questions → different file.
+After a Shipper run, the core execution files in `.shipper/` tell the
+release story, and optional evidence artifacts answer narrower questions such
+as auth posture, ambiguity reconciliation, or remediation planning. Different
+questions → different file.
 
 ## Which file for which question?
 
@@ -9,6 +12,9 @@ After a Shipper run, three files in `.shipper/` tell the story. Different questi
 | Exactly what happened, and when? | `events.jsonl` | `shipper inspect-events` |
 | What's the current state (for resume)? | `state.json` | `cat .shipper/state.json` |
 | What was the final outcome + evidence? | `receipt.json` | `shipper inspect-receipt` |
+| Which auth path was observed? | `auth-evidence.json` | `jq '.' .shipper/auth-evidence.json` |
+| How was an ambiguous publish reconciled? | `events.jsonl` / `reconciliation.json` | `jq -c 'select(.event_type.type == "publish_reconciled")' .shipper/events.jsonl` |
+| What would remediation do? | `remediation-plan.json` | `jq '.' .shipper/remediation-plan.json` |
 
 **Authority order:** events are truth, state is a projection, receipt is a summary. When they disagree, events win. See [INVARIANTS.md](../INVARIANTS.md).
 
@@ -77,6 +83,22 @@ shipper inspect-receipt --format json | jq '.'
 ```
 
 The receipt is the audit artifact. Keep it. It includes `plan_id`, per-package outcomes, captured evidence (stdout/stderr tails + exit codes), git context, and an environment fingerprint.
+
+## Reading auxiliary evidence
+
+Some workflows produce additional files next to the core event/state/receipt
+set:
+
+- `auth-evidence.json` records observed Trusted Publishing and fallback-token
+  posture without storing token values.
+- `reconciliation.json`, when present, records registry-truth evidence for an
+  ambiguous Cargo outcome. `events.jsonl` still carries the authoritative
+  `publish_reconciling` and `publish_reconciled` events.
+- `remediation-plan.json` records the dry-run containment and fix-forward plan
+  from `shipper remediate --dry-run`; it is a plan, not evidence that yanks or
+  fix-forward publishes already ran.
+- `plan.txt` and `preflight_workspace_verify.txt` are workflow-captured output
+  files used for release evidence and triage.
 
 ## Verifying consistency
 

--- a/docs/reference/state-files.md
+++ b/docs/reference/state-files.md
@@ -8,6 +8,10 @@ One-page cheat sheet. For the full contract see [INVARIANTS.md](../INVARIANTS.md
 
 When they disagree, events win. `state.json` and `receipt.json` are projections/summaries derived from events. An end-of-run consistency check emits `StateEventDriftDetected` if drift is found.
 
+That authority order applies to execution state. Other `.shipper/` artifacts
+answer narrower questions: auth posture, reconciliation evidence, remediation
+planning, or captured plan/preflight output.
+
 ## Per-file summary
 
 | File | Authority | Purpose | When written | Format |
@@ -16,6 +20,17 @@ When they disagree, events win. `state.json` and `receipt.json` are projections/
 | `state.json` | Projection | Serialized `ExecutionState` for fast resume | Per package state change | JSON |
 | `receipt.json` | Summary | End-of-run audit artifact with evidence | Once, at run completion | JSON |
 | `lock` | — | Concurrent-publish guard | Held during the run | Small text file |
+
+Additional evidence artifacts may appear when the related command or workflow
+runs:
+
+| File | Authority | Purpose | When written | Format |
+|---|---|---|---|---|
+| `auth-evidence.json` | Auth evidence | Observed Trusted Publishing/fallback context without token values | Release workflow auth setup | JSON |
+| `reconciliation.json` | Ambiguity evidence | Registry-truth evidence for ambiguous publish outcomes | When ambiguous cargo output is reconciled | JSON |
+| `remediation-plan.json` | Remediation plan | Dry-run containment and fix-forward plan derived from a receipt | `shipper remediate --dry-run` | JSON |
+| `plan.txt` | Captured output | Plan JSON captured for workflow artifacts | Release workflow plan stage | Text containing JSON |
+| `preflight_workspace_verify.txt` | Captured output | ANSI-stripped Cargo workspace dry-run output | Preflight workspace verification | Text |
 
 ## Which file for which question?
 
@@ -26,6 +41,9 @@ When they disagree, events win. `state.json` and `receipt.json` are projections/
 | Did the whole release succeed, and what's the audit trail? | `receipt.json` |
 | What would `shipper resume` skip? | `state.json` (packages with `state.state == "published"`) |
 | What's the truth when they disagree? | `events.jsonl` |
+| Which auth path was observed? | `auth-evidence.json` |
+| How did Shipper resolve ambiguity? | `events.jsonl`; `reconciliation.json` if present |
+| What would remediation do? | `remediation-plan.json` |
 
 ## Key field paths
 
@@ -117,15 +135,6 @@ jq -c 'select(.event_type.type == "publish_reconciled") | .event_type' .shipper/
 # Drift (should be empty on a healthy run)
 jq -c 'select(.event_type.type == "state_event_drift_detected")' .shipper/events.jsonl
 ```
-
-## Sidecar files
-
-Depending on what ran, `.shipper/` may also contain:
-
-| File | Produced by | Contents |
-|---|---|---|
-| `preflight_workspace_verify.txt` | Preflight, when workspace dry-run ran | Full ANSI-stripped cargo output ([#92](https://github.com/EffortlessMetrics/shipper/issues/92)) |
-| `plan.txt` | `shipper plan --format json` (with tee) | Plan JSON for artifact inspection |
 
 ## See also
 


### PR DESCRIPTION
## Summary
- Syncs shipper-swarm PR #54 back to the release-authority repo.
- Refreshes .shipper/ evidence reference docs for auxiliary artifacts such as auth evidence, reconciliation evidence, and remediation plans.
- Preserves swarm commit history through a merge commit.

## Merge Method
- Merge commit only.
- Do not squash or rebase this sync PR.

## Validation
- git rev-list --left-right --count origin/main...swarm/main => 0 2
- git merge-base --is-ancestor origin/main swarm/main => yes
- git diff --check