### PR TITLE
fix(clippy): activate duration_suboptimal_units after site cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,10 @@ unknown_lints = "deny"
 # round-trip with `unknown_lints = "deny"` in [workspace.lints.rust], which
 # rejected one fabricated name from the original #191 plan
 # (`clippy::manual_pop_if`). Fallout per real lint was measured against the
-# workspace at activation time; the eight here had zero fallout. The
-# remaining planned lint (`duration_suboptimal_units`) has 204 sites and
-# stays in [[planned]] until a focused cleanup PR lands.
+# workspace at activation time; the eight here had zero fallout.
+# `duration_suboptimal_units` was the ninth planned lint (deferred from #191
+# with 204 sites); activated after a focused `cargo clippy --fix` cleanup
+# reduced all sites to optimal units.
 same_length_and_capacity = "deny"
 manual_ilog2 = "warn"
 decimal_bitwise_operands = "warn"
@@ -58,6 +59,7 @@ manual_checked_ops = "warn"
 manual_take = "warn"
 unnecessary_trailing_comma = "warn"
 disallowed_fields = "deny"
+duration_suboptimal_units = "warn"
 
 [workspace.dependencies]
 # Intra-workspace crates (path + version for publish-readiness).

--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -4940,7 +4940,7 @@ mod tests {
             state_dir: state_dir.clone(),
             force_resume: false,
             force: false,
-            lock_timeout: Duration::from_secs(3600),
+            lock_timeout: Duration::from_hours(1),
             policy: shipper_core::types::PublishPolicy::Safe,
             verify_mode: shipper_core::types::VerifyMode::Workspace,
             readiness: shipper_core::types::ReadinessConfig::default(),
@@ -5012,7 +5012,7 @@ mod tests {
             state_dir: td.path().join("abs-state-2"),
             force_resume: false,
             force: false,
-            lock_timeout: Duration::from_secs(3600),
+            lock_timeout: Duration::from_hours(1),
             policy: shipper_core::types::PublishPolicy::Safe,
             verify_mode: shipper_core::types::VerifyMode::Workspace,
             readiness: shipper_core::types::ReadinessConfig::default(),
@@ -5214,7 +5214,7 @@ mode = "fast"
             readiness: shipper_core::config::ReadinessConfig::default(),
             output: shipper_core::config::OutputConfig { lines: 100 },
             lock: shipper_core::config::LockConfig {
-                timeout: Duration::from_secs(1800),
+                timeout: Duration::from_mins(30),
             },
             flags: shipper_core::config::FlagsConfig {
                 allow_dirty: false,
@@ -5225,7 +5225,7 @@ mode = "fast"
                 policy: shipper_core::retry::RetryPolicy::Custom,
                 max_attempts: 10,
                 base_delay: Duration::from_secs(5),
-                max_delay: Duration::from_secs(300),
+                max_delay: Duration::from_mins(5),
                 strategy: shipper_core::retry::RetryStrategyType::Exponential,
                 jitter: 0.5,
                 per_error: shipper_core::retry::PerErrorConfig::default(),
@@ -5275,12 +5275,12 @@ mode = "fast"
         );
         assert_eq!(
             merged.max_delay,
-            Duration::from_secs(300),
+            Duration::from_mins(5),
             "config max_delay should apply"
         );
         assert_eq!(
             merged.lock_timeout,
-            Duration::from_secs(1800),
+            Duration::from_mins(30),
             "config lock_timeout should apply"
         );
     }

--- a/crates/shipper-cli/src/output/progress/mod.rs
+++ b/crates/shipper-cli/src/output/progress/mod.rs
@@ -204,7 +204,7 @@ impl ProgressReporter {
 
         if self.is_tty {
             let start = Instant::now();
-            let tick = Duration::from_millis(1000);
+            let tick = Duration::from_secs(1);
             // Tick down once per second. `remaining == 0` ends the loop; we
             // still call `set_status` once on exit to show "retrying now".
             loop {

--- a/crates/shipper-config/src/lib.rs
+++ b/crates/shipper-config/src/lib.rs
@@ -564,7 +564,7 @@ fn default_schema_version() -> String {
 }
 
 fn default_lock_timeout() -> Duration {
-    Duration::from_secs(3600) // 1 hour
+    Duration::from_hours(1) // 1 hour
 }
 
 fn default_max_attempts() -> u32 {
@@ -576,7 +576,7 @@ fn default_base_delay() -> Duration {
 }
 
 fn default_max_delay() -> Duration {
-    Duration::from_secs(120) // 2 minutes
+    Duration::from_mins(2) // 2 minutes
 }
 
 impl ShipperConfig {
@@ -933,7 +933,7 @@ skip_ownership_check = true
         assert_eq!(config.verify.mode, VerifyMode::None);
         assert!(!config.readiness.enabled);
         assert_eq!(config.output.lines, 100);
-        assert_eq!(config.lock.timeout, Duration::from_secs(1800));
+        assert_eq!(config.lock.timeout, Duration::from_mins(30));
         assert_eq!(config.retry.max_attempts, 3);
         assert!(config.flags.allow_dirty);
         assert!(config.flags.skip_ownership_check);
@@ -1020,7 +1020,7 @@ per_package_timeout = "1h"
         assert_eq!(config.parallel.max_concurrent, 8);
         assert_eq!(
             config.parallel.per_package_timeout,
-            Duration::from_secs(3600)
+            Duration::from_hours(1)
         );
     }
 
@@ -1035,8 +1035,8 @@ method = "both"
         assert_eq!(config.readiness.method, ReadinessMethod::Both);
         assert!(config.readiness.enabled);
         assert_eq!(config.readiness.initial_delay, Duration::from_secs(1));
-        assert_eq!(config.readiness.max_delay, Duration::from_secs(60));
-        assert_eq!(config.readiness.max_total_wait, Duration::from_secs(300));
+        assert_eq!(config.readiness.max_delay, Duration::from_mins(1));
+        assert_eq!(config.readiness.max_total_wait, Duration::from_mins(5));
         assert_eq!(config.readiness.poll_interval, Duration::from_secs(2));
         assert_eq!(config.readiness.jitter_factor, 0.5);
     }
@@ -1053,7 +1053,7 @@ enabled = true
         assert_eq!(config.parallel.max_concurrent, 4);
         assert_eq!(
             config.parallel.per_package_timeout,
-            Duration::from_secs(1800)
+            Duration::from_mins(30)
         );
     }
 
@@ -1070,7 +1070,7 @@ enabled = true
         let config: ShipperConfig = toml::from_str(toml).unwrap();
         assert_eq!(config.output.lines, 50);
         assert_eq!(config.retry.max_attempts, 6);
-        assert_eq!(config.lock.timeout, Duration::from_secs(3600));
+        assert_eq!(config.lock.timeout, Duration::from_hours(1));
         assert!(config.validate().is_ok());
     }
 
@@ -1082,7 +1082,7 @@ enabled = true
                 policy: RetryPolicy::Custom,
                 max_attempts: 10,
                 base_delay: Duration::from_secs(5),
-                max_delay: Duration::from_secs(300),
+                max_delay: Duration::from_mins(5),
                 strategy: RetryStrategyType::Exponential,
                 jitter: 0.5,
                 per_error: PerErrorConfig::default(),
@@ -1115,7 +1115,7 @@ enabled = true
                 policy: RetryPolicy::Custom,
                 max_attempts: 10,
                 base_delay: Duration::from_secs(5),
-                max_delay: Duration::from_secs(300),
+                max_delay: Duration::from_mins(5),
                 strategy: RetryStrategyType::Exponential,
                 jitter: 0.5,
                 per_error: PerErrorConfig::default(),
@@ -1128,7 +1128,7 @@ enabled = true
                 mode: VerifyMode::Package,
             },
             lock: LockConfig {
-                timeout: Duration::from_secs(1800),
+                timeout: Duration::from_mins(30),
             },
             state_dir: Some(PathBuf::from("custom-state")),
             ..Default::default()
@@ -1139,11 +1139,11 @@ enabled = true
         let opts = config.build_runtime_options(cli);
         assert_eq!(opts.max_attempts, 10, "config max_attempts should apply");
         assert_eq!(opts.base_delay, Duration::from_secs(5));
-        assert_eq!(opts.max_delay, Duration::from_secs(300));
+        assert_eq!(opts.max_delay, Duration::from_mins(5));
         assert_eq!(opts.output_lines, 100);
         assert_eq!(opts.policy, PublishPolicy::Balanced);
         assert_eq!(opts.verify_mode, VerifyMode::Package);
-        assert_eq!(opts.lock_timeout, Duration::from_secs(1800));
+        assert_eq!(opts.lock_timeout, Duration::from_mins(30));
         assert_eq!(opts.state_dir, PathBuf::from("custom-state"));
     }
 
@@ -1181,7 +1181,7 @@ enabled = true
         let opts = config.build_runtime_options(cli);
         assert_eq!(opts.max_attempts, 6);
         assert_eq!(opts.base_delay, Duration::from_secs(2));
-        assert_eq!(opts.max_delay, Duration::from_secs(120));
+        assert_eq!(opts.max_delay, Duration::from_mins(2));
         assert_eq!(opts.policy, PublishPolicy::Safe);
         assert_eq!(opts.verify_mode, VerifyMode::Workspace);
         assert_eq!(opts.output_lines, 50);
@@ -1210,7 +1210,7 @@ enabled = true
             parallel: ParallelConfig {
                 enabled: true,
                 max_concurrent: 8,
-                per_package_timeout: Duration::from_secs(7200),
+                per_package_timeout: Duration::from_hours(2),
             },
             ..Default::default()
         };
@@ -1220,7 +1220,7 @@ enabled = true
         let opts = config.build_runtime_options(cli);
         assert!(opts.parallel.enabled);
         assert_eq!(opts.parallel.max_concurrent, 8);
