### PR TITLE
test(ops-git): serialize ensure_git_clean_new_phrasing

### DIFF
--- a/crates/shipper-core/src/ops/git/cleanliness.rs
+++ b/crates/shipper-core/src/ops/git/cleanliness.rs
@@ -90,6 +90,7 @@ pub(super) fn ensure_git_clean_legacy(path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::fs;
     use tempfile::tempdir;
 
@@ -179,6 +180,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn ensure_git_clean_new_phrasing() {
         let td = tempdir().expect("tempdir");
         init_git_repo(td.path());


### PR DESCRIPTION
## Summary

`ensure_git_clean` reads `SHIPPER_GIT_BIN` and routes through the bin override when the env var is set. The engine integration tests in `engine/mod.rs` set that env var under their own `#[serial]` group (~80 tests, via `fake_program_env_vars`).

`ensure_git_clean_new_phrasing` was the one cleanliness test exercising `ensure_git_clean` without `#[serial]`, so under parallel test execution a racing engine test could flip `SHIPPER_GIT_BIN` mid-call and route this test's `git status` through the override — a spurious failure.

This brings the test into the same serialization group as the engine tests that share the env var.

## Change

- `crates/shipper-core/src/ops/git/cleanliness.rs`: add `#[serial]` to `ensure_git_clean_new_phrasing` and the `serial_test::serial` import.

`serial_test` is already a dev-dependency of `shipper-core` (`3.4.0`); no new dependency.

## Verification

- `cargo fmt --all -- --check` — pass
- `cargo clippy -p shipper-core --all-targets --all-features -- -D warnings` — pass, no warnings
- `cargo test -p shipper-core ops::git::` — **163 passed, 0 failed** (includes the now-serialized test)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only serialization to avoid env-var races; no runtime or CLI logic is modified.
> 
> **Overview**
> Marks **`ensure_git_clean_new_phrasing`** with **`#[serial]`** and imports **`serial_test::serial`** in `cleanliness.rs`.
> 
> That test calls **`ensure_git_clean`**, which honors **`SHIPPER_GIT_BIN`**. Engine integration tests set that env var under their own serialized group, so parallel runs could flip the override mid-test and cause flaky failures. Serializing this test aligns it with those env-sensitive tests.
> 
> **No production behavior changes**—test harness only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5725d19072af54d149755c346ddf30fc48d4ff6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->