### PR TITLE
merge: sync shipper-swarm readiness proof boundaries

### DIFF
--- a/docs/specs/SHIPPER-SPEC-0002-release-readiness-proof.md
+++ b/docs/specs/SHIPPER-SPEC-0002-release-readiness-proof.md
@@ -119,9 +119,14 @@ candidate.
 
 The `0.4.0 release readiness proof` support-tier entry may move from
 `planned until #195` to `stable` only after `docs/release/0.4.0-readiness.md`
-exists and records the required evidence. Registry reconciliation and real
-interruption-resume claims remain planned until their own specs, tests, and
-artifacts exist.
+exists and records the required evidence.
+
+Release-readiness proof does not by itself promote adjacent release-closure
+claims. Registry reconciliation and interruption-resume support-tier rows must
+name their own specs, tests, and artifacts. Current proof lives in
+`docs/status/SUPPORT_TIERS.md`: ambiguous publish reconciliation is stable, and
+resume under live runner interruption is stable/internal against fake
+Cargo/mock registry proof surfaces.
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary
- merge the shipper-swarm readiness-proof promotion boundary spec correction
- preserve the merge-commit sync path from swarm to source
- clarify that release-readiness proof promotes only its own support-tier row; reconciliation and interruption-resume claims rely on their own proof rows

## Validation
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask policy-report
- cargo fmt --all -- --check
- git diff --check

## Notes
- Initial source-clone validation hit a local Windows linker temp-file error (LNK1108) under %TEMP%; reran successfully with TMP/TEMP pointed at the H: temp clone.
- Cargo emitted local cache last-use warnings (database or disk is full) during validation, but gates completed successfully.
- Swarm PR: EffortlessMetrics/shipper-swarm#81.
- Swarm routed run 26361779411 passed, including Shipper Rust Small Result.
- Droid approved the swarm PR.