### PR TITLE
fix(no-panic): burn down final 8 baseline entries to zero

### DIFF
--- a/crates/shipper-core/src/engine/parallel/publish.rs
+++ b/crates/shipper-core/src/engine/parallel/publish.rs
@@ -745,7 +745,7 @@ pub(super) fn publish_package(
                             }
 
                             // Preserve reconciliation evidence in the receipt.
-                            // Do NOT emit PublishSucceeded webhook here Ã¢â‚¬â€ the
+                            // Do NOT emit PublishSucceeded webhook here ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the
                             // end-of-function success path (below) handles that.
                             readiness_evidence = reconcile_evidence;
                             last_err = None;
@@ -866,7 +866,7 @@ pub(super) fn publish_package(
                     }
                     ErrorClass::Retryable | ErrorClass::Ambiguous => {
                         // Ambiguous can only reach here if reconciliation
-                        // returned NotPublished Ã¢â‚¬â€ registry confirms no
+                        // returned NotPublished ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â registry confirms no
                         // duplicate-upload risk, so cargo retry is safe.
                         // Only query crate_exists when the error looks like
                         // a rate limit (saves a registry round-trip for
@@ -1092,12 +1092,10 @@ pub(super) fn publish_package(
 
     // If package is still Uploaded (loop didn't run or readiness never checked), force a final check
     if last_err.is_none() {
-        let current_state = st
-            .lock()
-            .unwrap()
-            .packages
-            .get(&key)
-            .map(|p| p.state.clone());
+        let Ok(state) = st.lock() else {
+            return poisoned_lock("execution state");
+        };
+        let current_state = state.packages.get(&key).map(|p| p.state.clone());
         if matches!(current_state, Some(PackageState::Uploaded)) {
             if reg.version_exists(&p.name, &p.version).unwrap_or(false) {
                 {
@@ -1156,12 +1154,12 @@ pub(super) fn publish_package(
                 result: Ok(PackageReceipt {
                     name: p.name.clone(),
                     version: p.version.clone(),
-                    attempts: st
-                        .lock()
-                        .unwrap()
-                        .packages
-                        .get(&key)
-                        .map_or(0, |p| p.attempts),
+                    attempts: {
+                        let Ok(st) = st.lock() else {
+                            return poisoned_lock("execution state");
+                        };
+                        st.packages.get(&key).map_or(0, |p| p.attempts)
+                    },
                     state: PackageState::Published,
                     started_at,
                     finished_at,
@@ -1239,12 +1237,12 @@ pub(super) fn publish_package(
         result: Ok(PackageReceipt {
             name: p.name.clone(),
             version: p.version.clone(),
-            attempts: st
-                .lock()
-                .unwrap()
-                .packages
-                .get(&key)
-                .map_or(0, |p| p.attempts),
+            attempts: {
+                let Ok(st) = st.lock() else {
+                    return poisoned_lock("execution state");
+                };
+                st.packages.get(&key).map_or(0, |p| p.attempts)
+            },
             state: PackageState::Published,
             started_at,
             finished_at,

--- a/crates/shipper-core/src/plan/assembly.rs
+++ b/crates/shipper-core/src/plan/assembly.rs
@@ -4,20 +4,24 @@ use cargo_metadata::PackageId;
 use sha2::{Digest, Sha256};
 use shipper_types::PlannedPackage;
 
+use anyhow::Result;
+
 pub(super) fn planned_packages(
     order: &[PackageId],
     pkg_map: &BTreeMap<PackageId, &cargo_metadata::Package>,
-) -> Vec<PlannedPackage> {
+) -> Result<Vec<PlannedPackage>> {
     order
         .iter()
         .map(|id| {
-            let pkg = pkg_map.get(id).expect("pkg exists");
-            PlannedPackage {
+            let pkg = pkg_map.get(id).ok_or_else(|| {
+                anyhow::anyhow!("topo-sorted package id missing from pkg_map: {id}")
+            })?;
+            Ok(PlannedPackage {
                 name: pkg.name.to_string(),
                 version: pkg.version.to_string(),
                 manifest_path: pkg.manifest_path.clone().into_std_path_buf(),
                 regime: None,
-            }
+            })
         })
         .collect()
 }
@@ -27,10 +31,12 @@ pub(super) fn dependency_map(
     included: &BTreeSet<PackageId>,
     deps_of: &BTreeMap<PackageId, BTreeSet<PackageId>>,
     pkg_map: &BTreeMap<PackageId, &cargo_metadata::Package>,
-) -> BTreeMap<String, Vec<String>> {
+) -> Result<BTreeMap<String, Vec<String>>> {
     let mut dependencies = BTreeMap::new();
     for id in order {
-        let pkg = pkg_map.get(id).expect("pkg exists");
+        let pkg = pkg_map
+            .get(id)
+            .ok_or_else(|| anyhow::anyhow!("topo-sorted package id missing from pkg_map: {id}"))?;
         let pkg_name = pkg.name.to_string();
 
         // Get all dependencies of this package that are in the plan.
@@ -52,7 +58,7 @@ pub(super) fn dependency_map(
         dependencies.insert(pkg_name, dep_names);
     }
 
-    dependencies
+    Ok(dependencies)
 }
 
 pub(super) fn compute_plan_id(registry_api_base: &str, packages: &[PlannedPackage]) -> String {

--- a/crates/shipper-core/src/plan/build_pipeline.rs
+++ b/crates/shipper-core/src/plan/build_pipeline.rs
@@ -34,8 +34,8 @@ pub(super) fn build_plan(spec: &ReleaseSpec) -> Result<PlannedWorkspace> {
     validate_publishable_dependencies(&included, &graph, &pkg_map)?;
 
     let order = topo_sort(&included, &graph.deps_of, &graph.dependents_of, &pkg_map)?;
-    let packages = planned_packages(&order, &pkg_map);
-    let dependencies = dependency_map(&order, &included, &graph.deps_of, &pkg_map);
+    let packages = planned_packages(&order, &pkg_map)?;
+    let dependencies = dependency_map(&order, &included, &graph.deps_of, &pkg_map)?;
     let plan_id = compute_plan_id(&spec.registry.api_base, &packages);
 
     Ok(PlannedWorkspace {

--- a/crates/shipper-core/src/plan/graph.rs
+++ b/crates/shipper-core/src/plan/graph.rs
@@ -98,10 +98,9 @@ pub(super) fn validate_publishable_dependencies(
         if !included.contains(id) {
             continue;
         }
-        let dep_id = dep_ids
-            .iter()
-            .next()
-            .expect("non_publishable_workspace_deps entries are non-empty by construction");
+        let Some(dep_id) = dep_ids.iter().next() else {
+            bail!("non_publishable_workspace_deps entry for '{id}' has no dependency target");
+        };
         let pkg_name = pkg_map
             .get(id)
             .map(|p| p.name.as_str())
@@ -140,7 +139,7 @@ pub(super) fn topo_sort(
             &mut indegree,
             &mut ready,
             pkg_map,
-        );
+        )?;
     }
 
     if out.len() != included.len() {
@@ -191,21 +190,22 @@ fn relax_dependents(
     indegree: &mut BTreeMap<PackageId, usize>,
     ready: &mut BTreeSet<(String, PackageId)>,
     pkg_map: &BTreeMap<PackageId, &cargo_metadata::Package>,
-) {
+) -> Result<()> {
     if let Some(deps) = dependents_of.get(id) {
         for dep in deps {
             if !included.contains(dep) {
                 continue;
             }
-            let d = indegree
-                .get_mut(dep)
-                .expect("included package must have indegree");
+            let d = indegree.get_mut(dep).ok_or_else(|| {
+                anyhow::anyhow!("included package '{dep}' missing from indegree map")
+            })?;
             *d = d.saturating_sub(1);
             if *d == 0 {
                 ready.insert((package_name(pkg_map, dep), dep.clone()));
             }
         }
     }
+    Ok(())
 }
 
 fn package_name(pkg_map: &BTreeMap<PackageId, &cargo_metadata::Package>, id: &PackageId) -> String {

--- a/crates/shipper-core/src/state/execution_state/mod.rs
+++ b/crates/shipper-core/src/state/execution_state/mod.rs
@@ -269,20 +269,30 @@ pub fn migrate_receipt(path: &Path) -> Result<Receipt> {
 
 /// Migrate v1 receipt to v2
 fn migrate_v1_to_v2(mut receipt: serde_json::Value) -> Result<Receipt> {
+    let obj = receipt
+        .as_object_mut()
+        .context("receipt root is not an object during v1->v2 migration")?;
+
     // Add git_context: None if not present
-    if receipt.get("git_context").is_none() {
-        receipt["git_context"] = serde_json::Value::Null;
+    if !obj.contains_key("git_context") {
+        obj.insert("git_context".to_string(), serde_json::Value::Null);
     }
 
     // Add environment: default EnvironmentFingerprint if not present
-    if receipt.get("environment").is_none() {
+    if !obj.contains_key("environment") {
         let environment = collect_environment_fingerprint();
-        receipt["environment"] = serde_json::to_value(environment)
-            .context("failed to serialize environment fingerprint")?;
+        obj.insert(
+            "environment".to_string(),
+            serde_json::to_value(environment)
+                .context("failed to serialize environment fingerprint")?,
+        );
     }
 
     // Update receipt_version to v2
-    receipt["receipt_version"] = serde_json::Value::String(CURRENT_RECEIPT_VERSION.to_string());
+    obj.insert(
+        "receipt_version".to_string(),
+        serde_json::Value::String(CURRENT_RECEIPT_VERSION.to_string()),
+    );
 
     // Deserialize as Receipt
     serde_json::from_value(receipt).context("failed to deserialize migrated receipt")

--- a/policy/no-panic-baseline.json
+++ b/policy/no-panic-baseline.json
@@ -4,88 +4,11 @@
   "generated_on": "2026-06-16",
   "note": "Machine-generated. Run `cargo xtask no-panic baseline` to regenerate. See docs/NO_PANIC_POLICY.md for semantics.",
   "counts": {
-    "total_call_sites": 10,
-    "total_entries": 8,
+    "total_call_sites": 0,
+    "total_entries": 0,
     "files_scanned": 92,
-    "files_with_findings": 34,
-    "by_family": {
-      "expect": 4,
-      "index": 3,
-      "unwrap": 3
-    }
+    "files_with_findings": 30,
+    "by_family": {}
   },
-  "entries": [
-    {
-      "path": "crates/shipper-core/src/engine/parallel/publish.rs",
-      "family": "unwrap",
-      "selector_kind": "method_call",
-      "selector_callee": "unwrap",
-      "snippet": "attempts: st",
-      "count": 2,
-      "first_line": 1256
-    },
-    {
-      "path": "crates/shipper-core/src/engine/parallel/publish.rs",
-      "family": "unwrap",
-      "selector_kind": "method_call",
-      "selector_callee": "unwrap",
-      "snippet": "let current_state = st",
-      "count": 1,
-      "first_line": 1184
-    },
-    {
-      "path": "crates/shipper-core/src/plan/assembly.rs",
-      "family": "expect",
-      "selector_kind": "method_call",
-      "selector_callee": "expect",
-      "snippet": "let pkg = pkg_map.get(id).expect(\"pkg exists\");",
-      "count": 2,
-      "first_line": 14
-    },
-    {
-      "path": "crates/shipper-core/src/plan/graph.rs",
-      "family": "expect",
-      "selector_kind": "method_call",
-      "selector_callee": "expect",
-      "snippet": "let d = indegree",
-      "count": 1,
-      "first_line": 200
-    },
-    {
-      "path": "crates/shipper-core/src/plan/graph.rs",
-      "family": "expect",
-      "selector_kind": "method_call",
-      "selector_callee": "expect",
-      "snippet": "let dep_id = dep_ids",
-      "count": 1,
-      "first_line": 101
-    },
-    {
-      "path": "crates/shipper-core/src/state/execution_state/mod.rs",
-      "family": "index",
-      "selector_kind": "syntax",
-      "selector_callee": "[]",
-      "snippet": "receipt[\"environment\"] = serde_json::to_value(environment)",
-      "count": 1,
-      "first_line": 280
-    },
-    {
-      "path": "crates/shipper-core/src/state/execution_state/mod.rs",
-      "family": "index",
-      "selector_kind": "syntax",
-      "selector_callee": "[]",
-      "snippet": "receipt[\"git_context\"] = serde_json::Value::Null;",
-      "count": 1,
-      "first_line": 274
-    },
-    {
-      "path": "crates/shipper-core/src/state/execution_state/mod.rs",
-      "family": "index",
-      "selector_kind": "syntax",
-      "selector_callee": "[]",
-      "snippet": "receipt[\"receipt_version\"] = serde_json::Value::String(CURRENT_RECEIPT_VERSION.to_string());",
-      "count": 1,
-      "first_line": 285
-    }
-  ]
+  "entries": []
 }


### PR DESCRIPTION
## Summary

Completes the no-panic ratchet: the production panic-site baseline drops from **8 entries → 0 entries (0 production sites)**. Every `.unwrap()`, `.expect()`, and `[]` index in tracked production source has been converted to a panic-free idiom.

This achieves the no-panic policy goal stated in `docs/NO_PANIC_POLICY.md`: zero unintentional panic surfaces in production code paths.

## Sites converted (8 total)

| File | Sites | Before | After |
|---|---:|---|---|
| `engine/parallel/publish.rs` | 3 | `st.lock().unwrap()` inline in struct literals | `let Ok(state) = st.lock() else { return poisoned_lock(...) };` (reuses the helper from #412) |
| `state/execution_state/mod.rs` | 3 | `receipt["k"] = v` (panics if root isn't object) | `receipt.as_object_mut().context(...)?.insert("k".into(), v)` |
| `plan/assembly.rs` | 2 | `pkg_map.get(id).expect("pkg exists")` | `.ok_or_else(\|\| anyhow!(...))?` (functions promoted to `Result`) |
| `plan/graph.rs` | 2 | `.expect()` on invariant maps | `let-else` + `bail!` / `.ok_or_else(...)?` (`relax_dependents` promoted to `Result`) |

## Verification

- `cargo build -p shipper-core` — pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — **pass** (zero warnings)
- `cargo fmt --all -- --check` — pass
- `cargo run -p xtask -- no-panic check` — **8 resolved, 0 new, 0 violations**
- `cargo run -p xtask -- no-panic baseline` — regenerated: **`production_sites=0, entries=0`**
- `cargo run -p xtask -- check-lint-policy` — pass (9/13/0)
- Tests (all touched modules):
  - `plan::` — **236 passed**
  - `state::execution_state` — **102 passed**
  - `engine::parallel` — **101 passed**
  - Total: **439 passed, 0 failed**

## Behavior change

None on the happy path. The only behavior change is panic→typed-error when a provably-unreachable invariant is violated (e.g., a topo-sorted package id missing from the package map). All converted sites were already safe-by-construction; the new forms make that safety obvious to both the compiler and the reader, and remove the entries from the no-panic baseline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Happy-path behavior is unchanged; violations of internal invariants now return errors instead of panicking, which is safer for parallel publish and plan building.
> 
> **Overview**
> Clears the **no-panic policy baseline** by replacing the last eight production panic sites with typed errors, and regenerates `policy/no-panic-baseline.json` to **0 entries**.
> 
> In **parallel publish**, remaining inline `st.lock().unwrap()` reads now use `let Ok(...) else { return poisoned_lock(...) }`, consistent with the existing poisoned-mutex helper.
> 
> **Plan assembly** promotes `planned_packages` and `dependency_map` to `Result` (missing topo-sorted ids become `anyhow` errors instead of `.expect`), with `build_pipeline` propagating via `?`. **Graph** validation and `relax_dependents` similarly replace `.expect` with `bail!` / `ok_or_else?`.
> 
> **Receipt v1→v2 migration** stops using `receipt["field"] = ...` indexing; it mutates via `as_object_mut().context(...)?` and `insert`, so non-object roots fail as errors instead of panicking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c2e5b697d3209e1196c384a7fb5b47683b42458. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->