### PR TITLE
docs(changelog): record post-0.4.0 carry-over resolutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Post-0.4.0 release cleanup. Resolves carry-over items flagged in the
+0.4.0 readiness evidence packet and CHANGELOG.
+
+### Fixed
+
+- **`engine/parallel` mutex poison posture.** All production `.lock().unwrap()`
+  sites in `engine/parallel/` (40 sites across `publish.rs` and `mod.rs`) now
+  handle poison gracefully instead of panicking: `Result`-returning sites
+  propagate a typed `anyhow::Error` via `let-else`/`map_err`; the `SendReporter`
+  methods (which can't return `Result`) recover the guard via
+  `unwrap_or_else(|e| e.into_inner())`. The no-panic baseline drops from 20 → 8
+  entries. Closes the carry-over from the 0.4.0 readiness doc.
+- **Cleanliness test isolation flake.** `ensure_git_clean_new_phrasing` now
+  carries `#[serial]`, bringing it into the same serialization group as the
+  engine integration tests that share the `SHIPPER_GIT_BIN` environment
+  variable.
+
+### Changed
+
+- **`duration_suboptimal_units` clippy lint activated.** All 223 workspace
+  sites rewritten to their optimal `Duration` unit via `cargo clippy --fix`
+  (behavior-preserving exact aliases), and the lint moved from `[[planned]]` →
+  `[[active]]` in `policy/clippy-lints.toml`. Closes the last planned lint from
+  the #191 Clippy ratchet rollout and the 0.4.0 readiness carry-over.
+
 ## [0.4.0] - 2026-05-20
 
 Stable release of Shipper's 0.4.0 release-closure line.


### PR DESCRIPTION
Populates the \`[Unreleased]\` section with the three post-0.4.0 merges (#410, #411, #412). The readiness evidence packet and 0.4.0 CHANGELOG section are frozen release records and left untouched; \`[Unreleased]\` is the forward-looking surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only; no runtime, CI, or policy behavior changes in this diff.
> 
> **Overview**
> Fills in **`[Unreleased]`** with post-0.4.0 cleanup that already landed elsewhere (#410–#412), without changing the frozen **0.4.0** release section.
> 
> Under **Fixed**, it documents graceful **mutex poison** handling in `engine/parallel` (typed errors vs `SendReporter` guard recovery) and a lower no-panic baseline count, plus **`#[serial]`** on `ensure_git_clean_new_phrasing` to stop cleanliness test flakes when tests share `SHIPPER_GIT_BIN`.
> 
> Under **Changed**, it notes **`clippy::duration_suboptimal_units`** promoted to **active** in `policy/clippy-lints.toml` after a workspace-wide `clippy --fix` pass on `Duration` literals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 669846832befcc5f45cadf397cd4074b5bc9b6c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->