-        assert_eq!(opts.parallel.per_package_timeout, Duration::from_secs(7200));
+        assert_eq!(opts.parallel.per_package_timeout, Duration::from_hours(2));
 
         // CLI overrides max_concurrent
         let cli2 = CliOverrides {
@@ -1255,8 +1255,8 @@ enabled = true
                     enabled: false,
                     method: ReadinessMethod::Both,
                     initial_delay: Duration::from_secs(5),
-                    max_delay: Duration::from_secs(120),
-                    max_total_wait: Duration::from_secs(600),
+                    max_delay: Duration::from_mins(2),
+                    max_total_wait: Duration::from_mins(10),
                     poll_interval: Duration::from_secs(10),
                     jitter_factor: 0.3,
                     index_path: Some(std::path::PathBuf::from("/tmp/index")),
@@ -1264,7 +1264,7 @@ enabled = true
                 },
                 output: OutputConfig { lines: 200 },
                 lock: LockConfig {
-                    timeout: Duration::from_secs(7200),
+                    timeout: Duration::from_hours(2),
                 },
                 retry: RetryConfig {
                     policy: RetryPolicy::Aggressive,
@@ -1283,7 +1283,7 @@ enabled = true
                 parallel: ParallelConfig {
                     enabled: true,
                     max_concurrent: 8,
-                    per_package_timeout: Duration::from_secs(3600),
+                    per_package_timeout: Duration::from_hours(1),
                 },
                 state_dir: Some(std::path::PathBuf::from("/custom/state")),
                 registry: Some(RegistryConfig {
@@ -1479,19 +1479,19 @@ per_package_timeout = "15m"
                     policy: RetryPolicy::Custom,
                     max_attempts: 3,
                     base_delay: Duration::from_secs(2),
-                    max_delay: Duration::from_secs(60),
+                    max_delay: Duration::from_mins(1),
                     strategy: RetryStrategyType::Exponential,
                     jitter: 0.1,
                     per_error: PerErrorConfig::default(),
                 },
                 output: OutputConfig { lines: 50 },
                 lock: LockConfig {
-                    timeout: Duration::from_secs(1800),
+                    timeout: Duration::from_mins(30),
                 },
                 parallel: ParallelConfig {
                     enabled: false,
                     max_concurrent: 4,
-                    per_package_timeout: Duration::from_secs(600),
+                    per_package_timeout: Duration::from_mins(10),
                 },
                 ..ShipperConfig::default()
             };
@@ -1500,7 +1500,7 @@ per_package_timeout = "15m"
                 policy: Some(PublishPolicy::Fast),
                 max_attempts: Some(10),
                 output_lines: Some(200),
-                lock_timeout: Some(Duration::from_secs(7200)),
+                lock_timeout: Some(Duration::from_hours(2)),
                 parallel_enabled: true,
                 max_concurrent: Some(8),
                 allow_dirty: true,
@@ -1805,7 +1805,7 @@ per_package_timeout = "15m"
                     parallel: ParallelConfig {
                         enabled: true,
                         max_concurrent: 4,
-                        per_package_timeout: Duration::from_secs(600),
+                        per_package_timeout: Duration::from_mins(10),
                     },
                     ..Default::default()
                 };
@@ -2000,7 +2000,7 @@ lines = 999
 timeout = "10m"
 "#;
             let config: ShipperConfig = toml::from_str(toml).unwrap();
-            assert_eq!(config.lock.timeout, Duration::from_secs(600));
+            assert_eq!(config.lock.timeout, Duration::from_mins(10));
             assert!(config.validate().is_ok());
         }
 
@@ -2050,7 +2050,7 @@ per_package_timeout = "2h"
             assert_eq!(config.parallel.max_concurrent, 16);
             assert_eq!(
                 config.parallel.per_package_timeout,
-                Duration::from_secs(7200)
+                Duration::from_hours(2)
             );
             assert!(config.validate().is_ok());
         }

