### PR TITLE
merge: sync shipper-swarm active goal blocker

### DIFF
--- a/.shipper-meta/goals/active.toml
+++ b/.shipper-meta/goals/active.toml
@@ -1,6 +1,6 @@
 id = "shipper-trusted-publishing-default-proof"
 title = "Trusted Publishing default proof"
-status = "active"
+status = "blocked"
 owner = "EffortlessMetrics"
 created = "2026-05-19"
 
@@ -10,6 +10,11 @@ aspirational: release evidence must prove whether the short-lived-token path is
 available, whether fallback was used, which external crates.io registration gap
 remains, and why support tiers should or should not promote the default claim.
 """
+
+blocked_by = [
+  "External crates.io trusted-publisher registration is not proven for EffortlessMetrics/shipper; final 0.4.0 Release workflow run 26141754574 selected fallback_secret and recorded fallback configured/used with token values omitted.",
+]
+next_action = "After crates.io trusted-publisher registration is configured, run a release auth rehearsal and record `.shipper/auth-evidence.json` proving selected_token_source = \"trusted_publishing\" before promoting the default claim."
 
 end_state = [
   "The active goal points to the accepted release-auth evidence spec and plan.",

--- a/plans/0.4.0/release-auth-evidence-and-trusted-publishing.md
+++ b/plans/0.4.0/release-auth-evidence-and-trusted-publishing.md
@@ -32,6 +32,16 @@ Existing foundations, including Doctor JSON diagnostics, preflight OIDC
 warnings, release workflow OIDC wiring, and token sanitizer coverage, are
 treated as already landed baseline.
 
+## Current Status
+
+PRs 1-5 are complete. PR 6 is externally blocked on crates.io
+trusted-publisher registration proof for `EffortlessMetrics/shipper`.
+
+Until a release auth rehearsal or readiness artifact records
+`selected_token_source = "trusted_publishing"` for the release path, the active
+goal remains blocked and the Trusted Publishing default claim stays
+planned/advisory.
+
 ## PR Sequence
 
 ### PR 1 - Source-of-truth activation


### PR DESCRIPTION
Summary:
- merge the shipper-swarm active-goal blocker update with a merge commit
- preserve swarm commit history while carrying the Trusted Publishing external-blocker state into the release-authority repo

Validation:
- python active-goal TOML parse check
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask policy-report
- cargo fmt --all -- --check
- git diff --check origin/main..HEAD