### PR TITLE
merge: sync shipper-swarm recover rehearsal boundary

### DIFF
--- a/docs/how-to/run-recover-rehearsal.md
+++ b/docs/how-to/run-recover-rehearsal.md
@@ -243,8 +243,9 @@ release line the rehearsal was cut from until the regression is fixed
 
 The synthetic test at `crates/shipper-cli/tests/e2e_rehearse.rs` runs
 on every CI commit and acts as a cheap pre-flight, but it's not a
-substitute for this procedure — the real kill happens on a real runner
-with a real registry.
+substitute for this procedure. The safe rehearsal proves a real runner
+handoff with fake Cargo and a mock registry; the destructive crates.io
+path is the only rehearsal here that touches a real registry.
 
 ## See also
 


### PR DESCRIPTION
## Summary
- merge the shipper-swarm recover rehearsal registry-boundary doc correction
- preserve the merge-commit sync path from swarm to source
- clarify that the safe runner-artifact rehearsal uses fake Cargo/mock registry and only the destructive crates.io rehearsal touches a real registry

## Validation
- cargo xtask check-doc-contracts --mode advisory
- cargo xtask check-file-policy --mode blocking-allowlist
- cargo xtask policy-report
- cargo fmt --all -- --check
- git diff --check

## Notes
- Cargo emitted the local global-cache last-use warning (database or disk is full) during validation, but gates completed successfully.
- Swarm PR: EffortlessMetrics/shipper-swarm#82.
- Swarm routed run 26363027821 passed, including CPX42 and Shipper Rust Small Result.
- Droid approved the swarm PR.