--- a/crates/shipper-config/src/runtime/mod.rs
+++ b/crates/shipper-config/src/runtime/mod.rs
@@ -69,7 +69,7 @@ mod tests {
             retry_strategy: shipper_retry::RetryStrategyType::Exponential,
             retry_jitter: 0.25,
             retry_per_error: shipper_retry::PerErrorConfig::default(),
-            verify_timeout: Duration::from_secs(120),
+            verify_timeout: Duration::from_mins(2),
             verify_poll_interval: Duration::from_secs(3),
             state_dir: PathBuf::from("target/.shipper-tests"),
             force_resume: false,
@@ -80,7 +80,7 @@ mod tests {
                 method: ReadinessMethod::Both,
                 initial_delay: Duration::from_millis(150),
                 max_delay: Duration::from_secs(30),
-                max_total_wait: Duration::from_secs(300),
+                max_total_wait: Duration::from_mins(5),
                 poll_interval: Duration::from_secs(3),
                 jitter_factor: 0.4,
                 index_path: Some(PathBuf::from("ci-index")),
@@ -88,11 +88,11 @@ mod tests {
             },
             output_lines: 777,
             force: true,
-            lock_timeout: Duration::from_secs(4_800),
+            lock_timeout: Duration::from_mins(80),
             parallel: ParallelConfig {
                 enabled: true,
                 max_concurrent: 6,
-                per_package_timeout: Duration::from_secs(180),
+                per_package_timeout: Duration::from_mins(3),
             },
             webhook: WebhookConfig {
                 url: "https://example.internal/webhook".to_string(),
@@ -172,7 +172,7 @@ mod tests {
 
         assert!(converted.enabled);
         assert_eq!(converted.max_concurrent, 6);
-        assert_eq!(converted.per_package_timeout, Duration::from_secs(180));
+        assert_eq!(converted.per_package_timeout, Duration::from_mins(3));
     }
 
     #[test]
@@ -264,7 +264,7 @@ mod tests {
                     method: readiness_method,
                     initial_delay: Duration::from_millis(10),
                     max_delay: Duration::from_secs(1),
-                    max_total_wait: Duration::from_secs(60),
+                    max_total_wait: Duration::from_mins(1),
                     poll_interval: Duration::from_millis(250),
                     jitter_factor: 0.4,
                     index_path: None,
@@ -272,11 +272,11 @@ mod tests {
                 },
                 output_lines,
                 force: false,
-                lock_timeout: Duration::from_secs(300),
+                lock_timeout: Duration::from_mins(5),
                 parallel: ParallelConfig {
                     enabled: true,
                     max_concurrent: 4,
-                    per_package_timeout: Duration::from_secs(120),
+                    per_package_timeout: Duration::from_mins(2),
                 },
                 webhook,
                 encryption,
@@ -876,11 +876,11 @@ mod tests {
                 no_verify: false,
                 max_attempts: 3,
                 base_delay: Duration::from_secs(5),
-                max_delay: Duration::from_secs(300),
+                max_delay: Duration::from_mins(5),
                 retry_strategy: shipper_retry::RetryStrategyType::Exponential,
                 retry_jitter: 0.25,
                 retry_per_error: shipper_retry::PerErrorConfig::default(),
-                verify_timeout: Duration::from_secs(60),
+                verify_timeout: Duration::from_mins(1),
                 verify_poll_interval: Duration::from_secs(5),
                 state_dir: PathBuf::from(".shipper"),
                 force_resume: false,
@@ -890,8 +890,8 @@ mod tests {
                     enabled: false,
                     method: ReadinessMethod::Api,
                     initial_delay: Duration::from_millis(100),
-                    max_delay: Duration::from_secs(60),
-                    max_total_wait: Duration::from_secs(300),
+                    max_delay: Duration::from_mins(1),
+                    max_total_wait: Duration::from_mins(5),
                     poll_interval: Duration::from_secs(5),
                     jitter_factor: 0.25,
                     prefer_index: false,
@@ -903,7 +903,7 @@ mod tests {
                 parallel: ParallelConfig {
                     enabled: false,
                     max_concurrent: 4,
-                    per_package_timeout: Duration::from_secs(120),
+                    per_package_timeout: Duration::from_mins(2),
                 },
                 webhook: WebhookConfig {
                     url: String::new(),
@@ -985,8 +985,8 @@ mod tests {
                 enabled: true,
                 method: ReadinessMethod::Both,
                 initial_delay: Duration::from_millis(500),
-                max_delay: Duration::from_secs(120),
-                max_total_wait: Duration::from_secs(600),
+                max_delay: Duration::from_mins(2),
+                max_total_wait: Duration::from_mins(10),
                 poll_interval: Duration::from_secs(10),
                 jitter_factor: 0.5,
                 prefer_index: true,
@@ -1002,9 +1002,9 @@ mod tests {
             cfg.parallel = ParallelConfig {
                 enabled: true,
                 max_concurrent: 16,
-                per_package_timeout: Duration::from_secs(3600),
+                per_package_timeout: Duration::from_hours(1),
             };
-            cfg.lock_timeout = Duration::from_secs(7200);
+            cfg.lock_timeout = Duration::from_hours(2);
             let converted = into_runtime_options(cfg);
             assert_debug_snapshot!(converted);
         }
@@ -1077,8 +1077,8 @@ mod tests {
                 enabled: true,
                 method: ReadinessMethod::Both,
                 initial_delay: Duration::from_secs(1),
-                max_delay: Duration::from_secs(120),
-                max_total_wait: Duration::from_secs(600),
+                max_delay: Duration::from_mins(2),
+                max_total_wait: Duration::from_mins(10),
                 poll_interval: Duration::from_secs(5),
                 jitter_factor: 0.5,
                 prefer_index: true,
@@ -1217,11 +1217,11 @@ mod tests {
                 no_verify: false,
                 max_attempts: 3,
                 base_delay: Duration::from_secs(1),
-                max_delay: Duration::from_secs(60),
+                max_delay: Duration::from_mins(1),
                 retry_strategy: shipper_retry::RetryStrategyType::Exponential,
                 retry_jitter: 0.25,
                 retry_per_error: shipper_retry::PerErrorConfig::default(),
-                verify_timeout: Duration::from_secs(60),
+                verify_timeout: Duration::from_mins(1),
                 verify_poll_interval: Duration::from_secs(5),
                 state_dir: PathBuf::from(".shipper"),
                 force_resume: false,
@@ -1230,7 +1230,7 @@ mod tests {
                 readiness: ReadinessConfig::default(),
                 output_lines: 50,
                 force: false,
-                lock_timeout: Duration::from_secs(3600),
+                lock_timeout: Duration::from_hours(1),
                 parallel: ParallelConfig::default(),
                 webhook: WebhookConfig::default(),
                 encryption: EncryptionConfig::default(),
@@ -1323,7 +1323,7 @@ mod tests {
                 method: ReadinessMethod::Index,
                 initial_delay: Duration::from_millis(200),
                 max_delay: Duration::from_secs(15),
-                max_total_wait: Duration::from_secs(120),
+                max_total_wait: Duration::from_mins(2),
                 poll_interval: Duration::from_secs(2),
                 jitter_factor: 0.1,
                 index_path: None,
@@ -1347,14 +1347,14 @@ mod tests {
             opts.parallel = ParallelConfig {
                 enabled: true,
                 max_concurrent: 12,
-                per_package_timeout: Duration::from_secs(600),
+                per_package_timeout: Duration::from_mins(10),
             };
             let converted = into_runtime_options(opts);
             assert!(converted.parallel.enabled);
             assert_eq!(converted.parallel.max_concurrent, 12);
             assert_eq!(
                 converted.parallel.per_package_timeout,
-                Duration::from_secs(600)
+                Duration::from_mins(10)
             );
         }
 
@@ -1404,11 +1404,11 @@ mod tests {
                 no_verify: false,
                 max_attempts: 5,
                 base_delay: Duration::from_secs(2),
-                max_delay: Duration::from_secs(60),
+                max_delay: Duration::from_mins(1),
                 retry_strategy: shipper_retry::RetryStrategyType::Exponential,
                 retry_jitter: 0.25,
                 retry_per_error: shipper_retry::PerErrorConfig::default(),
-                verify_timeout: Duration::from_secs(120),
+                verify_timeout: Duration::from_mins(2),
                 verify_poll_interval: Duration::from_secs(5),
                 state_dir: PathBuf::from(".shipper"),
                 force_resume: false,
@@ -1417,7 +1417,7 @@ mod tests {
                 readiness: ReadinessConfig::default(),
                 output_lines: 50,
                 force: false,
-                lock_timeout: Duration::from_secs(3600),
+                lock_timeout: Duration::from_hours(1),
                 parallel: ParallelConfig::default(),
                 webhook: WebhookConfig::default(),
                 encryption: EncryptionConfig::default(),

--- a/crates/shipper-config/src/runtime_options/mod.rs
+++ b/crates/shipper-config/src/runtime_options/mod.rs
@@ -29,7 +29,7 @@ pub(crate) fn build(config: &ShipperConfig, cli: CliOverrides) -> RuntimeOptions
         retry_strategy: retry.strategy,
         retry_jitter: retry.jitter,
         retry_per_error: retry.per_error,
-        verify_timeout: cli.verify_timeout.unwrap_or(Duration::from_secs(120)),
+        verify_timeout: cli.verify_timeout.unwrap_or(Duration::from_mins(2)),
         verify_poll_interval: cli.verify_poll_interval.unwrap_or(Duration::from_secs(5)),
         state_dir: cli
             .state_dir

--- a/crates/shipper-config/src/runtime_options/retry.rs
+++ b/crates/shipper-config/src/runtime_options/retry.rs
@@ -216,7 +216,7 @@ mod tests {
             policy: RetryPolicy::Default,
             max_attempts: TEST_DEFAULT_MAX_ATTEMPTS,
             base_delay: Duration::from_secs(2),
-            max_delay: Duration::from_secs(120),
+            max_delay: Duration::from_mins(2),
             strategy: RetryStrategyType::Exponential,
             jitter: 0.5,
             per_error: per_error.clone(),

--- a/crates/shipper-config/tests/config_runtime_bdd.rs
+++ b/crates/shipper-config/tests/config_runtime_bdd.rs
@@ -19,7 +19,7 @@ fn sample_runtime_options(base_url: &str, registry_count: usize) -> RuntimeOptio
         retry_strategy: shipper_retry::RetryStrategyType::Linear,
         retry_jitter: 0.35,
         retry_per_error: shipper_retry::PerErrorConfig::default(),
-        verify_timeout: Duration::from_secs(120),
+        verify_timeout: Duration::from_mins(2),
         verify_poll_interval: Duration::from_secs(5),
         state_dir: PathBuf::from(".shipper"),
         force_resume: false,
@@ -38,7 +38,7 @@ fn sample_runtime_options(base_url: &str, registry_count: usize) -> RuntimeOptio
         },
         output_lines: 160,
         force: false,
-        lock_timeout: Duration::from_secs(600),
+        lock_timeout: Duration::from_mins(10),
         parallel: ParallelConfig {
             enabled: true,
             max_concurrent: 4,

--- a/crates/shipper-config/tests/config_runtime_contract.rs
+++ b/crates/shipper-config/tests/config_runtime_contract.rs
@@ -38,7 +38,7 @@ fn custom_config() -> ShipperConfig {
         },
         output: shipper_config::OutputConfig { lines: 300 },
         lock: shipper_config::LockConfig {
-            timeout: Duration::from_secs(1_800),
+            timeout: Duration::from_mins(30),
         },
         retry: shipper_config::RetryConfig {
             policy: shipper_retry::RetryPolicy::Aggressive,
@@ -52,7 +52,7 @@ fn custom_config() -> ShipperConfig {
         parallel: ParallelConfig {
             enabled: true,
             max_concurrent: 8,
-            per_package_timeout: Duration::from_secs(60),
+            per_package_timeout: Duration::from_mins(1),
         },
         state_dir: Some(PathBuf::from("custom-state")),
         registry: None,
@@ -88,7 +88,7 @@ fn converts_config_to_runtime_contract_with_registry_overrides() {
             method: ReadinessMethod::Both,
             initial_delay: Duration::from_secs(1),
             max_delay: Duration::from_secs(45),
-            max_total_wait: Duration::from_secs(360),
+            max_total_wait: Duration::from_mins(6),
             poll_interval: Duration::from_secs(2),
             jitter_factor: 0.3,
             index_path: Some(PathBuf::from("/tmp/index")),
@@ -96,7 +96,7 @@ fn converts_config_to_runtime_contract_with_registry_overrides() {
         },
         output: shipper_config::OutputConfig { lines: 101 },
         lock: shipper_config::LockConfig {
-            timeout: Duration::from_secs(900),
+            timeout: Duration::from_mins(15),
         },
         retry: shipper_config::RetryConfig::default(),
         flags: shipper_config::FlagsConfig {
@@ -148,7 +148,7 @@ fn converts_config_to_runtime_contract_with_registry_overrides() {
     assert_eq!(runtime.webhook.url, "https://override.example/webhook");
     assert_eq!(runtime.webhook.secret.as_deref(), Some("secret2"));
     assert_eq!(runtime.webhook.timeout_secs, 20);
-    assert_eq!(runtime.lock_timeout, Duration::from_secs(900));
+    assert_eq!(runtime.lock_timeout, Duration::from_mins(15));
 }
 
 // ---------------------------------------------------------------------------
@@ -163,7 +163,7 @@ fn empty_cli_overrides_yields_all_config_file_values() {
     assert_eq!(rt.policy, PublishPolicy::Fast);
     assert_eq!(rt.verify_mode, VerifyMode::None);
     assert_eq!(rt.output_lines, 300);
-    assert_eq!(rt.lock_timeout, Duration::from_secs(1_800));
+    assert_eq!(rt.lock_timeout, Duration::from_mins(30));
     assert_eq!(rt.readiness.method, ReadinessMethod::Index);
     assert_eq!(rt.readiness.poll_interval, Duration::from_secs(7));
     assert_eq!(rt.readiness.max_total_wait, Duration::from_secs(200));
@@ -183,10 +183,10 @@ fn default_config_with_empty_overrides_yields_all_defaults() {
     assert_eq!(rt.policy, PublishPolicy::Safe);
     assert_eq!(rt.verify_mode, VerifyMode::Workspace);
     assert_eq!(rt.output_lines, 50);
-    assert_eq!(rt.lock_timeout, Duration::from_secs(3_600));
+    assert_eq!(rt.lock_timeout, Duration::from_hours(1));
     assert_eq!(rt.max_attempts, 6);
     assert_eq!(rt.base_delay, Duration::from_secs(2));
-    assert_eq!(rt.max_delay, Duration::from_secs(120));
+    assert_eq!(rt.max_delay, Duration::from_mins(2));
     assert_eq!(rt.state_dir, PathBuf::from(".shipper"));
     assert!(!rt.allow_dirty);
     assert!(!rt.skip_ownership_check);
@@ -427,10 +427,10 @@ fn parallel_max_concurrent_override() {
 #[test]
 fn parallel_per_package_timeout_override() {
     let rt = into_runtime_options(custom_config().build_runtime_options(CliOverrides {
-        per_package_timeout: Some(Duration::from_secs(300)),
+        per_package_timeout: Some(Duration::from_mins(5)),
         ..Default::default()
     }));
-    assert_eq!(rt.parallel.per_package_timeout, Duration::from_secs(300));
+    assert_eq!(rt.parallel.per_package_timeout, Duration::from_mins(5));
 }
 
 // ---------------------------------------------------------------------------
@@ -719,7 +719,7 @@ fn conservative_retry_policy_defaults_without_cli_overrides() {
 
     assert_eq!(rt.max_attempts, 3);
     assert_eq!(rt.base_delay, Duration::from_secs(5));
-    assert_eq!(rt.max_delay, Duration::from_secs(60));
+    assert_eq!(rt.max_delay, Duration::from_mins(1));
     assert_eq!(rt.retry_strategy, RetryStrategyType::Linear);
 }
 
@@ -752,18 +752,18 @@ fn custom_retry_policy_uses_explicit_config_fields() {
 #[test]
 fn verify_timeout_defaults_when_no_cli_override() {
     let rt = into_runtime_options(default_config().build_runtime_options(CliOverrides::default()));
-    assert_eq!(rt.verify_timeout, Duration::from_secs(120));
+    assert_eq!(rt.verify_timeout, Duration::from_mins(2));
     assert_eq!(rt.verify_poll_interval, Duration::from_secs(5));
 }
 
 #[test]
 fn verify_timeout_cli_override() {
     let rt = into_runtime_options(default_config().build_runtime_options(CliOverrides {
-        verify_timeout: Some(Duration::from_secs(60)),
+        verify_timeout: Some(Duration::from_mins(1)),
         verify_poll_interval: Some(Duration::from_secs(1)),
         ..Default::default()
     }));
-    assert_eq!(rt.verify_timeout, Duration::from_secs(60));
+    assert_eq!(rt.verify_timeout, Duration::from_mins(1));
     assert_eq!(rt.verify_poll_interval, Duration::from_secs(1));
 }
 

--- a/crates/shipper-config/tests/config_runtime_proptest.rs
+++ b/crates/shipper-config/tests/config_runtime_proptest.rs
@@ -577,7 +577,7 @@ proptest! {
         prop_assert_eq!(rt.policy, PublishPolicy::Safe);
         prop_assert_eq!(rt.verify_mode, VerifyMode::Workspace);
         prop_assert_eq!(rt.output_lines, 50);
-        prop_assert_eq!(rt.lock_timeout, Duration::from_secs(3_600));
+        prop_assert_eq!(rt.lock_timeout, Duration::from_hours(1));
         prop_assert_eq!(rt.max_attempts, 6);
         prop_assert!(!rt.allow_dirty);
         prop_assert!(!rt.skip_ownership_check);

--- a/crates/shipper-core/src/config.rs
+++ b/crates/shipper-core/src/config.rs
@@ -49,7 +49,7 @@ mod tests {
         assert_eq!(config.verify.mode, VerifyMode::Workspace);
         assert!(config.readiness.enabled);
         assert_eq!(config.output.lines, 50);
-        assert_eq!(config.lock.timeout, Duration::from_secs(3600));
+        assert_eq!(config.lock.timeout, Duration::from_hours(1));
         assert_eq!(config.retry.max_attempts, 6);
         assert!(!config.flags.allow_dirty);
         assert!(!config.parallel.enabled);
@@ -257,14 +257,14 @@ lines = 123
                 policy: RetryPolicy::Custom,
                 max_attempts: 3,
                 base_delay: Duration::from_secs(1),
-                max_delay: Duration::from_secs(60),
+                max_delay: Duration::from_mins(1),
                 strategy: RetryStrategyType::Linear,
                 jitter: 0.2,
                 per_error: PerErrorConfig::default(),
             },
             output: OutputConfig { lines: 25 },
             lock: LockConfig {
-                timeout: Duration::from_secs(600),
+                timeout: Duration::from_mins(10),
             },
             readiness: ReadinessConfig {
                 method: ReadinessMethod::Api,
@@ -283,7 +283,7 @@ lines = 123
             retry_strategy: Some(RetryStrategyType::Constant),
             retry_jitter: Some(0.9),
             output_lines: Some(500),
-            lock_timeout: Some(Duration::from_secs(7200)),
+            lock_timeout: Some(Duration::from_hours(2)),
             state_dir: Some(PathBuf::from("cli-state")),
             readiness_method: Some(ReadinessMethod::Both),
             readiness_timeout: Some(Duration::from_secs(999)),
@@ -300,7 +300,7 @@ lines = 123
         assert_eq!(opts.retry_strategy, RetryStrategyType::Constant);
         assert!((opts.retry_jitter - 0.9).abs() < f64::EPSILON);
         assert_eq!(opts.output_lines, 500);
-        assert_eq!(opts.lock_timeout, Duration::from_secs(7200));
+        assert_eq!(opts.lock_timeout, Duration::from_hours(2));
         assert_eq!(opts.state_dir, PathBuf::from("cli-state"));
         assert_eq!(opts.readiness.method, ReadinessMethod::Both);
         assert_eq!(opts.readiness.max_total_wait, Duration::from_secs(999));
@@ -502,7 +502,7 @@ lines = 123
             readiness: ReadinessConfig {
                 enabled: true,
                 initial_delay: Duration::from_secs(10),
-                max_delay: Duration::from_secs(120),
+                max_delay: Duration::from_mins(2),
                 jitter_factor: 0.75,
                 index_path: Some(PathBuf::from("/custom/index")),
                 prefer_index: true,
@@ -513,7 +513,7 @@ lines = 123
         let opts = config.build_runtime_options(CliOverrides::default());
         // These fields are config-only (no CLI override)
         assert_eq!(opts.readiness.initial_delay, Duration::from_secs(10));
-        assert_eq!(opts.readiness.max_delay, Duration::from_secs(120));
+        assert_eq!(opts.readiness.max_delay, Duration::from_mins(2));
         assert!((opts.readiness.jitter_factor - 0.75).abs() < f64::EPSILON);
         assert_eq!(
             opts.readiness.index_path,
@@ -721,16 +721,16 @@ lines = 123
             parallel: ParallelConfig {
                 enabled: true,
                 max_concurrent: 4,
-                per_package_timeout: Duration::from_secs(1800),
+                per_package_timeout: Duration::from_mins(30),
             },
             ..ShipperConfig::default()
         };
         let cli = CliOverrides {
-            per_package_timeout: Some(Duration::from_secs(60)),
+            per_package_timeout: Some(Duration::from_mins(1)),
             ..Default::default()
         };
         let opts = config.build_runtime_options(cli);
-        assert_eq!(opts.parallel.per_package_timeout, Duration::from_secs(60));
+        assert_eq!(opts.parallel.per_package_timeout, Duration::from_mins(1));
     }
 
     // ── Encryption env_key passthrough ──────────────────────────────
@@ -827,11 +827,11 @@ base_path = "artifacts/"
         assert_eq!(config.readiness.method, ReadinessMethod::Both);
         assert_eq!(config.readiness.initial_delay, Duration::from_secs(3));
         assert_eq!(config.readiness.max_delay, Duration::from_secs(90));
-        assert_eq!(config.readiness.max_total_wait, Duration::from_secs(600));
+        assert_eq!(config.readiness.max_total_wait, Duration::from_mins(10));
         assert_eq!(config.readiness.poll_interval, Duration::from_secs(5));
         assert!((config.readiness.jitter_factor - 0.3).abs() < f64::EPSILON);
         assert_eq!(config.output.lines, 75);
-        assert_eq!(config.lock.timeout, Duration::from_secs(7200));
+        assert_eq!(config.lock.timeout, Duration::from_hours(2));
         assert_eq!(config.retry.policy, RetryPolicy::Custom);
         assert_eq!(config.retry.max_attempts, 8);
         assert_eq!(config.retry.base_delay, Duration::from_secs(3));
@@ -845,7 +845,7 @@ base_path = "artifacts/"
         assert_eq!(config.parallel.max_concurrent, 6);
         assert_eq!(
             config.parallel.per_package_timeout,
-            Duration::from_secs(2700)
+            Duration::from_mins(45)
         );
         let reg = config.registry.as_ref().unwrap();
         assert_eq!(reg.name, "my-reg");
@@ -909,7 +909,7 @@ timeout_secs = 15
     fn verify_timeout_defaults_when_not_set() {
         let config = ShipperConfig::default();
         let opts = config.build_runtime_options(CliOverrides::default());
-        assert_eq!(opts.verify_timeout, Duration::from_secs(120));
+        assert_eq!(opts.verify_timeout, Duration::from_mins(2));
         assert_eq!(opts.verify_poll_interval, Duration::from_secs(5));
     }
 
@@ -917,12 +917,12 @@ timeout_secs = 15
     fn verify_timeout_cli_override() {
         let config = ShipperConfig::default();
         let cli = CliOverrides {
-            verify_timeout: Some(Duration::from_secs(300)),
+            verify_timeout: Some(Duration::from_mins(5)),
             verify_poll_interval: Some(Duration::from_secs(10)),
             ..Default::default()
         };
         let opts = config.build_runtime_options(cli);
-        assert_eq!(opts.verify_timeout, Duration::from_secs(300));
+        assert_eq!(opts.verify_timeout, Duration::from_mins(5));
         assert_eq!(opts.verify_poll_interval, Duration::from_secs(10));
     }
 
@@ -988,7 +988,7 @@ timeout_secs = 15
                 method: ReadinessMethod::Index,
                 initial_delay: Duration::from_secs(7),
                 max_delay: Duration::from_secs(45),
-                max_total_wait: Duration::from_secs(180),
+                max_total_wait: Duration::from_mins(3),
                 poll_interval: Duration::from_secs(3),
                 jitter_factor: 0.8,
                 index_path: None,
@@ -996,13 +996,13 @@ timeout_secs = 15
             },
             output: OutputConfig { lines: 42 },
             lock: LockConfig {
-                timeout: Duration::from_secs(900),
+                timeout: Duration::from_mins(15),
             },
             retry: RetryConfig {
                 policy: RetryPolicy::Conservative,
                 max_attempts: 2,
                 base_delay: Duration::from_secs(5),
-                max_delay: Duration::from_secs(60),
+                max_delay: Duration::from_mins(1),
                 strategy: RetryStrategyType::Linear,
                 jitter: 0.15,
                 per_error: PerErrorConfig::default(),
@@ -1015,7 +1015,7 @@ timeout_secs = 15
             parallel: ParallelConfig {
                 enabled: true,
                 max_concurrent: 12,
-                per_package_timeout: Duration::from_secs(600),
+                per_package_timeout: Duration::from_mins(10),
             },
             state_dir: Some(PathBuf::from("custom-state")),
             registry: None,
@@ -1034,7 +1034,7 @@ timeout_secs = 15
         assert!(!deserialized.readiness.enabled);
         assert_eq!(deserialized.readiness.method, ReadinessMethod::Index);
         assert_eq!(deserialized.output.lines, 42);
-        assert_eq!(deserialized.lock.timeout, Duration::from_secs(900));
+        assert_eq!(deserialized.lock.timeout, Duration::from_mins(15));
         assert_eq!(deserialized.retry.policy, RetryPolicy::Conservative);
         assert_eq!(deserialized.retry.max_attempts, 2);
         assert!(deserialized.flags.allow_dirty);
@@ -1065,7 +1065,7 @@ max_delay = "1h"
 "#;
         let config2: ShipperConfig = toml::from_str(toml_str2).unwrap();
         assert_eq!(config2.retry.base_delay, Duration::from_millis(100));
-        assert_eq!(config2.retry.max_delay, Duration::from_secs(3600));
+        assert_eq!(config2.retry.max_delay, Duration::from_hours(1));
     }
 
     // ── Verify mode all variants via TOML ───────────────────────────
@@ -1229,14 +1229,14 @@ bucket = "bucket"
                 policy: RetryPolicy::Custom,
                 max_attempts: 15,
                 base_delay: Duration::from_secs(3),
-                max_delay: Duration::from_secs(180),
+                max_delay: Duration::from_mins(3),
                 strategy: RetryStrategyType::Exponential,
                 jitter: 0.6,
                 per_error: PerErrorConfig::default(),
             },
             output: OutputConfig { lines: 200 },
             lock: LockConfig {
-                timeout: Duration::from_secs(1800),
+                timeout: Duration::from_mins(30),
             },
             flags: FlagsConfig {
                 allow_dirty: true,
@@ -1260,9 +1260,9 @@ bucket = "bucket"
         // Preserved config values
         assert_eq!(opts.verify_mode, VerifyMode::Package);
         assert_eq!(opts.base_delay, Duration::from_secs(3));
-        assert_eq!(opts.max_delay, Duration::from_secs(180));
+        assert_eq!(opts.max_delay, Duration::from_mins(3));
         assert_eq!(opts.output_lines, 200);
-        assert_eq!(opts.lock_timeout, Duration::from_secs(1800));
+        assert_eq!(opts.lock_timeout, Duration::from_mins(30));
         assert!(opts.allow_dirty);
         assert!(!opts.skip_ownership_check);
         assert!(opts.strict_ownership);

--- a/crates/shipper-core/src/engine/mod.rs
+++ b/crates/shipper-core/src/engine/mod.rs
@@ -1756,7 +1756,7 @@ mod tests {
             },
             output_lines: 100,
             force: false,
-            lock_timeout: Duration::from_secs(3600),
+            lock_timeout: Duration::from_hours(1),
             parallel: crate::types::ParallelConfig::default(),
             webhook: crate::webhook::WebhookConfig::default(),
             retry_strategy: crate::retry::RetryStrategyType::Exponential,
@@ -3739,7 +3739,7 @@ mod tests {
         assert_eq!(estimate.registry_profile, "crates-io");
         assert_eq!(estimate.first_publish_count, 6);
         assert_eq!(estimate.update_count, 0);
-        assert_eq!(estimate.minimum_registry_pacing, Duration::from_secs(600));
+        assert_eq!(estimate.minimum_registry_pacing, Duration::from_mins(10));
         assert!(
             estimate
                 .notes
@@ -5050,7 +5050,7 @@ mod tests {
     #[test]
     fn backoff_delay_constant_strategy() {
         let base = Duration::from_millis(200);
-        let max = Duration::from_millis(1000);
+        let max = Duration::from_secs(1);
         let d1 = backoff_delay(base, max, 1, crate::retry::RetryStrategyType::Constant, 0.0);
         let d5 = backoff_delay(base, max, 5, crate::retry::RetryStrategyType::Constant, 0.0);
         let d10 = backoff_delay(
@@ -5069,7 +5069,7 @@ mod tests {
     #[test]
     fn backoff_delay_immediate_strategy() {
         let base = Duration::from_millis(200);
-        let max = Duration::from_millis(1000);
+        let max = Duration::from_secs(1);
         let d1 = backoff_delay(
             base,
             max,

--- a/crates/shipper-core/src/engine/parallel/tests.rs
+++ b/crates/shipper-core/src/engine/parallel/tests.rs
@@ -305,11 +305,11 @@ fn default_opts(state_dir: PathBuf) -> RuntimeOptions {
         },
         output_lines: 100,
         force: false,
-        lock_timeout: Duration::from_secs(3600),
+        lock_timeout: Duration::from_hours(1),
         parallel: shipper_types::ParallelConfig {
             enabled: true,
             max_concurrent: 4,
-            per_package_timeout: Duration::from_secs(60),
+            per_package_timeout: Duration::from_mins(1),
         },
         retry_strategy: shipper_retry::RetryStrategyType::Exponential,
         retry_jitter: 0.0,

--- a/crates/shipper-core/src/engine/publish/resume.rs
+++ b/crates/shipper-core/src/engine/publish/resume.rs
@@ -177,7 +177,7 @@ mod tests {
             },
             output_lines: 10,
             force: false,
-            lock_timeout: Duration::from_secs(60),
+            lock_timeout: Duration::from_mins(1),
             parallel: ParallelConfig::default(),
             webhook: WebhookConfig::default(),
             encryption: EncryptionConfig::default(),

--- a/crates/shipper-core/src/ops/lock/mod.rs
+++ b/crates/shipper-core/src/ops/lock/mod.rs
@@ -399,7 +399,7 @@ mod tests {
                 let result = LockFile::acquire_with_timeout(
                     td.path(),
                     None,
-                    Duration::from_secs(3600),
+                    Duration::from_hours(1),
                 );
                 prop_assert!(result.is_err());
                 prop_assert!(result.unwrap_err().to_string().contains("lock already held"));
@@ -486,7 +486,7 @@ mod tests {
                 let lock = LockFile::acquire_with_timeout(
                     td.path(),
                     None,
-                    Duration::from_secs(3600),
+                    Duration::from_hours(1),
                 ).expect("should replace stale lock with plan_id");
 
                 let new_info = LockFile::read_lock_info(td.path(), None).expect("read");
@@ -611,7 +611,7 @@ mod tests {
         .expect("write stale lock");
 
         // Acquire with 1 hour timeout - should succeed and remove stale lock
-        let _lock = LockFile::acquire_with_timeout(td.path(), None, Duration::from_secs(3600))
+        let _lock = LockFile::acquire_with_timeout(td.path(), None, Duration::from_hours(1))
             .expect("acquire with timeout");
 
         let info = LockFile::read_lock_info(td.path(), None).expect("read info");
@@ -627,7 +627,7 @@ mod tests {
         let _lock1 = LockFile::acquire(td.path(), None).expect("first acquire");
 
         // Try to acquire with timeout - should fail
-        let result = LockFile::acquire_with_timeout(td.path(), None, Duration::from_secs(3600));
+        let result = LockFile::acquire_with_timeout(td.path(), None, Duration::from_hours(1));
         assert!(result.is_err());
         assert!(
             result
@@ -782,7 +782,7 @@ mod tests {
         let lp = lock_path(td.path(), None);
         fs::write(&lp, "not-valid-json").expect("write corrupt");
 
-        let lock = LockFile::acquire_with_timeout(td.path(), None, Duration::from_secs(3600))
+        let lock = LockFile::acquire_with_timeout(td.path(), None, Duration::from_hours(1))
             .expect("acquire after corrupt");
         let info = LockFile::read_lock_info(td.path(), None).expect("read");
         assert_eq!(info.pid, std::process::id());
@@ -814,7 +814,7 @@ mod tests {
         };
         fs::write(&lp, serde_json::to_string(&info).expect("ser")).expect("write");
 
-        let result = LockFile::acquire_with_timeout(td.path(), None, Duration::from_secs(3600));
+        let result = LockFile::acquire_with_timeout(td.path(), None, Duration::from_hours(1));
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(err_msg.contains("lock already held"));
@@ -836,7 +836,7 @@ mod tests {
         fs::write(&lp, serde_json::to_string(&old_info).expect("ser")).expect("write");
 
         let lock =
-            LockFile::acquire_with_timeout(td.path(), Some(&root), Duration::from_secs(3600))
+            LockFile::acquire_with_timeout(td.path(), Some(&root), Duration::from_hours(1))
                 .expect("acquire stale with root");
         let info = LockFile::read_lock_info(td.path(), Some(&root)).expect("read");
         assert_eq!(info.pid, std::process::id());
@@ -959,7 +959,7 @@ mod snapshot_tests {
         // Use a real lock so the file definitely exists on disk
         let _existing = LockFile::acquire(td.path(), None).expect("seed lock");
 
-        let err = LockFile::acquire_with_timeout(td.path(), None, Duration::from_secs(86400 * 365))
+        let err = LockFile::acquire_with_timeout(td.path(), None, Duration::from_hours(8760))
             .unwrap_err();
         let msg = err.to_string();
         // The message contains the dynamic current PID/host/age, so snapshot only the stable prefix
@@ -1127,7 +1127,7 @@ mod edge_case_tests {
         };
         fs::write(&lp, serde_json::to_string(&info).unwrap()).unwrap();
 
-        let lock = LockFile::acquire_with_timeout(&nested, None, Duration::from_secs(60)).unwrap();
+        let lock = LockFile::acquire_with_timeout(&nested, None, Duration::from_mins(1)).unwrap();
         assert!(nested.exists());
         drop(lock);
     }
@@ -1181,7 +1181,7 @@ mod edge_case_tests {
                 let b = Arc::clone(&barrier);
                 std::thread::spawn(move || {
                     b.wait();
-                    LockFile::acquire_with_timeout(&dir, None, Duration::from_secs(60)).ok()
+                    LockFile::acquire_with_timeout(&dir, None, Duration::from_mins(1)).ok()
                 })
             })
             .collect();
@@ -1312,7 +1312,7 @@ mod edge_case_tests {
 
         // acquire_with_timeout should remove corrupt lock and succeed
         let lock =
-            LockFile::acquire_with_timeout(td.path(), None, Duration::from_secs(3600)).unwrap();
+            LockFile::acquire_with_timeout(td.path(), None, Duration::from_hours(1)).unwrap();
         let info = LockFile::read_lock_info(td.path(), None).unwrap();
         assert_eq!(info.pid, std::process::id());
         drop(lock);
@@ -1676,7 +1676,7 @@ mod proptest_edge_cases {
             let lock = LockFile::acquire_with_timeout(
                 &state_dir,
                 None,
-                Duration::from_secs(3600),
+                Duration::from_hours(1),
             ).expect("should recover from corrupt lock");
 
             let info = LockFile::read_lock_info(&state_dir, None).expect("read");
@@ -1839,7 +1839,7 @@ mod hardened_tests {
         fs::write(&lp, serde_json::to_string(&old).unwrap()).unwrap();
 
         let _lock =
-            LockFile::acquire_with_timeout(td.path(), None, Duration::from_secs(60)).unwrap();
+            LockFile::acquire_with_timeout(td.path(), None, Duration::from_mins(1)).unwrap();
         let info = LockFile::read_lock_info(td.path(), None).unwrap();
         assert_ne!(info.pid, 65432);
         assert_ne!(info.hostname, "old-machine");
@@ -1979,7 +1979,7 @@ mod lock_edge_case_tests {
         };
         std::fs::write(&lp, serde_json::to_string(&info).expect("ser")).expect("write");
 
-        let lock = LockFile::acquire_with_timeout(td.path(), None, Duration::from_secs(3600))
+        let lock = LockFile::acquire_with_timeout(td.path(), None, Duration::from_hours(1))
             .expect("should replace stale lock with wrong PID");
         let new_info = LockFile::read_lock_info(td.path(), None).expect("read");
         assert_eq!(new_info.pid, std::process::id());
@@ -1995,7 +1995,7 @@ mod lock_edge_case_tests {
         let lp = lock_path(td.path(), None);
         std::fs::write(&lp, r#"{"pid": 42, "hostname":"#).expect("write");
 
-        let lock = LockFile::acquire_with_timeout(td.path(), None, Duration::from_secs(3600))
+        let lock = LockFile::acquire_with_timeout(td.path(), None, Duration::from_hours(1))
             .expect("should replace corrupt lock");
         let info = LockFile::read_lock_info(td.path(), None).expect("read");
         assert_eq!(info.pid, std::process::id());
@@ -2010,7 +2010,7 @@ mod lock_edge_case_tests {
         let lp = lock_path(td.path(), None);
         std::fs::write(&lp, "").expect("write");
 
-        let lock = LockFile::acquire_with_timeout(td.path(), None, Duration::from_secs(3600))
+        let lock = LockFile::acquire_with_timeout(td.path(), None, Duration::from_hours(1))
             .expect("should replace empty lock");
         let info = LockFile::read_lock_info(td.path(), None).expect("read");
         assert_eq!(info.pid, std::process::id());

--- a/crates/shipper-core/src/ops/process/tests.rs
+++ b/crates/shipper-core/src/ops/process/tests.rs
@@ -966,7 +966,7 @@ fn timeout_none_does_not_set_timed_out() {
 #[test]
 fn timeout_generous_does_not_trigger() {
     let tmp = tempfile::tempdir().expect("tmpdir");
-    let timeout = Some(Duration::from_secs(120));
+    let timeout = Some(Duration::from_mins(2));
     let r = run_command_with_timeout("cargo", &["--version"], tmp.path(), timeout).expect("run");
     assert!(!r.timed_out);
     assert_eq!(r.exit_code, 0);

--- a/crates/shipper-core/src/runtime/execution/mod.rs
+++ b/crates/shipper-core/src/runtime/execution/mod.rs
@@ -122,7 +122,7 @@ pub fn backoff_delay(
 /// After the 5-crate account burst is consumed, new crates are admitted at
 /// most once per `CRATES_IO_NEW_CRATE_WINDOW`. Source:
 /// <https://crates.io/docs/rate-limits>.
-pub const CRATES_IO_NEW_CRATE_WINDOW: Duration = Duration::from_secs(10 * 60);
+pub const CRATES_IO_NEW_CRATE_WINDOW: Duration = Duration::from_mins(10);
 
 /// How Shipper expects a registry to propagate newly published packages.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -404,7 +404,7 @@ mod tests {
     fn registry_profile_aware_backoff_uses_profile_floor() {
         let d = registry_profile_aware_backoff(
             Duration::from_secs(10),
-            Duration::from_secs(120),
+            Duration::from_mins(2),
             1,
             RetryStrategyType::Exponential,
             0.0,
@@ -424,7 +424,7 @@ mod tests {
         );
         assert_eq!(
             retry_after_delay("< retry-after: \"120\""),
-            Some(Duration::from_secs(120))
+            Some(Duration::from_mins(2))
         );
     }
 
@@ -436,7 +436,7 @@ mod tests {
 
         assert_eq!(
             retry_after_delay_at("Retry-After: Wed, 21 Oct 2015 07:28:00 GMT", now),
-            Some(Duration::from_secs(60))
+            Some(Duration::from_mins(1))
         );
     }
 
@@ -464,7 +464,7 @@ mod tests {
     fn registry_profile_aware_backoff_honors_retry_after_floor() {
         let d = registry_profile_aware_backoff(
             Duration::from_secs(10),
-            Duration::from_secs(120),
+            Duration::from_mins(2),
             1,
             RetryStrategyType::Exponential,
             0.0,
@@ -480,7 +480,7 @@ mod tests {
     fn registry_profile_aware_backoff_uses_larger_floor() {
         let d = registry_profile_aware_backoff(
             Duration::from_secs(10),
-            Duration::from_secs(120),
+            Duration::from_mins(2),
             1,
             RetryStrategyType::Exponential,
             0.0,
@@ -496,7 +496,7 @@ mod tests {
     fn unknown_registry_profile_keeps_generic_backoff() {
         let d = registry_profile_aware_backoff(
             Duration::from_secs(10),
-            Duration::from_secs(120),
+            Duration::from_mins(2),
             1,
             RetryStrategyType::Exponential,
             0.0,
@@ -513,7 +513,7 @@ mod tests {
         let short = Duration::from_secs(10);
         let d = registry_aware_backoff(
             short,
-            Duration::from_secs(120),
+            Duration::from_mins(2),
             1,
             RetryStrategyType::Exponential,
             0.0,
@@ -532,7 +532,7 @@ mod tests {
         // Existing crate hitting a 429 uses the higher per-minute budget;
         // Shipper should NOT over-extend to the 10-min new-crate window.
         let base = Duration::from_secs(2);
-        let max = Duration::from_secs(120);
+        let max = Duration::from_mins(2);
         let d = registry_aware_backoff(
             base,
             max,
@@ -554,7 +554,7 @@ mod tests {
         // New crate hit a non-rate-limit retryable (network blip); we should
         // NOT wait 10 min for a transient network issue.
         let base = Duration::from_secs(2);
-        let max = Duration::from_secs(120);
+        let max = Duration::from_mins(2);
         let d = registry_aware_backoff(
             base,
             max,
@@ -575,8 +575,8 @@ mod tests {
     fn registry_aware_backoff_respects_longer_generic_when_it_exceeds_window() {
         // If the generic exponential delay is already >= 10 min, don't floor
         // downward — use whichever is larger.
-        let base = Duration::from_secs(60 * 20); // 20 min
-        let max = Duration::from_secs(60 * 30);
+        let base = Duration::from_mins(20); // 20 min
+        let max = Duration::from_mins(30);
         let d = registry_aware_backoff(base, max, 1, RetryStrategyType::Constant, 0.0, true, "429");
         assert!(
             d >= base,
@@ -1038,7 +1038,7 @@ mod tests {
     #[test]
     fn backoff_exponential_without_jitter_doubles() {
         let base = Duration::from_millis(100);
-        let max = Duration::from_secs(60);
+        let max = Duration::from_mins(1);
         let d1 = backoff_delay(
             base,
             max,
@@ -1103,7 +1103,7 @@ mod tests {
     #[test]
     fn backoff_high_attempt_does_not_overflow() {
         let base = Duration::from_millis(100);
-        let max = Duration::from_secs(60);
+        let max = Duration::from_mins(1);
         // Very high attempt number should not panic
         let d = backoff_delay(
             base,
@@ -1551,7 +1551,7 @@ mod tests {
                 _ => shipper_retry::RetryStrategyType::Constant,
             };
             let base = Duration::from_millis(100);
-            let max = Duration::from_secs(60);
+            let max = Duration::from_mins(1);
             let d = backoff_delay(base, max, attempt, strategy, 0.5);
             let upper = max + max.mul_f64(0.5);
             prop_assert!(d <= upper, "large attempt overflow: {d:?} > {upper:?}");
@@ -1731,7 +1731,7 @@ mod tests {
                 strategy: shipper_retry::RetryStrategyType::Exponential,
                 max_attempts: 5,
                 base_delay: Duration::from_secs(2),
-                max_delay: Duration::from_secs(120),
+                max_delay: Duration::from_mins(2),
                 jitter: 0.5,
             };
             insta::assert_yaml_snapshot!(config);

--- a/crates/shipper-duration/src/lib.rs
+++ b/crates/shipper-duration/src/lib.rs
@@ -298,7 +298,7 @@ mod edge_case_tests {
     #[test]
     fn parse_large_hours() {
         let d = parse_duration("9999h").unwrap();
-        assert_eq!(d, Duration::from_secs(9999 * 3600));
+        assert_eq!(d, Duration::from_hours(9999));
     }
 
     #[test]
@@ -308,7 +308,7 @@ mod edge_case_tests {
             #[serde(serialize_with = "serialize_duration")]
             v: Duration,
         }
-        let large = Duration::from_secs(365 * 24 * 3600); // 1 year
+        let large = Duration::from_hours(8760); // 1 year
         let json = serde_json::to_value(H { v: large }).unwrap();
         assert_eq!(json["v"], 365 * 24 * 3600 * 1000_u64);
     }
@@ -361,7 +361,7 @@ mod edge_case_tests {
     #[test]
     fn parse_day_unit() {
         let d = parse_duration("2days").unwrap();
-        assert_eq!(d, Duration::from_secs(2 * 86400));
+        assert_eq!(d, Duration::from_hours(48));
     }
 
     // -- Comparison / ordering --
@@ -383,7 +383,7 @@ mod edge_case_tests {
     fn parsed_durations_support_addition() {
         let a = parse_duration("30s").unwrap();
         let b = parse_duration("30s").unwrap();
-        assert_eq!(a + b, Duration::from_secs(60));
+        assert_eq!(a + b, Duration::from_mins(1));
     }
 
     #[test]
@@ -405,7 +405,7 @@ mod edge_case_tests {
     fn parse_combined_no_spaces() {
         assert_eq!(
             parse_duration("1h30m").unwrap(),
-            Duration::from_secs(3600 + 30 * 60)
+            Duration::from_mins(90)
         );
         assert_eq!(
             parse_duration("2m30s").unwrap(),
@@ -469,7 +469,7 @@ mod edge_case_tests {
     #[test]
     fn parse_days_hours_minutes_combined() {
         let d = parse_duration("1day 2h 30m").unwrap();
-        assert_eq!(d, Duration::from_secs(86400 + 2 * 3600 + 30 * 60));
+        assert_eq!(d, Duration::from_mins(1590));
     }
 }
 
@@ -557,7 +557,7 @@ mod coverage_gaps {
     #[test]
     fn serialize_500us_truncates_to_zero() {
         let h = Holder {
-            value: Duration::from_nanos(500_000),
+            value: Duration::from_micros(500),
         };
         let json = serde_json::to_value(&h).unwrap();
         assert_eq!(json["value"], 0);
@@ -741,9 +741,9 @@ mod snapshot_tests {
         let formatted: Vec<(&str, String)> = vec![
             ("zero", Duration::ZERO),
             ("half_second", Duration::from_millis(500)),
-            ("one_minute", Duration::from_secs(60)),
+            ("one_minute", Duration::from_mins(1)),
             ("one_hour_one_min_one_sec", Duration::from_secs(3661)),
-            ("one_day", Duration::from_secs(86400)),
+            ("one_day", Duration::from_hours(24)),
         ]
         .into_iter()
         .map(|(name, d)| (name, humantime::format_duration(d).to_string()))

--- a/crates/shipper-registry/src/context.rs
+++ b/crates/shipper-registry/src/context.rs
@@ -489,7 +489,7 @@ mod tests {
         let handle = thread::spawn(move || {
             let mut workers: Vec<thread::JoinHandle<()>> = Vec::with_capacity(request_count);
             for _ in 0..request_count {
-                match server.recv_timeout(Duration::from_secs(60)) {
+                match server.recv_timeout(Duration::from_mins(1)) {
                     Ok(Some(req)) => {
                         let handler = handler.clone();
                         workers.push(thread::spawn(move || handler(req)));
@@ -695,8 +695,8 @@ mod tests {
             enabled: false,
             method: ReadinessMethod::Api,
             initial_delay: Duration::from_secs(10),
-            max_delay: Duration::from_secs(60),
-            max_total_wait: Duration::from_secs(300),
+            max_delay: Duration::from_mins(1),
+            max_total_wait: Duration::from_mins(5),
             poll_interval: Duration::from_secs(2),
             jitter_factor: 0.5,
             index_path: None,
@@ -3138,11 +3138,11 @@ mod tests {
         // u32::MAX attempt should not panic due to saturating arithmetic
         let delay = cli.calculate_backoff_delay(
             Duration::from_millis(100),
-            Duration::from_secs(60),
+            Duration::from_mins(1),
             u32::MAX,
             0.0,
         );
-        assert!(delay <= Duration::from_secs(60));
+        assert!(delay <= Duration::from_mins(1));
     }
 
     #[test]

--- a/crates/shipper-registry/src/http.rs
+++ b/crates/shipper-registry/src/http.rs
@@ -340,8 +340,8 @@ mod tests {
 
     #[test]
     fn client_with_timeout() {
-        let client = HttpRegistryClient::crates_io().with_timeout(Duration::from_secs(60));
-        assert_eq!(client.timeout, Duration::from_secs(60));
+        let client = HttpRegistryClient::crates_io().with_timeout(Duration::from_mins(1));
+        assert_eq!(client.timeout, Duration::from_mins(1));
     }
 
     #[test]

--- a/crates/shipper-retry/src/lib.rs
+++ b/crates/shipper-retry/src/lib.rs
@@ -79,7 +79,7 @@ impl RetryPolicy {
                 strategy: RetryStrategyType::Exponential,
                 max_attempts: 6,
                 base_delay: Duration::from_secs(2),
-                max_delay: Duration::from_secs(120),
+                max_delay: Duration::from_mins(2),
                 jitter: 0.5,
             },
             RetryPolicy::Aggressive => RetryStrategyConfig {
@@ -93,7 +93,7 @@ impl RetryPolicy {
                 strategy: RetryStrategyType::Linear,
                 max_attempts: 3,
                 base_delay: Duration::from_secs(5),
-                max_delay: Duration::from_secs(60),
+                max_delay: Duration::from_mins(1),
                 jitter: 0.1,
             },
             RetryPolicy::Custom => {
@@ -131,7 +131,7 @@ fn default_base_delay() -> Duration {
 }
 
 fn default_max_delay() -> Duration {
-    Duration::from_secs(120)
+    Duration::from_mins(2)
 }
 
 fn default_jitter() -> f64 {
@@ -144,7 +144,7 @@ impl Default for RetryStrategyConfig {
             strategy: RetryStrategyType::Exponential,
             max_attempts: 6,
             base_delay: Duration::from_secs(2),
-            max_delay: Duration::from_secs(120),
+            max_delay: Duration::from_mins(2),
             jitter: 0.5,
         }
     }
@@ -400,7 +400,7 @@ mod tests {
         assert_eq!(config.strategy, RetryStrategyType::Exponential);
         assert_eq!(config.max_attempts, 6);
         assert_eq!(config.base_delay, Duration::from_secs(2));
-        assert_eq!(config.max_delay, Duration::from_secs(120));
+        assert_eq!(config.max_delay, Duration::from_mins(2));
     }
 
     #[test]
@@ -418,7 +418,7 @@ mod tests {
         assert_eq!(config.strategy, RetryStrategyType::Linear);
         assert_eq!(config.max_attempts, 3);
         assert_eq!(config.base_delay, Duration::from_secs(5));
-        assert_eq!(config.max_delay, Duration::from_secs(60));
+        assert_eq!(config.max_delay, Duration::from_mins(1));
     }
 
     #[test]
@@ -426,7 +426,7 @@ mod tests {
         let config = RetryStrategyConfig {
             strategy: RetryStrategyType::Immediate,
             base_delay: Duration::from_secs(1),
-            max_delay: Duration::from_secs(60),
+            max_delay: Duration::from_mins(1),
             jitter: 0.0,
             max_attempts: 3,
         };
@@ -440,7 +440,7 @@ mod tests {
         let config = RetryStrategyConfig {
             strategy: RetryStrategyType::Exponential,
             base_delay: Duration::from_secs(1),
-            max_delay: Duration::from_secs(60),
+            max_delay: Duration::from_mins(1),
             jitter: 0.0,
             max_attempts: 10,
         };
@@ -455,7 +455,7 @@ mod tests {
         assert_eq!(calculate_delay(&config, 3), Duration::from_secs(4));
 
         // Attempt 10: should be capped at max_delay
-        assert_eq!(calculate_delay(&config, 10), Duration::from_secs(60));
+        assert_eq!(calculate_delay(&config, 10), Duration::from_mins(1));
     }
 
     #[test]
@@ -597,7 +597,7 @@ mod tests {
         let config = RetryStrategyConfig {
             strategy: RetryStrategyType::Constant,
             base_delay: Duration::from_secs(10),
-            max_delay: Duration::from_secs(60),
+            max_delay: Duration::from_mins(1),
             jitter: 0.5,
             max_attempts: 10,
         };
@@ -605,8 +605,8 @@ mod tests {
         // With jitter of 0.5, delay should be between 5s and 15s
         for _ in 0..100 {
             let delay = calculate_delay(&config, 1);
-            assert!(delay >= Duration::from_millis(5000));
-            assert!(delay <= Duration::from_millis(15000));
+            assert!(delay >= Duration::from_secs(5));
+            assert!(delay <= Duration::from_secs(15));
         }
     }
 
@@ -639,7 +639,7 @@ mod tests {
             strategy: RetryStrategyType::Exponential,
             max_attempts: 0,
             base_delay: Duration::from_secs(1),
-            max_delay: Duration::from_secs(60),
+            max_delay: Duration::from_mins(1),
             jitter: 0.0,
         });
 
@@ -652,8 +652,8 @@ mod tests {
         let executor = RetryExecutor::new(RetryStrategyConfig {
             strategy: RetryStrategyType::Exponential,
             max_attempts: 100,
-            base_delay: Duration::from_secs(60),
-            max_delay: Duration::from_secs(3600),
+            base_delay: Duration::from_mins(1),
+            max_delay: Duration::from_hours(1),
             jitter: 0.5,
         });
 
@@ -703,7 +703,7 @@ mod tests {
         let config = RetryStrategyConfig {
             strategy: RetryStrategyType::Exponential,
             base_delay: Duration::from_millis(100),
-            max_delay: Duration::from_secs(60),
+            max_delay: Duration::from_mins(1),
             jitter: 0.0,
             max_attempts: 10,
         };
@@ -722,7 +722,7 @@ mod tests {
         let config = RetryStrategyConfig {
             strategy: RetryStrategyType::Constant,
             base_delay: Duration::from_secs(10),
-            max_delay: Duration::from_secs(60),
+            max_delay: Duration::from_mins(1),
             jitter: 1.0,
             max_attempts: 10,
         };
@@ -731,7 +731,7 @@ mod tests {
         // So delay should be in [0ms, 20_000ms]
         for _ in 0..200 {
             let delay = calculate_delay(&config, 1);
-            assert!(delay <= Duration::from_millis(20_000));
+            assert!(delay <= Duration::from_secs(20));
         }
     }
 
@@ -747,7 +747,7 @@ mod tests {
             let config = RetryStrategyConfig {
                 strategy,
                 base_delay: Duration::ZERO,
-                max_delay: Duration::from_secs(60),
+                max_delay: Duration::from_mins(1),
                 jitter: 0.0,
                 max_attempts: 10,
             };
@@ -825,7 +825,7 @@ mod tests {
         let config = RetryStrategyConfig {
             strategy: RetryStrategyType::Exponential,
             base_delay: Duration::from_millis(100),
-            max_delay: Duration::from_secs(3600),
+            max_delay: Duration::from_hours(1),
             jitter: 0.0,
             max_attempts: 20,
         };
@@ -849,7 +849,7 @@ mod tests {
         let config = RetryStrategyConfig {
             strategy: RetryStrategyType::Exponential,
             base_delay: Duration::from_millis(1),
-            max_delay: Duration::from_secs(3600),
+            max_delay: Duration::from_hours(1),
             jitter: 0.0,
             max_attempts: 30,
         };
@@ -867,7 +867,7 @@ mod tests {
     #[test]
     fn test_strategy_selection_produces_distinct_delays() {
         let base = Duration::from_secs(2);
-        let max = Duration::from_secs(3600);
+        let max = Duration::from_hours(1);
         let make = |s| RetryStrategyConfig {
             strategy: s,
             base_delay: base,
@@ -914,7 +914,7 @@ mod tests {
         let config = RetryStrategyConfig {
             strategy: RetryStrategyType::Constant,
             base_delay: Duration::from_millis(750),
-            max_delay: Duration::from_secs(60),
+            max_delay: Duration::from_mins(1),
             jitter: 0.0,
             max_attempts: 100,
         };
@@ -941,7 +941,7 @@ mod tests {
             let config = RetryStrategyConfig {
                 strategy,
                 base_delay: Duration::from_secs(1),
-                max_delay: Duration::from_secs(60),
+                max_delay: Duration::from_mins(1),
                 jitter: 0.0,
                 max_attempts: 10,
             };
@@ -1051,7 +1051,7 @@ mod tests {
         let config = RetryStrategyConfig {
             strategy: RetryStrategyType::Exponential,
             base_delay: Duration::from_secs(1),
-            max_delay: Duration::from_secs(3600),
+            max_delay: Duration::from_hours(1),
             jitter: 0.3,
             max_attempts: 10,
         };
@@ -1084,7 +1084,7 @@ mod tests {
             let config = RetryStrategyConfig {
                 strategy,
                 base_delay: Duration::from_millis(500),
-                max_delay: Duration::from_secs(120),
+                max_delay: Duration::from_mins(2),
                 jitter: 0.0,
                 max_attempts: 20,
             };
@@ -1104,7 +1104,7 @@ mod tests {
         assert_eq!(cfg.strategy, RetryStrategyType::Exponential);
         assert_eq!(cfg.max_attempts, 6);
         assert_eq!(cfg.base_delay, Duration::from_secs(2));
-        assert_eq!(cfg.max_delay, Duration::from_secs(120));
+        assert_eq!(cfg.max_delay, Duration::from_mins(2));
         assert_eq!(cfg.jitter, 0.5);
     }
 
@@ -1153,7 +1153,7 @@ mod tests {
         let config = RetryStrategyConfig {
             strategy: RetryStrategyType::Exponential,
             base_delay: Duration::from_secs(1),
-            max_delay: Duration::from_secs(120),
+            max_delay: Duration::from_mins(2),
             jitter: 0.0,
             max_attempts: 200,
         };
@@ -1176,7 +1176,7 @@ mod tests {
         let config = RetryStrategyConfig {
             strategy: RetryStrategyType::Constant,
             base_delay: Duration::from_millis(100),
-            max_delay: Duration::from_secs(60),
+            max_delay: Duration::from_mins(1),
             jitter: 1.5,
             max_attempts: 10,
         };
@@ -1199,7 +1199,7 @@ mod tests {
         let config = RetryStrategyConfig {
             strategy: RetryStrategyType::Constant,
             base_delay: Duration::from_millis(100),
-            max_delay: Duration::from_secs(60),
+            max_delay: Duration::from_mins(1),
             jitter: -0.5,
             max_attempts: 10,
         };
@@ -1236,8 +1236,8 @@ mod tests {
         let executor = RetryExecutor::new(RetryStrategyConfig {
             strategy: RetryStrategyType::Constant,
             max_attempts: 100,
-            base_delay: Duration::from_secs(3600),
-            max_delay: Duration::from_secs(3600),
+            base_delay: Duration::from_hours(1),
+            max_delay: Duration::from_hours(1),
             jitter: 0.0,
         });
 
@@ -1440,7 +1440,7 @@ mod property_tests {
         ) {
             let jitter = (jitter_pct as f64) / 100.0;
             let base_delay = Duration::from_millis(base_ms);
-            let max_delay = Duration::from_secs(3600);
+            let max_delay = Duration::from_hours(1);
 
             let config = RetryStrategyConfig {
                 strategy: RetryStrategyType::Constant,
@@ -1580,7 +1580,7 @@ mod snapshot_tests {
         let config = RetryStrategyConfig {
             strategy: RetryStrategyType::Exponential,
             base_delay: Duration::from_secs(1),
-            max_delay: Duration::from_secs(60),
+            max_delay: Duration::from_mins(1),
             jitter: 0.0,
             max_attempts: 10,
         };
@@ -1640,7 +1640,7 @@ mod snapshot_tests {
         let config = RetryStrategyConfig {
             strategy: RetryStrategyType::Constant,
             base_delay: Duration::from_millis(500),
-            max_delay: Duration::from_secs(60),
+            max_delay: Duration::from_mins(1),
             jitter: 0.0,
             max_attempts: 10,
         };
@@ -1655,7 +1655,7 @@ mod snapshot_tests {
         let make = |s| RetryStrategyConfig {
             strategy: s,
             base_delay: Duration::from_secs(1),
-            max_delay: Duration::from_secs(120),
+            max_delay: Duration::from_mins(2),
             jitter: 0.0,
             max_attempts: 10,
         };

--- a/crates/shipper-retry/tests/retry_integration.rs
+++ b/crates/shipper-retry/tests/retry_integration.rs
@@ -53,5 +53,5 @@ fn integration_executor_respects_classic_policy_defaults() {
     assert_eq!(cfg.strategy, RetryStrategyType::Exponential);
     assert_eq!(cfg.max_attempts, 6);
     assert_eq!(cfg.base_delay, Duration::from_secs(2));
-    assert_eq!(cfg.max_delay, Duration::from_secs(120));
+    assert_eq!(cfg.max_delay, Duration::from_mins(2));
 }

--- a/crates/shipper-types/src/lib.rs
+++ b/crates/shipper-types/src/lib.rs
@@ -409,8 +409,8 @@ impl Default for ReadinessConfig {
             enabled: true,
             method: ReadinessMethod::Api,
             initial_delay: Duration::from_secs(1),
-            max_delay: Duration::from_secs(60),
-            max_total_wait: Duration::from_secs(300), // 5 minutes
+            max_delay: Duration::from_mins(1),
+            max_total_wait: Duration::from_mins(5), // 5 minutes
             poll_interval: Duration::from_secs(2),
             jitter_factor: 0.5,
             index_path: None,
@@ -485,7 +485,7 @@ impl Default for ParallelConfig {
         Self {
             enabled: false,
             max_concurrent: 4,
-            per_package_timeout: Duration::from_secs(1800), // 30 minutes
+            per_package_timeout: Duration::from_mins(30), // 30 minutes
         }
     }
 }
@@ -2133,8 +2133,8 @@ mod tests {
         assert!(config.enabled);
         assert_eq!(config.method, ReadinessMethod::Api);
         assert_eq!(config.initial_delay, Duration::from_secs(1));
-        assert_eq!(config.max_delay, Duration::from_secs(60));
-        assert_eq!(config.max_total_wait, Duration::from_secs(300));
+        assert_eq!(config.max_delay, Duration::from_mins(1));
+        assert_eq!(config.max_total_wait, Duration::from_mins(5));
         assert_eq!(config.poll_interval, Duration::from_secs(2));
         assert_eq!(config.jitter_factor, 0.5);
     }
@@ -2146,7 +2146,7 @@ mod tests {
             method: ReadinessMethod::Both,
             initial_delay: Duration::from_millis(500),
             max_delay: Duration::from_secs(30),
-            max_total_wait: Duration::from_secs(600),
+            max_total_wait: Duration::from_mins(10),
             poll_interval: Duration::from_secs(5),
             jitter_factor: 0.25,
             index_path: None,
@@ -2156,7 +2156,7 @@ mod tests {
         assert_eq!(config.method, ReadinessMethod::Both);
         assert_eq!(config.initial_delay, Duration::from_millis(500));
         assert_eq!(config.max_delay, Duration::from_secs(30));
-        assert_eq!(config.max_total_wait, Duration::from_secs(600));
+        assert_eq!(config.max_total_wait, Duration::from_mins(10));
         assert_eq!(config.poll_interval, Duration::from_secs(5));
         assert_eq!(config.jitter_factor, 0.25);
     }
@@ -2767,11 +2767,11 @@ mod tests {
             no_verify: false,
             max_attempts: 3,
             base_delay: Duration::from_secs(1),
-            max_delay: Duration::from_secs(60),
+            max_delay: Duration::from_mins(1),
             retry_strategy: shipper_retry::RetryStrategyType::Exponential,
             retry_jitter: 0.5,
             retry_per_error: shipper_retry::PerErrorConfig::default(),
-            verify_timeout: Duration::from_secs(600),
+            verify_timeout: Duration::from_mins(10),
             verify_poll_interval: Duration::from_secs(10),
             state_dir: PathBuf::from(".shipper"),
             force_resume: false,
@@ -2780,7 +2780,7 @@ mod tests {
             readiness: ReadinessConfig::default(),
             output_lines: 1000,
             force: false,
-            lock_timeout: Duration::from_secs(3600),
+            lock_timeout: Duration::from_hours(1),
             parallel: ParallelConfig::default(),
             webhook: WebhookConfig::default(),
             encryption: EncryptionSettings::default(),
@@ -2801,7 +2801,7 @@ mod tests {
         assert!(!opts.no_verify);
         assert_eq!(opts.max_attempts, 3);
         assert_eq!(opts.base_delay, Duration::from_secs(1));
-        assert_eq!(opts.max_delay, Duration::from_secs(60));
+        assert_eq!(opts.max_delay, Duration::from_mins(1));
         assert_eq!(opts.policy, PublishPolicy::Safe);
         assert_eq!(opts.verify_mode, VerifyMode::Workspace);
         assert_eq!(opts.output_lines, 1000);
@@ -2988,7 +2988,7 @@ mod tests {
         let config = ParallelConfig::default();
         assert!(!config.enabled);
         assert_eq!(config.max_concurrent, 4);
-        assert_eq!(config.per_package_timeout, Duration::from_secs(1800));
+        assert_eq!(config.per_package_timeout, Duration::from_mins(30));
     }
 
     #[test]
@@ -2996,13 +2996,13 @@ mod tests {
         let config = ParallelConfig {
             enabled: true,
             max_concurrent: 16,
-            per_package_timeout: Duration::from_secs(300),
+            per_package_timeout: Duration::from_mins(5),
         };
         let json = serde_json::to_string(&config).unwrap();
         let parsed: ParallelConfig = serde_json::from_str(&json).unwrap();
         assert!(parsed.enabled);
         assert_eq!(parsed.max_concurrent, 16);
-        assert_eq!(parsed.per_package_timeout, Duration::from_secs(300));
+        assert_eq!(parsed.per_package_timeout, Duration::from_mins(5));
     }
 
     // ===== PackageState serde =====
@@ -3155,8 +3155,8 @@ mod tests {
             enabled: true,
             method: ReadinessMethod::Index,
             initial_delay: Duration::from_secs(2),
-            max_delay: Duration::from_secs(120),
-            max_total_wait: Duration::from_secs(600),
+            max_delay: Duration::from_mins(2),
+            max_total_wait: Duration::from_mins(10),
             poll_interval: Duration::from_secs(5),
             jitter_factor: 0.3,
             index_path: Some(PathBuf::from("/tmp/test-index")),
@@ -3549,7 +3549,7 @@ mod tests {
                                 stdout_tail: "Uploading core-lib v0.1.0".to_string(),
                                 stderr_tail: String::new(),
                                 timestamp: t,
-                                duration: Duration::from_millis(3000),
+                                duration: Duration::from_secs(3),
                             }],
                             readiness_checks: vec![ReadinessEvidence {
                                 attempt: 1,
@@ -3896,8 +3896,8 @@ mod tests {
                 enabled: false,
                 method: ReadinessMethod::Both,
                 initial_delay: Duration::from_millis(500),
-                max_delay: Duration::from_secs(120),
-                max_total_wait: Duration::from_secs(900),
+                max_delay: Duration::from_mins(2),
+                max_total_wait: Duration::from_mins(15),
                 poll_interval: Duration::from_secs(10),
                 jitter_factor: 0.25,
                 index_path: Some(PathBuf::from("/tmp/test-index")),
@@ -3917,7 +3917,7 @@ mod tests {
             let config = ParallelConfig {
                 enabled: true,
                 max_concurrent: 8,
-                per_package_timeout: Duration::from_secs(600),
+                per_package_timeout: Duration::from_mins(10),
             };
             insta::assert_yaml_snapshot!(config);
         }

--- a/crates/shipper/tests/pipeline_integration.rs
+++ b/crates/shipper/tests/pipeline_integration.rs
@@ -461,7 +461,7 @@ fn lock_stale_timeout_allows_reacquire() {
     let mut lock = shipper_core::lock::LockFile::acquire_with_timeout(
         &state_dir,
         None,
-        Duration::from_secs(60),
+        Duration::from_mins(1),
     )
     .expect("acquire with timeout");
     assert!(shipper_core::lock::LockFile::is_locked(&state_dir, None).expect("locked"));

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -116,13 +116,14 @@ class = "boundary"
 reason = "Ban direct field access across protected seams (pending seam configuration; see docs/CLIPPY_POLICY.md)"
 since = "1.95"
 
-# ─── Planned lints (MSRV-gated) ─────────────────────────────────────────────
-
-[[planned]]
+[[active]]
 name = "clippy::duration_suboptimal_units"
 level = "warn"
-min_msrv = "1.95"
-reason = "Make durations legible. Activation deferred from #191: 204 fallout sites across 20 files (config/runtime/retry/types/lock APIs that accept user-supplied millisecond values); needs a focused cleanup PR rather than a debt entry."
+class = "style"
+reason = "Make durations legible by using the largest available unit. Activated after a focused cleanup PR reduced all 204 fallout sites (config/runtime/retry/types/lock APIs) to optimal units via `cargo clippy --fix`."
+since = "1.95"
+
+# ─── Planned lints (MSRV-gated) ─────────────────────────────────────────────
 
 # ─── Fabricated names rejected by the activation audit ──────────────────────
 #


### PR DESCRIPTION
## Summary

Activates `clippy::duration_suboptimal_units` — the last lint deferred from the #191 Clippy ratchet rollout — after rewriting all 223 fallout sites to their optimal `Duration` unit.

This closes the carry-over flagged in the CHANGELOG (`## [0.4.0-rc.1]` → "planned for the 0.4.0 line but did not land in rc.1") and in `Cargo.toml`'s `[workspace.lints.clippy]` comment.

## Changes

- **223 sites rewritten across 23 files** via `cargo clippy --fix` (machine-applicable, behavior-preserving exact aliases). Examples:
  - `Duration::from_secs(120)` → `Duration::from_mins(2)`
  - `Duration::from_secs(3600)` → `Duration::from_hours(1)`
  - `Duration::from_millis(3000)` → `Duration::from_secs(3)`
  - `Duration::from_nanos(500_000)` → `Duration::from_micros(500)`
- **`Cargo.toml`**: added `duration_suboptimal_units = "warn"` to `[workspace.lints.clippy]`; updated the ratchet comment.
- **`policy/clippy-lints.toml`**: moved the entry from `[[planned]]` → `[[active]]`.

The new `Duration::from_mins`/`from_hours`/`from_days` APIs are stable since Rust 1.95, matching the workspace MSRV.

## Why now

The lint was deferred in #191 because of the fallout count (204 at the time, grew to 223). `Duration::from_mins`/`from_hours` stabilized in 1.95, so the deferral reason no longer applies. Without activation, the debt regenerates: new code can re-introduce suboptimal units freely.

## Verification

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — **pass** (zero warnings; the newly-active lint produces no fallout)
- `cargo run -p xtask -- check-lint-policy` — **pass** (`workspace.lints.clippy=9 active_in_ledger=13 planned_in_ledger=0` — reconciliation clean)
- `cargo build --workspace --all-targets --all-features` — **pass**
- Tests (changed crates, lib + unit):
  - `shipper-retry` — 71 + 3 passed
  - `shipper-config` — 280+ passed (incl. runtime contract/proptest/bdd + snapshot)
  - `shipper-types` — 273+ passed (incl. schema snapshots)
  - `shipper-duration` — 79+ passed (incl. snapshots)
  - `shipper-core` — `ops::lock` 127 passed, `config::` 71 passed
  - `shipper-registry` — 282 passed
  - `shipper-cli` — 136 passed

Every conversion is an exact alias (verified value-by-value), so no behavior change.

## Known gaps

The full `cargo test --workspace` was not run to completion in this session (shipper-core's complete suite + cli e2e exceed the local timeout). CI will supply the full workspace test run. The changed crates' tests all pass, and clippy + build cover compilation correctness across the whole workspace.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical, value-preserving duration constructor renames plus a style lint; no auth, I/O semantics, or algorithm changes beyond readability.
> 
> **Overview**
> Completes the #191 Clippy ratchet by turning on **`clippy::duration_suboptimal_units`** (`warn` in `Cargo.toml`, moved from `[[planned]]` to `[[active]]` in `policy/clippy-lints.toml`).
> 
> Across the workspace, **`Duration` literals are rewritten** to the largest stable unit (`from_secs(3600)` → `from_hours(1)`, `from_secs(120)` → `from_mins(2)`, etc.) in config defaults, retry/lock/runtime code, CLI progress ticks, and tests. These are exact aliases—no timeout or backoff behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 714b801f50579104a7b9d2c9c19d522580f8096f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->