### PR TITLE
merge: sync shipper-swarm Trusted Publishing proof docs

### DIFF
--- a/.shipper-meta/goals/active.toml
+++ b/.shipper-meta/goals/active.toml
@@ -43,7 +43,7 @@ spec = "docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishin
 plan = "plans/0.4.0/release-auth-evidence-and-trusted-publishing.md"
 issue = "105"
 blocked_by = [
-  "External crates.io trusted-publisher registration is not proven for EffortlessMetrics/shipper; release workflow run 26072938626 recorded selected_token_source = \"fallback_secret\" and the setup gap `No Trusted Publishing config found for repository EffortlessMetrics/shipper`.",
+  "External crates.io trusted-publisher registration is not proven for EffortlessMetrics/shipper; final 0.4.0 Release workflow run 26141754574 recorded selected_token_source = \"fallback_secret\", fallback.configured = true, fallback.used = true, auth_action.outcome = \"failure\", and no token values in .shipper/auth-evidence.json.",
 ]
 next_action = "After crates.io trusted-publisher registration is configured, run a release auth rehearsal and record the resulting `.shipper/auth-evidence.json` artifact."
 commands = [

--- a/docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
+++ b/docs/specs/SHIPPER-SPEC-0006-release-auth-evidence-and-trusted-publishing.md
@@ -175,17 +175,15 @@ fallback path; green CI without that artifact is not sufficient.
 
 Current workflow proof:
 
-- Release workflow run `26072938626` (`workflow_dispatch`, `mode=rehearse`,
-  `main`) completed successfully without running publish jobs.
-- The uploaded `shipper-rehearse-26072938626` artifact contains
-  `.shipper/auth-evidence.json`.
+- Final 0.4.0 Release workflow run `26141754574` completed the crates.io
+  publish path and uploaded `shipper-state-final`.
+- The uploaded `shipper-state-final` artifact contains `.shipper/auth-evidence.json`.
 - That artifact records `schema_version = "shipper.release_auth_evidence.v1"`,
   `auth_action.outcome = "failure"`, `auth_action.token_minted = false`,
   `fallback.configured = true`, `fallback.used = true`, and
   `selected_token_source = "fallback_secret"`.
-- The action log records the actionable external setup gap:
-  `No Trusted Publishing config found for repository
-  EffortlessMetrics/shipper`.
+- The readiness proof records the final release carry-over: crates.io-side
+  trusted-publisher registration and short-lived-token proof remain unproven.
 - This proves fallback evidence is recorded and uploaded. It does not prove
   Trusted Publishing is the default release auth path.
 

--- a/plans/0.4.0/release-auth-evidence-and-trusted-publishing.md
+++ b/plans/0.4.0/release-auth-evidence-and-trusted-publishing.md
@@ -157,10 +157,10 @@ not rehearsed.
 - Artifact limits state that token values are omitted and crates.io-side
   trusted-publisher registration is externally unproven unless separately
   rehearsed.
-- Release workflow run `26072938626` uploaded `shipper-rehearse-26072938626`
-  with `.shipper/auth-evidence.json`; the artifact records token mint failure,
-  fallback configured, fallback used, and `selected_token_source =
-  "fallback_secret"`.
+- Final 0.4.0 Release workflow run `26141754574` uploaded
+  `shipper-state-final` with `.shipper/auth-evidence.json`; the artifact
+  records token mint failure, fallback configured, fallback used,
+  `selected_token_source = "fallback_secret"`, and no token values.
 
 #### Proof Commands
 
@@ -178,10 +178,10 @@ fallback behavior.
 
 #### Result
 
-Complete. The first proof artifact exists and proves fallback behavior for the
-current release environment. It intentionally does not promote Trusted
-Publishing as the default, because crates.io returned `No Trusted Publishing
-config found for repository EffortlessMetrics/shipper`.
+Complete. Release workflow proof exists and proves fallback behavior for the
+0.4.0 release environment. It intentionally does not promote Trusted Publishing
+as the default, because the final release evidence selected `fallback_secret`
+rather than a short-lived Trusted Publishing token.
 
 ### PR 4 - Support-tier promotion
 
@@ -307,10 +307,10 @@ configuration, or claiming crates.io registration from repo files alone.
 #### Current Blocker
 
 Blocked on external crates.io trusted-publisher registration evidence. The
-latest recorded release auth proof is workflow run `26072938626`, which uploaded
-`.shipper/auth-evidence.json` with `selected_token_source =
-"fallback_secret"` and the setup gap `No Trusted Publishing config found for
-repository EffortlessMetrics/shipper`.
+latest recorded release auth proof is final 0.4.0 Release workflow run
+`26141754574`, which uploaded `.shipper/auth-evidence.json` with
+`selected_token_source = "fallback_secret"`, fallback configured and used,
+`auth_action.outcome = "failure"`, and token values omitted.
 
 #### Proof Commands
 


### PR DESCRIPTION
## Summary
- sync shipper-swarm PR #56 into the release-authority repo with a merge commit
- refresh Trusted Publishing proof references to final 0.4.0 Release workflow run 26141754574
- keep Trusted Publishing default planned/advisory because final evidence selected fallback_secret

## Validation
- git rev-list --left-right --count origin/main...HEAD => 0 3
- git diff --check
- swarm PR #56 passed CI and Droid before squash merge

## Merge method
Merge commit only. Do not squash this source sync PR.