### PR TITLE
merge: sync shipper-swarm live interruption proof docs

### DIFF
--- a/docs/release/0.4.0-readiness.md
+++ b/docs/release/0.4.0-readiness.md
@@ -217,6 +217,12 @@ Auth evidence:
 - crates.io is the proof-backed registry profile in this release; additional
   registries remain follow-up work.
 - Broader mutation coverage and further CI cost routing remain future work.
+- Live-runner interruption proof was not part of this readiness packet's
+  evidence base; current support tiers now record GitHub Actions run
+  `26051581056` and the `shipper-live-interruption-seed-26051581056` /
+  `shipper-live-interruption-resume-26051581056` artifacts as the later
+  stable/internal proof for artifact handoff and safe resume against fake
+  Cargo/mock registry surfaces.
 - Local Windows full-suite execution exposed mock-registry harness instability;
   final tag approval should require green GitHub PR CI on the readiness PR.
 - The release workflow did not produce the `x86_64-apple-darwin` binary asset
@@ -315,8 +321,11 @@ current product claim, but they do not change what this release proof observed.
 ### Known Carry-Over
 
 - Runtime Reconcile proof was outside this release-readiness packet.
-- Resume under real interruption remains planned until rehearsal evidence
-  exists.
+- Resume under real interruption was outside this release-readiness packet.
+  Later support-tier evidence records live-runner artifact handoff and safe
+  resume proof in GitHub Actions run `26051581056`, with
+  `shipper-live-interruption-seed-26051581056` and
+  `shipper-live-interruption-resume-26051581056` artifacts.
 - Mutation expansion remains advisory/opt-in unless release policy requests it.
 - The `duration_suboptimal_units` cleanup remains carry-over from the 0.4.0
   quality lane.


### PR DESCRIPTION
## Summary
- merge the shipper-swarm docs correction for 0.4.0 live interruption proof status
- preserve the historical release-readiness boundary while pointing to later support-tier evidence run 26051581056 and artifacts
- keep source/release authority history synchronized through a merge commit, not squash

## Validation
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask policy-report
- cargo fmt --all -- --check
- git diff --check

## Swarm evidence
- EffortlessMetrics/shipper-swarm#79
- Routed Rust Small run 26358997010 passed, including Shipper Rust Small Result
- Droid approved the amended head