### PR TITLE
feat(integrate): exit-code vocabulary + execution_result on receipt

### DIFF
--- a/crates/shipper-cli/src/lib.rs
+++ b/crates/shipper-cli/src/lib.rs
@@ -41,8 +41,9 @@ use shipper_core::engine::{self, Reporter};
 use shipper_core::plan;
 use shipper_core::runtime::execution::pkg_key;
 use shipper_core::types::{
-    EventType, ExecutionState, Finishability, PackageState, PlannedPackage, PreflightPackage,
-    PreflightReport, PublishEvent, Registry, ReleasePlan, ReleaseSpec, RuntimeOptions,
+    EventType, ExecutionResult, ExecutionState, Finishability, PackageState, PlannedPackage,
+    PreflightPackage, PreflightReport, PublishEvent, Registry, ReleasePlan, ReleaseSpec,
+    RuntimeOptions,
 };
 
 mod doctor;
@@ -779,22 +780,24 @@ impl Reporter for CliReporter {
 /// and for the `shipper-cli` crate's own `shipper-cli` binary — both
 /// are three-line `fn main() { shipper_cli::run() }` wrappers over
 /// this function.
-pub fn run() -> Result<()> {
+pub fn run() -> Result<std::process::ExitCode> {
     let cli = Cli::parse();
 
     if cli.version {
         print_version(cli.verbose);
-        return Ok(());
+        return Ok(std::process::ExitCode::SUCCESS);
     }
 
     // Handle Config commands early (they don't need workspace plan)
     if let Some(Commands::Config(config_cmd)) = &cli.cmd {
-        return run_config(config_cmd.clone());
+        run_config(config_cmd.clone())?;
+        return Ok(std::process::ExitCode::SUCCESS);
     }
 
     // Handle Completion commands early (they don't need workspace plan)
     if let Some(Commands::Completion { shell }) = &cli.cmd {
-        return run_completion(shell);
+        run_completion(shell)?;
+        return Ok(std::process::ExitCode::SUCCESS);
     }
 
     if cli.cmd.is_none() {
@@ -982,6 +985,7 @@ pub fn run() -> Result<()> {
                 opts.registries.clone()
             };
 
+            let mut last_exit_code = std::process::ExitCode::SUCCESS;
             for reg in target_registries {
                 if opts.registries.len() > 1 {
                     if cli.format == "json" {
@@ -1038,7 +1042,11 @@ pub fn run() -> Result<()> {
                     &current_opts.state_dir,
                     &cli.format,
                 )?;
+
+                last_exit_code = exit_code_for_result(&receipt.execution_result);
             }
+
+            return Ok(last_exit_code);
         }
         Commands::Resume => {
             let target_registries = if opts.registries.is_empty() {
@@ -1047,6 +1055,7 @@ pub fn run() -> Result<()> {
                 opts.registries.clone()
             };
 
+            let mut last_exit_code = std::process::ExitCode::SUCCESS;
             for reg in target_registries {
                 if opts.registries.len() > 1 {
                     if cli.format == "json" {
@@ -1102,7 +1111,11 @@ pub fn run() -> Result<()> {
                     &current_opts.state_dir,
                     &cli.format,
                 )?;
+
+                last_exit_code = exit_code_for_result(&receipt.execution_result);
             }
+
+            return Ok(last_exit_code);
         }
         Commands::Rehearse => {
             let outcome = engine::run_rehearsal(&planned, &opts, &mut reporter)?;
@@ -1144,7 +1157,7 @@ pub fn run() -> Result<()> {
                     );
                 }
                 run_status_watch(&planned, &opts, &cli.format)?;
-                return Ok(());
+                return Ok(std::process::ExitCode::SUCCESS);
             }
 
             let mut registry_reports = Vec::new();
@@ -1325,7 +1338,7 @@ pub fn run() -> Result<()> {
                         "yank plan complete: {succeeded}/{} entries yanked successfully",
                         yank_plan.entries.len()
                     ));
-                    return Ok(());
+                    return Ok(std::process::ExitCode::SUCCESS);
                 }
             }
 
@@ -1684,7 +1697,7 @@ pub fn run() -> Result<()> {
                     "remediation containment complete: {succeeded}/{} yanks executed successfully",
                     plan.yank_order.len()
                 ));
-                return Ok(());
+                return Ok(std::process::ExitCode::SUCCESS);
             }
 
             if !dry_run {
@@ -1749,7 +1762,32 @@ pub fn run() -> Result<()> {
         }
     }
 
-    Ok(())
+    Ok(std::process::ExitCode::SUCCESS)
+}
+
+/// Map an [`ExecutionResult`] to a process exit code.
+///
+/// This gives CI systems a machine-readable way to distinguish publish
+/// outcomes without parsing stderr or the JSON envelope:
+///
+/// | Code | Meaning |
+/// |-----:|---------|
+/// | 0 | All packages published/skipped (`Success`) |
+/// | 1 | All packages failed / general error (`CompleteFailure`) |
+/// | 2 | Some packages published, some failed — resume is safe (`PartialFailure`) |
+///
+/// The `PartialFailure → 2` mapping is the key integration improvement: a CI
+/// pipeline can check `if exit_code == 2` to trigger a `shipper resume` step
+/// rather than treating the run as a hard failure.
+fn exit_code_for_result(result: &ExecutionResult) -> std::process::ExitCode {
+    use std::process::ExitCode;
+    match result {
+        ExecutionResult::Success => ExitCode::SUCCESS,
+        // Partial failure: some packages published, some didn't. Resume is
+        // the intended next step — distinguish from a hard error (exit 1).
+        ExecutionResult::PartialFailure => ExitCode::from(2),
+        ExecutionResult::CompleteFailure => ExitCode::FAILURE,
+    }
 }
 
 /// Operator-facing hint attached to a failed `preflight` run.
@@ -2738,6 +2776,7 @@ fn package_noun(count: usize) -> &'static str {
 struct PublishJsonReport<'a> {
     schema_version: &'static str,
     command: &'static str,
+    execution_result: &'a ExecutionResult,
     safe_to_rerun: bool,
     registry: String,
     plan_id: &'a str,
@@ -2757,6 +2796,7 @@ struct PublishJsonReport<'a> {
 struct ResumeJsonReport<'a> {
     schema_version: &'static str,
     command: &'static str,
+    execution_result: &'a ExecutionResult,
     safe_to_resume: bool,
     registry: String,
     plan_id: &'a str,
@@ -2871,6 +2911,7 @@ fn build_publish_json_report<'a>(
     Ok(PublishJsonReport {
         schema_version: "shipper.publish.v1",
         command: "publish",
+        execution_result: &receipt.execution_result,
         safe_to_rerun,
         registry: receipt.registry.name.clone(),
         plan_id: &receipt.plan_id,
@@ -2899,6 +2940,7 @@ fn build_resume_json_report<'a>(
     Ok(ResumeJsonReport {
         schema_version: "shipper.resume.v1",
         command: "resume",
+        execution_result: &receipt.execution_result,
         safe_to_resume,
         registry: receipt.registry.name.clone(),
         plan_id: &receipt.plan_id,
@@ -4407,6 +4449,27 @@ mod tests {
     fn parse_duration_handles_valid_and_invalid_inputs() {
         assert!(parse_duration("1s").is_ok());
         assert!(parse_duration("nope").is_err());
+    }
+
+    #[test]
+    fn exit_code_for_result_maps_correctly() {
+        use std::process::ExitCode;
+
+        // Success → 0
+        assert_eq!(
+            ExitCode::SUCCESS,
+            exit_code_for_result(&ExecutionResult::Success)
+        );
+        // PartialFailure → 2 (CI gate: resume recommended)
+        assert_eq!(
+            ExitCode::from(2),
+            exit_code_for_result(&ExecutionResult::PartialFailure)
+        );
+        // CompleteFailure → 1 (hard failure)
+        assert_eq!(
+            ExitCode::FAILURE,
+            exit_code_for_result(&ExecutionResult::CompleteFailure)
+        );
     }
 
     #[test]

--- a/crates/shipper-cli/src/main.rs
+++ b/crates/shipper-cli/src/main.rs
@@ -9,6 +9,12 @@
 //!    wired into their pipelines on the old name.
 //! 2. Local workspace development: `cargo run -p shipper-cli -- <args>`
 //!    is still a reasonable way to exercise the CLI without installing.
-fn main() -> anyhow::Result<()> {
-    shipper_cli::run()
+fn main() -> std::process::ExitCode {
+    match shipper_cli::run() {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("{e:#}");
+            std::process::ExitCode::FAILURE
+        }
+    }
 }

--- a/crates/shipper-core/src/engine/fix_forward.rs
+++ b/crates/shipper-core/src/engine/fix_forward.rs
@@ -3,10 +3,10 @@
 //! When a published release turns out to be compromised (CVE, leaked
 //! secret, broken artifact), the remediation options are:
 //!
-//! 1. **Yank** — containment. Prevents NEW resolves but leaves
+//! 1. **Yank** â€” containment. Prevents NEW resolves but leaves
 //!    existing lockfiles unchanged. Covered by `shipper yank` (PR 1)
 //!    and `shipper plan-yank` (PR 2).
-//! 2. **Fix-forward** — ship a successor release that replaces the
+//! 2. **Fix-forward** â€” ship a successor release that replaces the
 //!    compromised one. Downstream consumers pick it up on
 //!    `cargo update`. **This module plans that.**
 //!
@@ -27,18 +27,18 @@
 //! ## What this module does NOT do (yet)
 //!
 //! - **Edit Cargo.toml files** to bump versions. That's workspace-edit
-//!   territory — invasive enough to deserve its own PR with dry-run /
+//!   territory â€” invasive enough to deserve its own PR with dry-run /
 //!   --apply / git-guard semantics.
 //! - **Run the bumped publish**. Once the operator has bumped versions
 //!   and committed them, `shipper publish` handles the actual train
 //!   exactly as for any release. Fix-forward's job is the planning
 //!   layer, not the execution.
-//! - **Chain successor → receipt** via the `superseded_by` field.
+//! - **Chain successor â†’ receipt** via the `superseded_by` field.
 //!   Wiring that requires post-publish receipt amendment from the
 //!   successor run; another follow-on.
 //!
 //! Keeping the first PR to *planning only* matches the scope pattern
-//! of `plan-yank` (PR 2) — give operators a text blueprint, let them
+//! of `plan-yank` (PR 2) â€” give operators a text blueprint, let them
 //! apply it, leave execution orchestration for a later pass once the
 //! shape is validated in the field.
 
@@ -94,7 +94,7 @@ fn suggest_next(current: &str, strategy: SuccessorStrategy) -> String {
 
 /// Build a fix-forward plan from a receipt.
 ///
-/// Topological order — same direction as `publish`, **opposite** of
+/// Topological order â€” same direction as `publish`, **opposite** of
 /// `plan-yank`. Rationale: for fix-forward you're *publishing*
 /// replacements, so dependencies go first (downstream fixes can pull
 /// updated deps); for yank you're *removing* reachability, so
@@ -126,7 +126,7 @@ pub fn build_plan(receipt: &Receipt, strategy: SuccessorStrategy) -> FixForwardP
 pub fn render_text(plan: &FixForwardPlan) -> String {
     let mut out = String::new();
     out.push_str(&format!(
-        "# fix-forward plan — registry={}, plan_id={}\n",
+        "# fix-forward plan â€” registry={}, plan_id={}\n",
         plan.registry, plan.plan_id
     ));
     out.push_str(&format!(
@@ -225,6 +225,7 @@ mod tests {
                 arch: "x86_64".into(),
             },
             auth_evidence: None,
+            execution_result: crate::types::ExecutionResult::Success,
         }
     }
 

--- a/crates/shipper-core/src/engine/mod.rs
+++ b/crates/shipper-core/src/engine/mod.rs
@@ -54,7 +54,7 @@ pub trait Reporter {
     /// implementation preserves the pre-#103 behavior (a single `warn()` line
     /// then `thread::sleep(delay)`); richer UIs (e.g., the CLI) override it to
     /// render a live countdown during the wait window. Overrides MUST block
-    /// for the full `delay` before returning — the engine relies on this
+    /// for the full `delay` before returning â€” the engine relies on this
     /// method to own the retry sleep. See #103 and #91.
     #[allow(clippy::too_many_arguments)]
     fn retry_wait(
@@ -1141,7 +1141,7 @@ pub fn run_rehearsal(
     let started_at = Utc::now();
 
     reporter.info(&format!(
-        "rehearsal starting — {} packages against '{}'",
+        "rehearsal starting â€” {} packages against '{}'",
         ws.plan.packages.len(),
         rehearsal_name
     ));
@@ -1165,7 +1165,7 @@ pub fn run_rehearsal(
 
     for p in &ws.plan.packages {
         let pkg_label = format!("{}@{}", p.name, p.version);
-        reporter.info(&format!("rehearsing {pkg_label} → {rehearsal_name}"));
+        reporter.info(&format!("rehearsing {pkg_label} â†’ {rehearsal_name}"));
         let start = Instant::now();
 
         let out = cargo::cargo_publish(
@@ -1201,7 +1201,7 @@ pub fn run_rehearsal(
         }
 
         // Post-publish visibility check on the rehearsal registry. Reuse
-        // `version_exists` — same mechanism live publish trusts.
+        // `version_exists` â€” same mechanism live publish trusts.
         if !rehearsal_client.version_exists(&p.name, &p.version)? {
             let msg = format!(
                 "rehearsal: cargo publish succeeded but {pkg_label} is not visible on '{rehearsal_name}'"
@@ -1238,7 +1238,7 @@ pub fn run_rehearsal(
         packages_published += 1;
     }
 
-    // #97 PR 4 — smoke-install. Opt-in. Runs only if:
+    // #97 PR 4 â€” smoke-install. Opt-in. Runs only if:
     //   (a) all packages in the plan were published successfully AND
     //   (b) the operator named a crate via --smoke-install / config.
     // The named crate must be in the plan; resolves its planned version
@@ -1318,7 +1318,7 @@ pub fn run_rehearsal(
             }
             None => {
                 // Operator named a crate that isn't in the plan. Warn,
-                // don't fail — their intent is clear but the workspace
+                // don't fail â€” their intent is clear but the workspace
                 // shape disagrees, and failing the whole rehearsal over
                 // a typo would be overkill.
                 reporter.warn(&format!(
@@ -1361,7 +1361,7 @@ pub fn run_rehearsal(
     event_log.write_to_file(&events_path)?;
 
     // Persist the sidecar receipt so the hard gate in `run_publish`
-    // can consult it without parsing events.jsonl. Best-effort — a
+    // can consult it without parsing events.jsonl. Best-effort â€” a
     // write failure here doesn't invalidate the events log, which is
     // the authoritative source; the gate will just act as if no
     // rehearsal happened and block, which is the safe default.
@@ -1382,7 +1382,7 @@ pub fn run_rehearsal(
     ) {
         reporter.warn(&format!(
             "rehearsal outcome event was written, but sidecar receipt could not be persisted: {err:#}. \
-             The hard gate may not recognize this rehearsal — check {}.",
+             The hard gate may not recognize this rehearsal â€” check {}.",
             crate::state::rehearsal::rehearsal_path(&state_dir).display()
         ));
     }
@@ -2384,7 +2384,7 @@ mod tests {
         });
     }
 
-    // #100 — fresh-audit mode must not read or append the authoritative
+    // #100 â€” fresh-audit mode must not read or append the authoritative
     // `events.jsonl`. We seed a pre-existing `events.jsonl` with a bogus
     // event that would fail deserialization, run preflight in
     // `fresh_audit` mode, and assert: (a) the authoritative log is
@@ -2425,7 +2425,7 @@ mod tests {
             let sentinel = "{\"sentinel\":\"do not touch\"}\n";
             std::fs::write(&authoritative_events, sentinel).expect("seed events");
 
-            // Seed a state.json too — fresh-audit must not produce or
+            // Seed a state.json too â€” fresh-audit must not produce or
             // overwrite a publish state file as a side-effect.
             let state_json = td.path().join(".shipper").join("state.json");
             std::fs::write(&state_json, "{\"sentinel\":\"state\"}").expect("seed state");
@@ -2482,11 +2482,11 @@ mod tests {
         });
     }
 
-    // #100 — fresh-audit reflects *current* workspace state, not a
+    // #100 â€” fresh-audit reflects *current* workspace state, not a
     // cached prior result. We run preflight twice in fresh_audit mode:
     // first against a registry that treats the crate as new (NotProven),
     // then against the same workspace but with a server that returns
-    // 200 + owners — ownership verified, so Proven. If fresh_audit were
+    // 200 + owners â€” ownership verified, so Proven. If fresh_audit were
     // cached/reused, the second run would incorrectly still report
     // NotProven; it must reflect the changed registry reality.
     //
@@ -2509,7 +2509,7 @@ mod tests {
             ("CARGO_REGISTRY_TOKEN", Some("token-abc".to_string())),
         ]);
         temp_env::with_vars(env_vars, || {
-            // Run 1: new crate (404 on crate lookup) → NotProven (no
+            // Run 1: new crate (404 on crate lookup) â†’ NotProven (no
             // ownership possible for new crates when strict=false and
             // token present).
             let server1 = spawn_registry_server(
@@ -2553,7 +2553,7 @@ mod tests {
                 authoritative_events.display()
             );
 
-            // Run 2: established crate with confirmed owners → Proven.
+            // Run 2: established crate with confirmed owners â†’ Proven.
             // Same workspace, different registry reality. Fresh audit
             // must pick up the new state, not cache the previous run.
             let server2 = spawn_registry_server(
@@ -2891,7 +2891,7 @@ mod tests {
             let state_dir = td.path().join(".shipper");
 
             // Seed: existing state says demo@0.1.0 is Published. Resume
-            // should recognize it and skip — but crucially, emit the event.
+            // should recognize it and skip â€” but crucially, emit the event.
             let mut packages = BTreeMap::new();
             packages.insert(
                 "demo@0.1.0".to_string(),
@@ -2947,7 +2947,7 @@ mod tests {
         write_fake_tools(&bin);
         let env_vars = fake_program_env_vars(&bin);
         temp_env::with_vars(env_vars, || {
-            // Registry returns 200 for the version check — the crate IS
+            // Registry returns 200 for the version check â€” the crate IS
             // visible, even though run 1 left us with Failed/Ambiguous.
             let server = spawn_registry_server(
                 std::collections::BTreeMap::from([(
@@ -4161,7 +4161,7 @@ mod tests {
         let td = tempdir().expect("tempdir");
         let bin = td.path().join("bin");
         write_fake_tools(&bin);
-        // Deliberately set cargo to fail — if dry-run runs, it would fail
+        // Deliberately set cargo to fail â€” if dry-run runs, it would fail
         with_test_env(
             &bin,
             vec![("SHIPPER_CARGO_EXIT", Some("1".to_string()))],
@@ -4302,7 +4302,7 @@ mod tests {
         let td = tempdir().expect("tempdir");
         let bin = td.path().join("bin");
         write_fake_tools(&bin);
-        // Set cargo to fail — if dry-run ran, it would fail
+        // Set cargo to fail â€” if dry-run ran, it would fail
         with_test_env(
             &bin,
             vec![("SHIPPER_CARGO_EXIT", Some("1".to_string()))],
@@ -4446,7 +4446,7 @@ mod tests {
             );
 
             // Cargo publish should NOT have been invoked
-            // (args_log should not exist or be empty — no cargo publish calls)
+            // (args_log should not exist or be empty â€” no cargo publish calls)
             let cargo_invoked = args_log.exists()
                 && fs::read_to_string(&args_log)
                     .unwrap_or_default()
@@ -4549,7 +4549,7 @@ mod tests {
         });
     }
 
-    // ── Additional coverage tests ──────────────────────────────────────
+    // â”€â”€ Additional coverage tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn init_state_creates_pending_entries_for_all_packages() {
@@ -5586,6 +5586,7 @@ mod tests {
             git_context: None,
             environment: environment::collect_environment_fingerprint(),
             auth_evidence: None,
+            execution_result: crate::types::ExecutionResult::Success,
         };
 
         let json = serde_json::to_string_pretty(&receipt).expect("serialize");
@@ -5766,7 +5767,7 @@ mod tests {
         assert!(effects.run_dry_run);
     }
 
-    // ── Retry logic edge-case tests ────────────────────────────────────
+    // â”€â”€ Retry logic edge-case tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     #[serial]
@@ -5779,7 +5780,7 @@ mod tests {
             vec![("SHIPPER_CARGO_EXIT", Some("0".to_string()))],
             || {
                 // Registry says version doesn't exist, so engine enters the publish loop
-                // with max_attempts=0 → loop body never executes → package stays Pending
+                // with max_attempts=0 â†’ loop body never executes â†’ package stays Pending
                 let server = spawn_registry_server(
                     std::collections::BTreeMap::from([(
                         "/api/v1/crates/demo/0.1.0".to_string(),
@@ -5897,7 +5898,7 @@ mod tests {
         );
     }
 
-    // ── State persistence: Uploaded vs Published transitions ──────────
+    // â”€â”€ State persistence: Uploaded vs Published transitions â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn state_transition_pending_to_uploaded_persists() {
@@ -5995,7 +5996,7 @@ mod tests {
         assert!(pkg.last_updated_at >= initial_updated);
     }
 
-    // ── Error classification tests ─────────────────────────────────────
+    // â”€â”€ Error classification tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn classify_cargo_failure_connection_refused_is_retryable() {
@@ -6040,7 +6041,7 @@ mod tests {
         );
     }
 
-    // ── State machine transition tests ────────────────────────────────
+    // â”€â”€ State machine transition tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     /// Helper: build a multi-package workspace for state machine tests.
     fn multi_package_workspace(
@@ -6074,7 +6075,7 @@ mod tests {
         }
     }
 
-    // 1. Pending → Published (happy path, single crate)
+    // 1. Pending â†’ Published (happy path, single crate)
     #[test]
     #[serial]
     fn sm_pending_to_published_happy_path() {
@@ -6113,7 +6114,7 @@ mod tests {
         );
     }
 
-    // 2. Pending → Uploaded → Verified (two-phase with readiness check)
+    // 2. Pending â†’ Uploaded â†’ Verified (two-phase with readiness check)
     #[test]
     #[serial]
     fn sm_pending_uploaded_verified_two_phase() {
@@ -6152,7 +6153,7 @@ mod tests {
         );
     }
 
-    // 3. Pending → Failed (permanent error, no retry)
+    // 3. Pending â†’ Failed (permanent error, no retry)
     #[test]
     #[serial]
     fn sm_pending_to_failed_permanent_no_retry() {
@@ -6204,7 +6205,7 @@ mod tests {
         );
     }
 
-    // 4. Pending → Uploaded → Failed (upload ok, verify failed)
+    // 4. Pending â†’ Uploaded â†’ Failed (upload ok, verify failed)
     #[test]
     #[serial]
     fn sm_uploaded_then_verify_failed() {
@@ -6246,7 +6247,7 @@ mod tests {
         );
     }
 
-    // 5. Multiple packages: first succeeds, second fails → partial progress saved
+    // 5. Multiple packages: first succeeds, second fails â†’ partial progress saved
     #[test]
     #[serial]
     fn sm_multi_package_partial_progress() {
@@ -6310,7 +6311,7 @@ mod tests {
         );
     }
 
-    // 6. Resume from partial state — only remaining packages are attempted
+    // 6. Resume from partial state â€” only remaining packages are attempted
     #[test]
     #[serial]
     fn sm_resume_from_partial_state() {
@@ -6406,7 +6407,7 @@ mod tests {
         );
     }
 
-    // 7. Plan ID mismatch on resume — verify rejection
+    // 7. Plan ID mismatch on resume â€” verify rejection
     #[test]
     fn sm_plan_id_mismatch_rejected() {
         let td = tempdir().expect("tempdir");
@@ -6446,7 +6447,7 @@ mod tests {
         assert!(msg.contains("does not match current plan_id"), "got: {msg}");
     }
 
-    // 8. Empty package list — verify graceful handling
+    // 8. Empty package list â€” verify graceful handling
     #[test]
     fn sm_empty_package_list_graceful() {
         let td = tempdir().expect("tempdir");
@@ -6509,7 +6510,7 @@ mod tests {
         );
     }
 
-    // 10. Max retries exceeded — verify proper error with attempt count
+    // 10. Max retries exceeded â€” verify proper error with attempt count
     #[test]
     #[serial]
     fn sm_max_retries_exceeded_attempt_count() {
@@ -6575,7 +6576,7 @@ mod tests {
         );
     }
 
-    // 11. Timeout during publish — verify state preservation
+    // 11. Timeout during publish â€” verify state preservation
     #[test]
     #[serial]
     fn sm_timeout_preserves_state() {
@@ -6626,7 +6627,7 @@ mod tests {
         );
     }
 
-    // 12. Concurrent package independence — parallel packages don't affect each other
+    // 12. Concurrent package independence â€” parallel packages don't affect each other
     //     (sequential mode: verify each package state is independent)
     #[test]
     #[serial]
@@ -6849,11 +6850,11 @@ mod tests {
             crate::state::execution_state::CURRENT_STATE_VERSION
         );
 
-        // Transition alpha: Pending → Uploaded → Published
+        // Transition alpha: Pending â†’ Uploaded â†’ Published
         update_state(&mut st, &state_dir, "alpha@1.0.0", PackageState::Uploaded).expect("update");
         update_state(&mut st, &state_dir, "alpha@1.0.0", PackageState::Published).expect("update");
 
-        // Transition beta: Pending → Failed
+        // Transition beta: Pending â†’ Failed
         update_state(
             &mut st,
             &state_dir,
@@ -7016,7 +7017,7 @@ mod tests {
         );
     }
 
-    // ── Snapshot tests with insta for engine state ─────────────────────
+    // â”€â”€ Snapshot tests with insta for engine state â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn snapshot_init_state_single_package() {
@@ -7167,7 +7168,7 @@ mod tests {
         insta::assert_debug_snapshot!("error_classification_matrix", snapshot);
     }
 
-    // ── Proptest: state transition invariants ──────────────────────────
+    // â”€â”€ Proptest: state transition invariants â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     mod engine_proptests {
         use super::*;
@@ -7306,9 +7307,9 @@ mod tests {
         }
     }
 
-    // ───────────────────────────────────────────────────────────────────
-    // run_rehearsal (#97 PR 2) — phase-2 preflight against an alt registry
-    // ───────────────────────────────────────────────────────────────────
+    // â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+    // run_rehearsal (#97 PR 2) â€” phase-2 preflight against an alt registry
+    // â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     fn read_events_raw(state_dir: &Path) -> Vec<serde_json::Value> {
         let path = events::events_path(state_dir);
@@ -7384,7 +7385,7 @@ mod tests {
             let ws = planned_workspace(td.path(), "http://127.0.0.1:1".into());
             let mut opts = default_opts(PathBuf::from(".shipper"));
             opts.rehearsal_registry = Some("bogus-registry".to_string());
-            // opts.registries is empty — bogus-registry won't resolve.
+            // opts.registries is empty â€” bogus-registry won't resolve.
 
             let mut reporter = CollectingReporter::default();
             let err = run_rehearsal(&ws, &opts, &mut reporter).expect_err("must fail");
@@ -7412,7 +7413,7 @@ mod tests {
             assert!(!outcome.passed, "skip should not claim a pass");
             assert_eq!(outcome.packages_published, 0);
             assert!(outcome.summary.contains("skipped"));
-            // Skip path must not write events — nothing to audit.
+            // Skip path must not write events â€” nothing to audit.
             let events_path = events::events_path(&td.path().join(".shipper"));
             assert!(
                 !events_path.exists(),
@@ -7483,9 +7484,9 @@ mod tests {
         });
     }
 
-    // ───────────────────────────────────────────────────────────────────
+    // â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
     // enforce_rehearsal_gate (#97 PR 3)
-    // ───────────────────────────────────────────────────────────────────
+    // â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     fn write_rehearsal_receipt(
         state_dir: &Path,
@@ -7612,7 +7613,7 @@ mod tests {
     }
 
     /// End-to-end: `run_publish` refuses to run when rehearsal is required
-    /// but no receipt exists. This is the gate's actual contract — the
+    /// but no receipt exists. This is the gate's actual contract â€” the
     /// finer-grained tests above exercise the gate helper in isolation;
     /// this one confirms run_publish wires it in correctly.
     #[test]
@@ -7638,7 +7639,7 @@ mod tests {
         });
     }
 
-    /// #97 PR 4 — smoke-install happy path. --smoke-install names a
+    /// #97 PR 4 â€” smoke-install happy path. --smoke-install names a
     /// crate in the plan; fake cargo returns 0 for the install call;
     /// rehearsal emits smoke-check events and passes.
     #[test]
@@ -7685,7 +7686,7 @@ mod tests {
         });
     }
 
-    /// #97 PR 4 — smoke-install named a crate not in the plan. Warn-only
+    /// #97 PR 4 â€” smoke-install named a crate not in the plan. Warn-only
     /// path: rehearsal itself still passes (publish was fine) but the
     /// reporter surfaces the misconfiguration so the operator can fix it.
     #[test]

--- a/crates/shipper-core/src/engine/plan_yank.rs
+++ b/crates/shipper-core/src/engine/plan_yank.rs
@@ -3,12 +3,12 @@
 //! Given a receipt.json from a prior publish run, produce an ordered list of
 //! `<crate>@<version>` entries describing the yank order for containment:
 //! dependents first, dependencies last. This is the opposite of publish
-//! order — we want downstream consumers of the bad version to stop being
+//! order â€” we want downstream consumers of the bad version to stop being
 //! resolvable against it *before* we yank the bad version itself.
 //!
 //! ## Example
 //!
-//! For a workspace A → B → C (A is a leaf, B depends on A, C depends on B):
+//! For a workspace A â†’ B â†’ C (A is a leaf, B depends on A, C depends on B):
 //!
 //! - Publish order (receipt.packages): `[A, B, C]`
 //! - Yank order (reverse topological): `[C, B, A]`
@@ -23,13 +23,13 @@
 //! - Provide both a structured `YankPlan` API and a text renderer
 //!
 //! **Does not (yet):**
-//! - Execute the plan — that's `shipper yank` (already landed) running
+//! - Execute the plan â€” that's `shipper yank` (already landed) running
 //!   one entry at a time. Plan execution wrapping is #98 PR 3.
-//! - Mark a package compromised — that's `--mark-compromised`, landing
+//! - Mark a package compromised â€” that's `--mark-compromised`, landing
 //!   in #98 PR 3 alongside fix-forward.
 //!
 //! Keeping this PR to **planning only** matches the staged rollout agreed
-//! in the #98 scope: primitive → plan → execute / fix-forward.
+//! in the #98 scope: primitive â†’ plan â†’ execute / fix-forward.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -94,7 +94,7 @@ fn include(receipt: &PackageReceipt, filter: PlanYankFilter) -> bool {
 ///
 /// The receipt's `packages` vector is in publish (topological) order, so
 /// we filter then reverse. Failing and skipped packages are excluded by
-/// default — yanking a version that was never published is a no-op on
+/// default â€” yanking a version that was never published is a no-op on
 /// the registry and would just produce noise.
 pub fn build_plan(receipt: &Receipt, filter: PlanYankFilter) -> YankPlan {
     let mut entries: Vec<YankEntry> = receipt
@@ -128,10 +128,10 @@ pub fn build_plan(receipt: &Receipt, filter: PlanYankFilter) -> YankPlan {
 /// This is the **graph mode** complement to `build_plan`'s receipt-filter
 /// modes. Use when you know exactly which crate is broken (e.g. CVE
 /// targeting `my-lib`) and want containment of only the affected
-/// dependency chain — not a full-release rollback.
+/// dependency chain â€” not a full-release rollback.
 ///
 /// `dependency_graph` is `plan.dependencies` from the original
-/// `ReleasePlan` (crate → list of its intra-workspace deps). Not
+/// `ReleasePlan` (crate â†’ list of its intra-workspace deps). Not
 /// embedded in `Receipt` because receipts are summaries, not graphs.
 ///
 /// Errors if `starting_crate` is not in the receipt.
@@ -224,7 +224,7 @@ pub fn load_receipt_from_path(path: &std::path::Path) -> Result<Receipt> {
 pub fn render_text(plan: &YankPlan) -> String {
     let mut out = String::new();
     out.push_str(&format!(
-        "# yank plan (reverse topological) — registry={}, plan_id={}, filter={}\n",
+        "# yank plan (reverse topological) â€” registry={}, plan_id={}, filter={}\n",
         plan.registry, plan.plan_id, plan.filter
     ));
     out.push_str(&format!("# {} entries\n", plan.entries.len()));
@@ -294,6 +294,7 @@ mod tests {
                 arch: "x86_64".into(),
             },
             auth_evidence: None,
+            execution_result: crate::types::ExecutionResult::Success,
         }
     }
 
@@ -372,9 +373,9 @@ mod tests {
         assert!(out.starts_with("# yank plan"));
     }
 
-    // ── build_plan_from_starting_crate tests (#98 PR 4) ─────────────────
+    // â”€â”€ build_plan_from_starting_crate tests (#98 PR 4) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
-    /// Graph: a (leaf) ← b ← c. Dep map says: b depends on a, c depends
+    /// Graph: a (leaf) â† b â† c. Dep map says: b depends on a, c depends
     /// on b and a. Starting from "a" (the leaf), all three should be in
     /// the plan, with c yanked first, then b, then a.
     #[test]
@@ -395,7 +396,7 @@ mod tests {
         assert_eq!(plan.filter, "starting_crate");
     }
 
-    /// Graph: a ← b (b depends on a), plus an unrelated crate z. Starting
+    /// Graph: a â† b (b depends on a), plus an unrelated crate z. Starting
     /// from "a" should yank a and b but NOT z (no dependency edge).
     #[test]
     fn starting_crate_ignores_unrelated_crates() {
@@ -432,8 +433,8 @@ mod tests {
         deps.insert("b".to_string(), vec!["a".to_string()]);
 
         let plan = build_plan_from_starting_crate(&r, &deps, "a", None).expect("plan");
-        // b is a dependent of a but it Failed to publish — never on
-        // registry — so it's excluded from the yank plan. Only a remains.
+        // b is a dependent of a but it Failed to publish â€” never on
+        // registry â€” so it's excluded from the yank plan. Only a remains.
         let names: Vec<_> = plan.entries.iter().map(|e| e.name.clone()).collect();
         assert_eq!(names, vec!["a"]);
     }
@@ -466,7 +467,7 @@ mod tests {
         assert!(msg.contains("not in this receipt"), "err: {msg}");
     }
 
-    // ── load_plan_from_path (#98 PR 5) roundtrip ──────────────────────────
+    // â”€â”€ load_plan_from_path (#98 PR 5) roundtrip â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     #[test]
     fn yank_plan_json_roundtrips_via_load_plan_from_path() {

--- a/crates/shipper-core/src/engine/publish/finalize.rs
+++ b/crates/shipper-core/src/engine/publish/finalize.rs
@@ -69,6 +69,7 @@ pub(in crate::engine) fn finish_sequential_run(
         environment,
         auth_evidence,
         events_path,
+        exec_result,
     )
 }
 
@@ -108,6 +109,7 @@ pub(in crate::engine) fn finish_parallel_run(
         environment,
         auth_evidence,
         events_path,
+        exec_result,
     )
 }
 
@@ -122,6 +124,7 @@ fn write_receipt(
     environment: EnvironmentFingerprint,
     auth_evidence: AuthEvidence,
     events_path: &Path,
+    execution_result: ExecutionResult,
 ) -> Result<Receipt> {
     let receipt = Receipt {
         receipt_version: "shipper.receipt.v2".to_string(),
@@ -134,6 +137,7 @@ fn write_receipt(
         git_context,
         environment,
         auth_evidence: Some(auth_evidence),
+        execution_result,
     };
 
     let reconciliation_report = crate::state::reconciliation::write_report_from_events(

--- a/crates/shipper-core/src/engine/remediation.rs
+++ b/crates/shipper-core/src/engine/remediation.rs
@@ -338,6 +338,7 @@ mod tests {
                 arch: "test".to_string(),
             },
             auth_evidence: None,
+            execution_result: crate::types::ExecutionResult::Success,
         }
     }
 

--- a/crates/shipper-core/src/state/consistency.rs
+++ b/crates/shipper-core/src/state/consistency.rs
@@ -433,6 +433,7 @@ mod tests {
                 arch: "test".to_string(),
             },
             auth_evidence: None,
+            execution_result: crate::types::ExecutionResult::Success,
         }
     }
 
@@ -523,7 +524,7 @@ mod tests {
 
     #[test]
     fn detects_in_events_only() {
-        // events says published, state says pending → resume would duplicate
+        // events says published, state says pending â†’ resume would duplicate
         let td = tempdir().expect("tempdir");
         write_events(td.path(), vec![published_event("a", "1.0.0")]);
 
@@ -538,7 +539,7 @@ mod tests {
 
     #[test]
     fn detects_in_state_only() {
-        // state says published but no event recorded it → event log bypassed
+        // state says published but no event recorded it â†’ event log bypassed
         let td = tempdir().expect("tempdir");
         write_events(td.path(), vec![]);
 
@@ -691,7 +692,7 @@ mod tests {
     #[test]
     fn empty_state_and_empty_events_are_consistent() {
         let td = tempdir().expect("tempdir");
-        // No events file written at all — read_from_file treats missing as empty.
+        // No events file written at all â€” read_from_file treats missing as empty.
         let state = make_state(vec![]);
 
         let drift = verify_events_state_consistency(&td.path().join(EVENTS_FILE), &state)

--- a/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__receipt_all_failed.snap
+++ b/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__receipt_all_failed.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-state/src/lib.rs
+source: crates/shipper-core/src/state/execution_state/tests.rs
 expression: json
 ---
 {
@@ -56,5 +56,6 @@ expression: json
     "rust_version": "1.82.0",
     "os": "linux",
     "arch": "x86_64"
-  }
+  },
+  "execution_result": "success"
 }

--- a/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__receipt_json_format.snap
+++ b/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__receipt_json_format.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-state/src/lib.rs
+source: crates/shipper-core/src/state/execution_state/tests.rs
 expression: json
 ---
 {
@@ -54,5 +54,6 @@ expression: json
     "rust_version": "1.82.0",
     "os": "linux",
     "arch": "x86_64"
-  }
+  },
+  "execution_result": "success"
 }

--- a/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__receipt_with_evidence.snap
+++ b/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__receipt_with_evidence.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/shipper-state/src/lib.rs
-assertion_line: 2475
+source: crates/shipper-core/src/state/execution_state/tests.rs
 expression: json
 ---
 {
@@ -64,5 +63,6 @@ expression: json
     "rust_version": "1.82.0",
     "os": "linux",
     "arch": "x86_64"
-  }
+  },
+  "execution_result": "success"
 }

--- a/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__receipt_with_git_context.snap
+++ b/crates/shipper-core/src/state/execution_state/snapshots/shipper_core__state__execution_state__tests__receipt_with_git_context.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/shipper-state/src/lib.rs
-assertion_line: 2412
+source: crates/shipper-core/src/state/execution_state/tests.rs
 expression: json
 ---
 {
@@ -43,5 +42,6 @@ expression: json
     "rust_version": "1.82.0",
     "os": "linux",
     "arch": "x86_64"
-  }
+  },
+  "execution_result": "success"
 }

--- a/crates/shipper-core/src/state/execution_state/tests.rs
+++ b/crates/shipper-core/src/state/execution_state/tests.rs
@@ -70,6 +70,7 @@ fn sample_receipt() -> Receipt {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: crate::types::ExecutionResult::Success,
     }
 }
 
@@ -527,7 +528,7 @@ fn clear_state_does_not_remove_receipt_file() {
     assert!(receipt_path(&dir).exists());
 }
 
-// ── Persistence double-roundtrip ────────────────────────────────
+// â”€â”€ Persistence double-roundtrip â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn state_double_save_produces_identical_json() {
@@ -542,7 +543,10 @@ fn state_double_save_produces_identical_json() {
 
     let json1 = fs::read_to_string(state_path(&dir1)).expect("read first");
     let json2 = fs::read_to_string(state_path(&dir2)).expect("read second");
-    assert_eq!(json1, json2, "save→load→save must produce identical JSON");
+    assert_eq!(
+        json1, json2,
+        "saveâ†’loadâ†’save must produce identical JSON"
+    );
 }
 
 #[test]
@@ -595,10 +599,13 @@ fn receipt_double_save_produces_identical_json() {
 
     let json1 = fs::read_to_string(receipt_path(&dir1)).expect("read first");
     let json2 = fs::read_to_string(receipt_path(&dir2)).expect("read second");
-    assert_eq!(json1, json2, "write→load→write must produce identical JSON");
+    assert_eq!(
+        json1, json2,
+        "writeâ†’loadâ†’write must produce identical JSON"
+    );
 }
 
-// ── State lifecycle transitions ─────────────────────────────────
+// â”€â”€ State lifecycle transitions â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn state_lifecycle_pending_uploaded_published() {
@@ -635,7 +642,7 @@ fn state_lifecycle_pending_uploaded_published() {
         PackageState::Pending
     ));
 
-    // Pending → Uploaded
+    // Pending â†’ Uploaded
     state.packages.get_mut("crate-a@1.0.0").unwrap().state = PackageState::Uploaded;
     state.packages.get_mut("crate-a@1.0.0").unwrap().attempts = 1;
     save_state(&dir, &state).expect("save uploaded");
@@ -645,7 +652,7 @@ fn state_lifecycle_pending_uploaded_published() {
         PackageState::Uploaded
     ));
 
-    // Uploaded → Published
+    // Uploaded â†’ Published
     state.packages.get_mut("crate-a@1.0.0").unwrap().state = PackageState::Published;
     save_state(&dir, &state).expect("save published");
     let loaded = load_state(&dir).expect("load").expect("exists");
@@ -717,7 +724,7 @@ fn state_all_error_classes_persist() {
     }
 }
 
-// ── Edge cases ──────────────────────────────────────────────────
+// â”€â”€ Edge cases â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn state_empty_packages_roundtrip() {
@@ -840,7 +847,7 @@ fn state_with_special_chars_in_plan_id() {
         "plan with spaces",
         "plan/with/slashes",
         "plan\"with\"quotes",
-        "план-юникод",
+        "Ð¿Ð»Ð°Ð½-ÑŽÐ½Ð¸ÐºÐ¾Ð´",
         "\u{1f680}release-v1",
     ];
 
@@ -914,7 +921,7 @@ fn receipt_with_high_attempt_count() {
     assert_eq!(loaded.packages[0].duration_ms, 999_999);
 }
 
-// ── Insta snapshot helpers ──────────────────────────────────────
+// â”€â”€ Insta snapshot helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 use chrono::TimeZone;
 
@@ -1013,10 +1020,11 @@ fn deterministic_receipt() -> Receipt {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: crate::types::ExecutionResult::Success,
     }
 }
 
-// ── Snapshot: state JSON format ─────────────────────────────────
+// â”€â”€ Snapshot: state JSON format â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn snapshot_state_json_format() {
@@ -1025,7 +1033,7 @@ fn snapshot_state_json_format() {
     insta::assert_snapshot!("state_json_format", json);
 }
 
-// ── Snapshot: receipt JSON format ────────────────────────────────
+// â”€â”€ Snapshot: receipt JSON format â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn snapshot_receipt_json_format() {
@@ -1034,14 +1042,14 @@ fn snapshot_receipt_json_format() {
     insta::assert_snapshot!("receipt_json_format", json);
 }
 
-// ── Snapshot: state transitions ─────────────────────────────────
+// â”€â”€ Snapshot: state transitions â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn snapshot_state_transition_pending_to_published() {
     let fixed = Utc.with_ymd_and_hms(2025, 1, 15, 12, 0, 0).unwrap();
     let mut state = deterministic_state();
 
-    // Transition alpha from Pending → Published
+    // Transition alpha from Pending â†’ Published
     if let Some(pkg) = state.packages.get_mut("alpha@0.1.0") {
         pkg.state = PackageState::Published;
         pkg.attempts = 1;
@@ -1058,7 +1066,7 @@ fn snapshot_state_transition_pending_to_failed() {
     let fixed = Utc.with_ymd_and_hms(2025, 1, 15, 12, 0, 0).unwrap();
     let mut state = deterministic_state();
 
-    // Transition alpha from Pending → Failed
+    // Transition alpha from Pending â†’ Failed
     if let Some(pkg) = state.packages.get_mut("alpha@0.1.0") {
         pkg.state = PackageState::Failed {
             class: shipper_types::ErrorClass::Permanent,
@@ -1078,7 +1086,7 @@ fn snapshot_state_transition_pending_to_skipped() {
     let fixed = Utc.with_ymd_and_hms(2025, 1, 15, 12, 0, 0).unwrap();
     let mut state = deterministic_state();
 
-    // Transition alpha from Pending → Skipped
+    // Transition alpha from Pending â†’ Skipped
     if let Some(pkg) = state.packages.get_mut("alpha@0.1.0") {
         pkg.state = PackageState::Skipped {
             reason: "already published".to_string(),
@@ -1092,7 +1100,7 @@ fn snapshot_state_transition_pending_to_skipped() {
     insta::assert_snapshot!("state_transition_pending_to_skipped", json);
 }
 
-// ── Snapshot: state with all PackageState variants ─────────────
+// â”€â”€ Snapshot: state with all PackageState variants â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn snapshot_state_all_lifecycle_variants() {
@@ -1180,7 +1188,7 @@ fn snapshot_state_all_lifecycle_variants() {
     insta::assert_snapshot!("state_all_lifecycle_variants", json);
 }
 
-// ── Snapshot: receipt with all packages failed ───────────────────
+// â”€â”€ Snapshot: receipt with all packages failed â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn snapshot_receipt_all_failed() {
@@ -1243,13 +1251,14 @@ fn snapshot_receipt_all_failed() {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: crate::types::ExecutionResult::Success,
     };
 
     let json = serde_json::to_string_pretty(&receipt).expect("serialize");
     insta::assert_snapshot!("receipt_all_failed", json);
 }
 
-// ── Property-based tests (proptest) ─────────────────────────────
+// â”€â”€ Property-based tests (proptest) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 mod proptests {
     use super::*;
@@ -1360,6 +1369,7 @@ mod proptests {
                     arch: "x86_64".to_string(),
                 },
                 auth_evidence: None,
+                execution_result: crate::types::ExecutionResult::Success,
             })
     }
 
@@ -1393,7 +1403,7 @@ mod proptests {
             })
     }
 
-    // ── State serialization roundtrip ───────────────────────────
+    // â”€â”€ State serialization roundtrip â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     proptest! {
         #[test]
@@ -1423,7 +1433,7 @@ mod proptests {
         }
     }
 
-    // ── Plan ID with arbitrary inputs ───────────────────────────
+    // â”€â”€ Plan ID with arbitrary inputs â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     proptest! {
         #[test]
@@ -1445,7 +1455,7 @@ mod proptests {
         }
     }
 
-    // ── Package state transitions ───────────────────────────────
+    // â”€â”€ Package state transitions â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     proptest! {
         #[test]
@@ -1489,7 +1499,7 @@ mod proptests {
         }
     }
 
-    // ── Atomic write/read consistency ───────────────────────────
+    // â”€â”€ Atomic write/read consistency â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(20))]
@@ -1535,7 +1545,7 @@ mod proptests {
         }
     }
 
-    // ── Double-roundtrip idempotency ────────────────────────────
+    // â”€â”€ Double-roundtrip idempotency â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(20))]
@@ -1572,7 +1582,7 @@ mod proptests {
     }
 }
 
-// ── Atomic write crash-safety ───────────────────────────────────
+// â”€â”€ Atomic write crash-safety â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn atomic_write_orphaned_tmp_does_not_affect_load() {
@@ -1648,7 +1658,7 @@ fn atomic_write_no_partial_state_on_serialization_error_path() {
     assert_eq!(loaded.plan_id, "updated");
 }
 
-// ── Receipt generation completeness ─────────────────────────────
+// â”€â”€ Receipt generation completeness â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn receipt_all_fields_individually_verified_after_roundtrip() {
@@ -1699,6 +1709,7 @@ fn receipt_all_fields_individually_verified_after_roundtrip() {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: crate::types::ExecutionResult::Success,
     };
 
     write_receipt(&dir, &receipt).expect("write");
@@ -1837,7 +1848,7 @@ fn receipt_with_evidence_data_roundtrip() {
     assert_eq!(pkg.evidence.readiness_checks[0].attempt, 1);
 }
 
-// ── State migration / versioning ────────────────────────────────
+// â”€â”€ State migration / versioning â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn migrate_v1_receipt_with_packages_populated() {
@@ -1936,7 +1947,7 @@ fn receipt_v0_rejected_by_validation() {
     assert!(msg.contains("too old"), "unexpected error: {msg}");
 }
 
-// ── Concurrent state access patterns ────────────────────────────
+// â”€â”€ Concurrent state access patterns â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn concurrent_readers_all_see_consistent_state() {
@@ -1986,7 +1997,7 @@ fn concurrent_readers_all_see_consistent_state() {
 
 #[test]
 fn sequential_writer_reader_pattern() {
-    // Simulates a writer-lock pattern: write → verify → write → verify.
+    // Simulates a writer-lock pattern: write â†’ verify â†’ write â†’ verify.
     let td = tempdir().expect("tempdir");
     let dir = td.path().join("seq-wr");
 
@@ -2063,7 +2074,7 @@ fn concurrent_writer_then_readers() {
     }
 }
 
-// ── PackageState variant roundtrip through disk ─────────────────
+// â”€â”€ PackageState variant roundtrip through disk â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn each_package_state_variant_disk_roundtrip() {
@@ -2140,7 +2151,7 @@ fn each_package_state_variant_disk_roundtrip() {
     }
 }
 
-// ── Snapshot tests: receipt with git_context ─────────────────────
+// â”€â”€ Snapshot tests: receipt with git_context â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn snapshot_receipt_with_git_context() {
@@ -2184,6 +2195,7 @@ fn snapshot_receipt_with_git_context() {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: crate::types::ExecutionResult::Success,
     };
 
     let json = serde_json::to_string_pretty(&receipt).expect("serialize");
@@ -2251,6 +2263,7 @@ fn snapshot_receipt_with_evidence() {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: crate::types::ExecutionResult::Success,
     };
 
     let json = serde_json::to_string_pretty(&receipt).expect("serialize");
@@ -2273,7 +2286,7 @@ fn snapshot_state_empty_packages() {
     insta::assert_snapshot!("state_empty_packages", json);
 }
 
-// ── error message quality snapshots ──────────────────────────────────
+// â”€â”€ error message quality snapshots â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 fn normalize_error(err: &str, state_dir: &std::path::Path) -> String {
     err.replace(&state_dir.display().to_string(), "<STATE_DIR>")
@@ -2344,7 +2357,7 @@ fn snapshot_error_message_corrupted_receipt_json() {
     );
 }
 
-// ── Proptest additions ──────────────────────────────────────────
+// â”€â”€ Proptest additions â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 mod proptests_extended {
     use super::*;
@@ -2462,6 +2475,7 @@ mod proptests_extended {
                     arch: "x86_64".to_string(),
                 },
                 auth_evidence: None,
+            execution_result: crate::types::ExecutionResult::Success,
             };
 
             write_receipt(&dir, &receipt).expect("write");
@@ -2475,7 +2489,7 @@ mod proptests_extended {
     }
 }
 
-// ── Reconciliation-report persistence ────────────────────────────────────
+// â”€â”€ Reconciliation-report persistence â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn reconciliation_path_appends_expected_filename() {
@@ -2556,7 +2570,7 @@ fn write_reconciliation_report_overwrites_existing_atomically() {
     assert_eq!(parsed.plan_id, "p2", "second write must replace contents");
 }
 
-// ── Encrypted state I/O ──────────────────────────────────────────────────
+// â”€â”€ Encrypted state I/O â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 fn sample_encryption_config() -> shipper_encrypt::EncryptionConfig {
     shipper_encrypt::EncryptionConfig::new("test-passphrase".to_string())
@@ -2620,7 +2634,7 @@ fn load_state_encrypted_fails_with_wrong_passphrase() {
     );
 }
 
-// ── Encrypted receipt I/O ────────────────────────────────────────────────
+// â”€â”€ Encrypted receipt I/O â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn load_receipt_encrypted_returns_none_when_file_missing() {

--- a/crates/shipper-core/src/state/store/snapshot_tests.rs
+++ b/crates/shipper-core/src/state/store/snapshot_tests.rs
@@ -19,7 +19,7 @@ fn fixed_time() -> DateTime<Utc> {
     Utc.with_ymd_and_hms(2025, 1, 15, 12, 0, 0).unwrap()
 }
 
-// ── ExecutionState snapshots ────────────────────────────────────
+// â”€â”€ ExecutionState snapshots â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn snapshot_execution_state_single_pending() {
@@ -154,7 +154,7 @@ fn snapshot_execution_state_empty_packages() {
     insta::assert_snapshot!("execution_state_empty_packages", json);
 }
 
-// ── Receipt snapshots ───────────────────────────────────────────
+// â”€â”€ Receipt snapshots â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn snapshot_receipt_minimal() {
@@ -191,6 +191,7 @@ fn snapshot_receipt_minimal() {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: crate::types::ExecutionResult::Success,
     };
 
     let json = serde_json::to_string_pretty(&receipt).expect("serialize");
@@ -237,6 +238,7 @@ fn snapshot_receipt_with_git_context() {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: crate::types::ExecutionResult::Success,
     };
 
     let json = serde_json::to_string_pretty(&receipt).expect("serialize");
@@ -317,13 +319,14 @@ fn snapshot_receipt_mixed_outcomes() {
             arch: "aarch64".to_string(),
         },
         auth_evidence: None,
+        execution_result: crate::types::ExecutionResult::Success,
     };
 
     let json = serde_json::to_string_pretty(&receipt).expect("serialize");
     insta::assert_snapshot!("receipt_mixed_outcomes", json);
 }
 
-// ── FileStore persistence format snapshots ──────────────────────
+// â”€â”€ FileStore persistence format snapshots â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn snapshot_state_persisted_json() {
@@ -409,6 +412,7 @@ fn snapshot_receipt_persisted_json() {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: crate::types::ExecutionResult::Success,
     };
 
     store.save_receipt(&receipt).expect("save");
@@ -419,7 +423,7 @@ fn snapshot_receipt_persisted_json() {
     insta::assert_snapshot!("receipt_persisted_json", pretty);
 }
 
-// ── Event serialization snapshots ───────────────────────────────
+// â”€â”€ Event serialization snapshots â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn snapshot_event_execution_started() {
@@ -517,7 +521,7 @@ fn snapshot_event_execution_finished_partial_failure() {
     insta::assert_snapshot!("event_execution_finished_partial_failure", json);
 }
 
-// ── Schema version error message snapshots ──────────────────────
+// â”€â”€ Schema version error message snapshots â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn snapshot_error_version_too_old() {
@@ -557,7 +561,7 @@ fn snapshot_error_non_numeric_version() {
     insta::assert_snapshot!("error_non_numeric_version", err);
 }
 
-// ── Events JSONL persisted format ───────────────────────────────
+// â”€â”€ Events JSONL persisted format â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn snapshot_events_persisted_jsonl() {
@@ -607,7 +611,7 @@ fn snapshot_events_persisted_jsonl() {
     insta::assert_snapshot!("events_persisted_jsonl", snapshot);
 }
 
-// ── Registry serialization snapshot ─────────────────────────────
+// â”€â”€ Registry serialization snapshot â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn snapshot_registry_crates_io() {
@@ -627,7 +631,7 @@ fn snapshot_registry_custom() {
     insta::assert_snapshot!("registry_custom", json);
 }
 
-// ── Edge case snapshot: retry cycle state ───────────────────────
+// â”€â”€ Edge case snapshot: retry cycle state â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn snapshot_state_retry_cycle() {
@@ -658,7 +662,7 @@ fn snapshot_state_retry_cycle() {
     insta::assert_snapshot!("state_retry_cycle", json);
 }
 
-// ── Edge case snapshot: receipt all published ────────────────────
+// â”€â”€ Edge case snapshot: receipt all published â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn snapshot_receipt_all_published() {
@@ -713,13 +717,14 @@ fn snapshot_receipt_all_published() {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: crate::types::ExecutionResult::Success,
     };
 
     let json = serde_json::to_string_pretty(&receipt).expect("serialize");
     insta::assert_snapshot!("receipt_all_published", json);
 }
 
-// ── Edge case snapshot: receipt some failed ──────────────────────
+// â”€â”€ Edge case snapshot: receipt some failed â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn snapshot_receipt_some_failed() {
@@ -777,13 +782,14 @@ fn snapshot_receipt_some_failed() {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: crate::types::ExecutionResult::Success,
     };
 
     let json = serde_json::to_string_pretty(&receipt).expect("serialize");
     insta::assert_snapshot!("receipt_some_failed", json);
 }
 
-// ── Directory layout snapshot ───────────────────────────────────
+// â”€â”€ Directory layout snapshot â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn snapshot_directory_layout_after_full_save() {
@@ -845,6 +851,7 @@ fn snapshot_directory_layout_after_full_save() {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: crate::types::ExecutionResult::Success,
     };
     store.save_receipt(&receipt).expect("save receipt");
 
@@ -871,7 +878,7 @@ fn snapshot_directory_layout_after_full_save() {
     insta::assert_snapshot!("directory_layout_after_full_save", layout);
 }
 
-// ── Custom registry state snapshot ──────────────────────────────
+// â”€â”€ Custom registry state snapshot â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[test]
 fn snapshot_state_with_custom_registry() {

--- a/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__receipt_all_published.snap
+++ b/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__receipt_all_published.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-store/src/lib.rs
+source: crates/shipper-core/src/state/store/snapshot_tests.rs
 expression: json
 ---
 {
@@ -52,5 +52,6 @@ expression: json
     "rust_version": "1.82.0",
     "os": "linux",
     "arch": "x86_64"
-  }
+  },
+  "execution_result": "success"
 }

--- a/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__receipt_minimal.snap
+++ b/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__receipt_minimal.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-store/src/lib.rs
+source: crates/shipper-core/src/state/store/snapshot_tests.rs
 expression: json
 ---
 {
@@ -37,5 +37,6 @@ expression: json
     "rust_version": "1.82.0",
     "os": "linux",
     "arch": "x86_64"
-  }
+  },
+  "execution_result": "success"
 }

--- a/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__receipt_mixed_outcomes.snap
+++ b/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__receipt_mixed_outcomes.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-store/src/lib.rs
+source: crates/shipper-core/src/state/store/snapshot_tests.rs
 expression: json
 ---
 {
@@ -70,5 +70,6 @@ expression: json
     "rust_version": null,
     "os": "macos",
     "arch": "aarch64"
-  }
+  },
+  "execution_result": "success"
 }

--- a/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__receipt_persisted_json.snap
+++ b/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__receipt_persisted_json.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-store/src/lib.rs
+source: crates/shipper-core/src/state/store/snapshot_tests.rs
 expression: pretty
 ---
 {
@@ -11,6 +11,7 @@ expression: pretty
     "shipper_version": "0.3.0"
   },
   "event_log_path": ".shipper/events.jsonl",
+  "execution_result": "success",
   "finished_at": "2025-01-15T12:00:00Z",
   "git_context": null,
   "packages": [

--- a/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__receipt_some_failed.snap
+++ b/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__receipt_some_failed.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-store/src/lib.rs
+source: crates/shipper-core/src/state/store/snapshot_tests.rs
 expression: json
 ---
 {
@@ -54,5 +54,6 @@ expression: json
     "rust_version": null,
     "os": "linux",
     "arch": "x86_64"
-  }
+  },
+  "execution_result": "success"
 }

--- a/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__receipt_with_git_context.snap
+++ b/crates/shipper-core/src/state/store/snapshots/shipper_core__store__snapshot_tests__receipt_with_git_context.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/shipper-store/src/lib.rs
+source: crates/shipper-core/src/state/store/snapshot_tests.rs
 expression: json
 ---
 {
@@ -42,5 +42,6 @@ expression: json
     "rust_version": "1.82.0",
     "os": "linux",
     "arch": "x86_64"
-  }
+  },
+  "execution_result": "success"
 }

--- a/crates/shipper-core/src/state/store/tests.rs
+++ b/crates/shipper-core/src/state/store/tests.rs
@@ -66,6 +66,7 @@ fn sample_receipt() -> Receipt {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: crate::types::ExecutionResult::Success,
     }
 }
 
@@ -900,6 +901,7 @@ mod proptests {
                     arch: "x86_64".to_string(),
                 },
                 auth_evidence: None,
+            execution_result: crate::types::ExecutionResult::Success,
             };
 
             store.save_receipt(&receipt).expect("save receipt");
@@ -960,6 +962,7 @@ mod proptests {
                     arch: "test".to_string(),
                 },
                 auth_evidence: None,
+            execution_result: crate::types::ExecutionResult::Success,
             };
 
             let json = serde_json::to_string(&receipt).expect("serialize");
@@ -1039,7 +1042,7 @@ fn file_store_load_receipt_truncated_json_returns_error() {
     );
 }
 
-// --- State transition: retry cycle (Pending → Failed → Pending) ---
+// --- State transition: retry cycle (Pending â†’ Failed â†’ Pending) ---
 
 #[test]
 fn file_store_state_retry_cycle_pending_failed_pending() {
@@ -1158,7 +1161,7 @@ fn file_store_state_empty_plan_id() {
 #[test]
 fn file_store_unicode_directory_path() {
     let td = tempdir().expect("tempdir");
-    let unicode_dir = td.path().join("données").join("日本語");
+    let unicode_dir = td.path().join("donnÃ©es").join("æ—¥æœ¬èªž");
     let store = FileStore::new(unicode_dir);
 
     store.save_state(&sample_state()).expect("save");
@@ -1250,6 +1253,7 @@ fn file_store_receipt_all_published() {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: crate::types::ExecutionResult::Success,
     };
 
     store.save_receipt(&receipt).expect("save");
@@ -1324,6 +1328,7 @@ fn file_store_receipt_some_failed() {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: crate::types::ExecutionResult::Success,
     };
 
     store.save_receipt(&receipt).expect("save");
@@ -1583,6 +1588,7 @@ fn file_store_receipt_empty_strings_roundtrip() {
             arch: String::new(),
         },
         auth_evidence: None,
+        execution_result: crate::types::ExecutionResult::Success,
     };
 
     store.save_receipt(&receipt).expect("save");
@@ -1618,10 +1624,10 @@ fn file_store_load_receipt_wrong_json_shape_returns_error() {
 
     let receipt_file = crate::state::execution_state::receipt_path(td.path());
     std::fs::create_dir_all(receipt_file.parent().unwrap_or(td.path())).ok();
-    // Valid JSON but completely wrong shape — no receipt_version, no packages, etc.
+    // Valid JSON but completely wrong shape â€” no receipt_version, no packages, etc.
     std::fs::write(&receipt_file, r#"{"unexpected_key": true, "number": 42}"#).expect("write");
 
-    // Either returns an error or migrates/fails gracefully — must not panic
+    // Either returns an error or migrates/fails gracefully â€” must not panic
     let result = store.load_receipt();
     // The implementation attempts migration which may also fail; either Err or Ok is fine
     // but it must never panic
@@ -1698,7 +1704,7 @@ mod proptests_hardened {
             std::fs::create_dir_all(state_file.parent().unwrap_or(td.path())).ok();
             std::fs::write(&state_file, &data).expect("write");
 
-            // Must not panic — may return Ok(None) or Err, both acceptable
+            // Must not panic â€” may return Ok(None) or Err, both acceptable
             let _ = store.load_state();
         }
 
@@ -1711,7 +1717,7 @@ mod proptests_hardened {
             std::fs::create_dir_all(receipt_file.parent().unwrap_or(td.path())).ok();
             std::fs::write(&receipt_file, &data).expect("write");
 
-            // Must not panic — may return Ok(None) or Err, both acceptable
+            // Must not panic â€” may return Ok(None) or Err, both acceptable
             let _ = store.load_receipt();
         }
 

--- a/crates/shipper-core/src/stress_tests.rs
+++ b/crates/shipper-core/src/stress_tests.rs
@@ -234,6 +234,7 @@ mod tests {
                 arch: std::env::consts::ARCH.to_string(),
             },
             auth_evidence: None,
+            execution_result: crate::types::ExecutionResult::Success,
         };
 
         // Serialize large receipt

--- a/crates/shipper-types/src/lib.rs
+++ b/crates/shipper-types/src/lib.rs
@@ -334,7 +334,7 @@ pub enum ReadinessMethod {
 /// - `max_delay`: 60 seconds
 /// - `max_total_wait`: 300 seconds (5 minutes)
 /// - `poll_interval`: 2 seconds
-/// - `jitter_factor`: 0.5 (±50%)
+/// - `jitter_factor`: 0.5 (Ãƒâ€šÃ‚Â±50%)
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -383,11 +383,11 @@ pub struct ReadinessConfig {
         serialize_with = "serialize_duration"
     )]
     pub poll_interval: Duration,
-    /// Jitter factor (±50% means 0.5)
+    /// Jitter factor (Ãƒâ€šÃ‚Â±50% means 0.5)
     ///
     /// Adds randomness to poll intervals to reduce thundering herd
     /// when many clients are checking simultaneously. A value of 0.5
-    /// means the actual interval varies by ±50%.
+    /// means the actual interval varies by Ãƒâ€šÃ‚Â±50%.
     pub jitter_factor: f64,
     /// Custom index path for testing (optional)
     ///
@@ -581,14 +581,14 @@ pub struct RuntimeOptions {
     pub registries: Vec<Registry>,
     /// Optional package name to resume from (skips all packages before this one)
     pub resume_from: Option<String>,
-    /// Rehearsal registry name (#97) — if `Some`, `shipper rehearse` publishes
+    /// Rehearsal registry name (#97) ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â if `Some`, `shipper rehearse` publishes
     /// to this registry as phase-2 proof before live dispatch. `None` means
     /// rehearsal is disabled (the default; opt-in until phase-2 stabilizes).
     ///
     /// The name must resolve against the configured [`Self::registries`] at
     /// runtime; `engine::run_rehearsal` errors clean otherwise.
     pub rehearsal_registry: Option<String>,
-    /// Operator override — explicitly skip rehearsal even if a
+    /// Operator override ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â explicitly skip rehearsal even if a
     /// [`Self::rehearsal_registry`] is configured (#97). Default `false`.
     /// When the hard gate lands (#97 PR 3), live publish will refuse to run
     /// without this flag if rehearsal has not passed for the current `plan_id`.
@@ -596,7 +596,7 @@ pub struct RuntimeOptions {
     /// Crate name to install via `cargo install --registry <rehearsal>`
     /// after all rehearsal publishes succeed (#97 PR 4). This is the
     /// install/smoke check that proves end-to-end registry-index
-    /// resolution — the scenario that killed the rc.1 first-publish.
+    /// resolution ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the scenario that killed the rc.1 first-publish.
     /// `None` means no smoke install (opt-in). The named crate must
     /// exist in the plan AND have a `[[bin]]` target.
     pub rehearsal_smoke_install: Option<String>,
@@ -932,10 +932,10 @@ where
 /// # State Transitions
 ///
 /// ```text
-/// Pending → Uploaded → Published
-///              ↓
+/// Pending ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢ Uploaded ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢ Published
+///              ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬Å“
 ///            Failed
-///              ↓
+///              ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬Å“
 ///           Pending (retry)
 /// ```
 ///
@@ -998,19 +998,19 @@ pub enum PackageState {
 ///
 /// # Classification is a hint, not truth
 ///
-/// This enum is produced by parsing cargo's stdout/stderr — a human-facing
+/// This enum is produced by parsing cargo's stdout/stderr ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â a human-facing
 /// log that is explicitly not a stable machine protocol. Pattern-matching on
 /// cargo text gives Shipper a fast first-pass signal, but **it must never be
 /// treated as the final word** on what actually happened:
 ///
 /// - [`ErrorClass::Permanent`] and [`ErrorClass::Retryable`] are still
-///   hints — they drive retry scheduling, but every retry attempt re-checks
+///   hints ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â they drive retry scheduling, but every retry attempt re-checks
 ///   the registry before and after the next `cargo publish`.
 /// - [`ErrorClass::Ambiguous`] is the dangerous case. Cargo's publish flow
 ///   uploads to the registry first and polls the index afterwards; the poll
 ///   can time out without affecting the upload. So a non-zero cargo exit
 ///   can coexist with a successful upload. Ambiguous outcomes MUST be
-///   reconciled against registry truth before any further action — never
+///   reconciled against registry truth before any further action ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â never
 ///   blind-retry. See [`ReconciliationOutcome`] and the reconciliation flow
 ///   in `shipper::engine::parallel::reconcile`.
 ///
@@ -1021,11 +1021,11 @@ pub enum PackageState {
 /// # Classification Heuristics (hints)
 ///
 /// Shipper uses various heuristics to classify errors:
-/// - HTTP 429 (Too Many Requests) → Retryable
-/// - HTTP 401/403 (Auth errors) → Permanent
-/// - HTTP 409 (Version conflict) → Permanent
-/// - Network timeouts → Retryable
-/// - Unknown errors → Ambiguous (triggers registry reconciliation)
+/// - HTTP 429 (Too Many Requests) ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢ Retryable
+/// - HTTP 401/403 (Auth errors) ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢ Permanent
+/// - HTTP 409 (Version conflict) ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢ Permanent
+/// - Network timeouts ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢ Retryable
+/// - Unknown errors ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢ Ambiguous (triggers registry reconciliation)
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ErrorClass {
@@ -1039,7 +1039,7 @@ pub enum ErrorClass {
 /// Per [`docs/INVARIANTS.md`](https://github.com/EffortlessMetrics/shipper/blob/main/docs/INVARIANTS.md),
 /// `events.jsonl` is the authoritative source of truth and `state.json` is a
 /// projection derived from it. They should always agree about which packages
-/// were published. A drift is a bug — this struct captures which side claims
+/// were published. A drift is a bug ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â this struct captures which side claims
 /// what, so the end-of-run consistency check can surface it loudly rather
 /// than silently corrupting resume.
 ///
@@ -1296,7 +1296,7 @@ pub struct PackageReceipt {
     pub duration_ms: u128,
     pub evidence: PackageEvidence,
 
-    // ── Remediate pillar (#98) — compromised-release tracking ──
+    // ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ Remediate pillar (#98) ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â compromised-release tracking ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬ÃƒÂ¢Ã¢â‚¬ÂÃ¢â€šÂ¬
     // All three fields are additive Options; existing receipts read back
     // cleanly without migration. Shipper populates them via `shipper yank`
     // / `shipper plan-yank --mark-compromised` (PR 2) and
@@ -1532,6 +1532,11 @@ pub struct Receipt {
     pub environment: EnvironmentFingerprint,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_evidence: Option<AuthEvidence>,
+    /// Aggregate outcome of the run. `#[serde(default)]` so receipts written
+    /// before this field existed still deserialize (defaulting to `Success`,
+    /// which matches the "all published" receipts those files represent).
+    #[serde(default)]
+    pub execution_result: ExecutionResult,
 }
 
 // Event types for evidence-first receipts
@@ -1695,7 +1700,7 @@ pub enum EventType {
     // `shipper rehearse` so an auditor can replay the rehearsal from the
     // event log without re-running it.
     //
-    // `plan_id` is NOT carried in the event payload — the enclosing
+    // `plan_id` is NOT carried in the event payload ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the enclosing
     // `PublishEvent.package` field already disambiguates per-package events,
     // and the end-of-run `RehearsalComplete` is sufficient for plan-level
     // correlation since events.jsonl is append-only scoped to one state dir.
@@ -1726,9 +1731,9 @@ pub enum EventType {
         summary: String,
     },
 
-    // #97 PR 4 — install/smoke check. Opt-in post-publish step that runs
+    // #97 PR 4 ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â install/smoke check. Opt-in post-publish step that runs
     // `cargo install --registry <rehearsal> <crate>` to prove end-to-end
-    // registry-index resolution — the scenario that killed the rc.1
+    // registry-index resolution ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the scenario that killed the rc.1
     // first-publish. Events bracket the check so an auditor replaying
     // events.jsonl can see the proof (or failure) inline with publishes.
     RehearsalSmokeCheckStarted {
@@ -1747,7 +1752,7 @@ pub enum EventType {
         message: String,
     },
 
-    // Retry visibility (#91) — emitted immediately before Shipper sleeps on a
+    // Retry visibility (#91) ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â emitted immediately before Shipper sleeps on a
     // retry backoff. `attempt` is the just-failed attempt number (1-indexed),
     // so the next attempt will be `attempt + 1` of `max_attempts`. `reason`
     // classifies why the retry is happening; `message` is the one-line
@@ -1843,9 +1848,10 @@ pub enum EventType {
 /// - `Success`: All packages published successfully
 /// - `PartialFailure`: Some packages failed but others succeeded
 /// - `CompleteFailure`: All packages failed (or no packages to publish)
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecutionResult {
+    #[default]
     Success,
     PartialFailure,
     CompleteFailure,
@@ -2527,6 +2533,7 @@ mod tests {
                 arch: "x86_64".to_string(),
             },
             auth_evidence: None,
+            execution_result: ExecutionResult::Success,
         };
         let json = serde_json::to_string(&receipt).unwrap();
         let parsed: Receipt = serde_json::from_str(&json).unwrap();
@@ -2556,6 +2563,7 @@ mod tests {
                 arch: "x86_64".to_string(),
             },
             auth_evidence: None,
+            execution_result: ExecutionResult::Success,
         };
         let json = serde_json::to_string(&receipt).unwrap();
         let parsed: Receipt = serde_json::from_str(&json).unwrap();
@@ -2617,6 +2625,7 @@ mod tests {
                 arch: "x86_64".to_string(),
             },
             auth_evidence: None,
+            execution_result: ExecutionResult::Success,
         };
         let json = serde_json::to_string(&receipt).unwrap();
         let parsed: Receipt = serde_json::from_str(&json).unwrap();
@@ -3347,6 +3356,7 @@ mod tests {
                     arch: "x86_64".to_string(),
                 },
                 auth_evidence: None,
+                execution_result: ExecutionResult::Success,
             };
             insta::assert_yaml_snapshot!(receipt);
         }
@@ -3643,6 +3653,7 @@ mod tests {
                     arch: "x86_64".to_string(),
                 },
                 auth_evidence: None,
+                execution_result: ExecutionResult::Success,
             };
             insta::assert_yaml_snapshot!(receipt);
         }
@@ -3682,6 +3693,7 @@ mod tests {
                     arch: "aarch64".to_string(),
                 },
                 auth_evidence: None,
+                execution_result: ExecutionResult::Success,
             };
             insta::assert_yaml_snapshot!(receipt);
         }
@@ -3757,10 +3769,36 @@ mod tests {
                     arch: "aarch64".to_string(),
                 },
                 auth_evidence: None,
+                execution_result: ExecutionResult::Success,
             };
             insta::assert_yaml_snapshot!(receipt);
         }
 
+        #[test]
+        fn receipt_without_execution_result_defaults_to_success() {
+            // A v2 receipt written before execution_result existed lacks the
+            // field. It must deserialize with default = Success so old
+            // receipt.json files remain readable.
+            let json = r#"{
+                "receipt_version": "shipper.receipt.v2",
+                "plan_id": "legacy",
+                "registry": { "name": "crates-io", "api_base": "https://crates.io", "index_url": "https://index.crates.io" },
+                "started_at": "2025-01-15T12:00:00Z",
+                "finished_at": "2025-01-15T12:01:00Z",
+                "packages": [],
+                "event_log_path": ".shipper/events.jsonl",
+                "environment": {
+                    "shipper_version": "0.3.0",
+                    "cargo_version": null,
+                    "rust_version": null,
+                    "os": "linux",
+                    "arch": "x86_64"
+                }
+            }"#;
+            let receipt: Receipt = serde_json::from_str(json)
+                .expect("old receipt without execution_result must deserialize");
+            assert_eq!(receipt.execution_result, ExecutionResult::Success);
+        }
         // --- ExecutionState variations ---
 
         #[test]
@@ -4825,6 +4863,7 @@ mod tests {
                         arch: "x86_64".to_string(),
                     },
                     auth_evidence: None,
+                execution_result: ExecutionResult::Success,
                 };
                 let json = serde_json::to_string(&receipt).unwrap();
                 let parsed: Receipt = serde_json::from_str(&json).unwrap();
@@ -5107,6 +5146,7 @@ mod tests {
                     arch: "test".to_string(),
                 },
                 auth_evidence: None,
+                execution_result: ExecutionResult::Success,
             }
         }
 
@@ -5463,6 +5503,7 @@ mod tests {
                         arch: "x86_64".to_string(),
                     },
                     auth_evidence: None,
+                execution_result: ExecutionResult::Success,
                 };
                 let json = serde_json::to_string(&receipt).unwrap();
                 let parsed: Receipt = serde_json::from_str(&json).unwrap();
@@ -5742,7 +5783,7 @@ mod tests {
                 assert!(!debug.is_empty());
             }
 
-            /// The happy path Pending→Uploaded→Published always completes in 2 transitions
+            /// The happy path PendingÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢UploadedÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢Published always completes in 2 transitions
             #[test]
             fn happy_path_always_reaches_published(_seed in 0u64..100) {
                 let mut state = PackageState::Pending;
@@ -5977,6 +6018,7 @@ mod tests {
                         arch: "x86_64".to_string(),
                     },
                     auth_evidence: None,
+                execution_result: ExecutionResult::Success,
                 };
 
                 // Every planned package appears in the receipt

--- a/crates/shipper-types/src/snapshots/shipper_types__tests__snapshots__receipt_complete_failure.snap
+++ b/crates/shipper-types/src/snapshots/shipper_types__tests__snapshots__receipt_complete_failure.snap
@@ -55,3 +55,4 @@ environment:
   rust_version: 1.82.0
   os: macos
   arch: aarch64
+execution_result: success

--- a/crates/shipper-types/src/snapshots/shipper_types__tests__snapshots__receipt_full_snapshot.snap
+++ b/crates/shipper-types/src/snapshots/shipper_types__tests__snapshots__receipt_full_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/shipper-types/src/lib.rs
-assertion_line: 1608
 expression: receipt
 ---
 receipt_version: shipper.receipt.v1
@@ -46,3 +45,4 @@ environment:
   rust_version: 1.82.0
   os: linux
   arch: x86_64
+execution_result: success

--- a/crates/shipper-types/src/snapshots/shipper_types__tests__snapshots__receipt_no_git_context.snap
+++ b/crates/shipper-types/src/snapshots/shipper_types__tests__snapshots__receipt_no_git_context.snap
@@ -30,3 +30,4 @@ environment:
   rust_version: ~
   os: windows
   arch: aarch64
+execution_result: success

--- a/crates/shipper-types/src/snapshots/shipper_types__tests__snapshots__receipt_partial_failure.snap
+++ b/crates/shipper-types/src/snapshots/shipper_types__tests__snapshots__receipt_partial_failure.snap
@@ -91,3 +91,4 @@ environment:
   rust_version: 1.82.0
   os: linux
   arch: x86_64
+execution_result: success

--- a/crates/shipper/src/bin/shipper.rs
+++ b/crates/shipper/src/bin/shipper.rs
@@ -4,6 +4,12 @@
 //! `shipper-cli` crate; all engine logic lives in `shipper-core`. The
 //! `shipper` package exists as the install surface: a maintainer installs
 //! the facade crate and gets a binary named `shipper` that forwards here.
-fn main() -> anyhow::Result<()> {
-    shipper_cli::run()
+fn main() -> std::process::ExitCode {
+    match shipper_cli::run() {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("{e:#}");
+            std::process::ExitCode::FAILURE
+        }
+    }
 }

--- a/crates/shipper/tests/cross_crate_integration.rs
+++ b/crates/shipper/tests/cross_crate_integration.rs
@@ -1,6 +1,6 @@
 //! Cross-crate integration tests verifying that shipper's public modules
-//! compose correctly: config → plan, plan → state, auth → registry,
-//! state → store → events, and full preflight flows with a mocked registry.
+//! compose correctly: config â†’ plan, plan â†’ state, auth â†’ registry,
+//! state â†’ store â†’ events, and full preflight flows with a mocked registry.
 
 use std::collections::BTreeMap;
 use std::fs;
@@ -136,11 +136,12 @@ fn sample_receipt(plan_id: &str) -> shipper::types::Receipt {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: ExecutionResult::Success,
     }
 }
 
 // ===========================================================================
-// 1. Config loading → plan building flow
+// 1. Config loading â†’ plan building flow
 // ===========================================================================
 
 #[test]
@@ -180,7 +181,7 @@ fn config_load_then_build_plan() {
 }
 
 // ===========================================================================
-// 2. Plan building → state persistence flow
+// 2. Plan building â†’ state persistence flow
 // ===========================================================================
 
 #[test]
@@ -237,7 +238,7 @@ fn plan_build_then_persist_state() {
 }
 
 // ===========================================================================
-// 3. Auth resolution → registry checking flow (mocked HTTP)
+// 3. Auth resolution â†’ registry checking flow (mocked HTTP)
 // ===========================================================================
 
 #[test]
@@ -311,7 +312,7 @@ fn registry_reports_missing_version() {
 }
 
 // ===========================================================================
-// 4. Full flow: config → plan → preflight (mocked registry)
+// 4. Full flow: config â†’ plan â†’ preflight (mocked registry)
 // ===========================================================================
 
 #[test]
@@ -374,7 +375,7 @@ fn config_to_plan_to_registry_version_check() {
 }
 
 // ===========================================================================
-// 5. State save → reload → resume verification
+// 5. State save â†’ reload â†’ resume verification
 // ===========================================================================
 
 #[test]
@@ -572,7 +573,7 @@ fn event_log_simulated_publish_lifecycle() {
 
     // Verify per-package filtering
     let core_events = loaded.events_for_package("core@0.1.0");
-    assert_eq!(core_events.len(), 7); // started, attempted, published, readiness×4
+    assert_eq!(core_events.len(), 7); // started, attempted, published, readinessÃ—4
 
     let app_events = loaded.events_for_package("app@0.1.0");
     assert_eq!(app_events.len(), 4); // started, failed, attempted, published
@@ -736,7 +737,7 @@ fn events_persisted_via_store_readable_via_state_module() {
 // 11. Plan creation for multi-level dependency trees (deep 5-crate chain)
 // ===========================================================================
 
-/// Five-crate linear chain: a → b → c → d → e
+/// Five-crate linear chain: a â†’ b â†’ c â†’ d â†’ e
 fn create_deep_chain_workspace(root: &Path) {
     write_file(
         &root.join("Cargo.toml"),
@@ -1348,7 +1349,7 @@ fn event_log_full_publish_flow_deep_chain() {
     log.write_to_file(&events_path).expect("write events");
     let loaded = EventLog::read_from_file(&events_path).expect("read events");
 
-    // 2 global + 4×3 simple + 4 for c (started+failed+attempted+published) = 2 + 12 + 4 + 1 = 19
+    // 2 global + 4Ã—3 simple + 4 for c (started+failed+attempted+published) = 2 + 12 + 4 + 1 = 19
     assert_eq!(loaded.all_events().len(), 19);
 
     // c had a failure + retry
@@ -1440,6 +1441,7 @@ fn receipt_with_mixed_outcomes_roundtrips() {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: ExecutionResult::Success,
     };
 
     state::write_receipt(&state_dir, &receipt).expect("write receipt");
@@ -1491,6 +1493,7 @@ fn receipt_environment_fingerprint_roundtrips() {
             arch: "aarch64".to_string(),
         },
         auth_evidence: None,
+        execution_result: ExecutionResult::Success,
     };
 
     state::write_receipt(&state_dir, &receipt).expect("write receipt");

--- a/crates/shipper/tests/facade_integration.rs
+++ b/crates/shipper/tests/facade_integration.rs
@@ -207,11 +207,12 @@ fn sample_receipt(plan_id: &str, pkg_names: &[&str]) -> shipper::types::Receipt 
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: ExecutionResult::Success,
     }
 }
 
 // ===========================================================================
-// 1. Plan building from a three-crate workspace — dependency ordering
+// 1. Plan building from a three-crate workspace â€” dependency ordering
 // ===========================================================================
 
 #[test]
@@ -296,7 +297,7 @@ fn plan_filters_out_non_publishable_crates() {
 }
 
 // ===========================================================================
-// 4. Config validation pipeline: valid → roundtrip → invalid rejection
+// 4. Config validation pipeline: valid â†’ roundtrip â†’ invalid rejection
 // ===========================================================================
 
 #[test]
@@ -372,7 +373,7 @@ fn config_cli_overrides_take_precedence() {
 }
 
 // ===========================================================================
-// 6. State persistence: three-package partial progress → resume → complete
+// 6. State persistence: three-package partial progress â†’ resume â†’ complete
 // ===========================================================================
 
 #[test]
@@ -578,7 +579,7 @@ fn event_emission_full_lifecycle_with_preflight() {
         package: "base@0.2.0".to_string(),
     });
 
-    // Publish mid — fails once then succeeds
+    // Publish mid â€” fails once then succeeds
     log.record(PublishEvent {
         timestamp: Utc::now(),
         event_type: EventType::PackageStarted {
@@ -609,7 +610,7 @@ fn event_emission_full_lifecycle_with_preflight() {
         package: "mid@0.2.0".to_string(),
     });
 
-    // Publish top — succeeds first try
+    // Publish top â€” succeeds first try
     log.record(PublishEvent {
         timestamp: Utc::now(),
         event_type: EventType::PackageStarted {
@@ -649,7 +650,7 @@ fn event_emission_full_lifecycle_with_preflight() {
 
     // Verify per-package event counts
     let base_events = loaded.events_for_package("base@0.2.0");
-    assert_eq!(base_events.len(), 7); // new-crate + started + attempted + published + readiness×3
+    assert_eq!(base_events.len(), 7); // new-crate + started + attempted + published + readinessÃ—3
 
     let mid_events = loaded.events_for_package("mid@0.2.0");
     assert_eq!(mid_events.len(), 4); // started + failed + attempted + published
@@ -658,7 +659,7 @@ fn event_emission_full_lifecycle_with_preflight() {
     assert_eq!(top_events.len(), 3); // started + attempted + published
 
     let global_events = loaded.events_for_package("all");
-    assert_eq!(global_events.len(), 6); // preflight×3 + plan_created + exec_started + exec_finished
+    assert_eq!(global_events.len(), 6); // preflightÃ—3 + plan_created + exec_started + exec_finished
 }
 
 // ===========================================================================
@@ -870,7 +871,7 @@ fn registry_list_owners_with_mock() {
 }
 
 // ===========================================================================
-// 13. Registry: multi-request session — version check for all planned packages
+// 13. Registry: multi-request session â€” version check for all planned packages
 // ===========================================================================
 
 #[test]
@@ -1300,6 +1301,7 @@ fn receipt_mixed_outcomes_through_file_store() {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: ExecutionResult::Success,
     };
 
     store.save_receipt(&receipt).expect("save receipt");
@@ -1358,6 +1360,7 @@ fn environment_fingerprint_in_receipt_through_store() {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: ExecutionResult::Success,
     };
 
     store.save_receipt(&receipt).expect("save");
@@ -1770,7 +1773,7 @@ fn error_recovery_fail_persist_resume_succeed() {
     // Verify incomplete state exists
     assert!(state::has_incomplete_state(&state_dir));
 
-    // Phase 2: Resume — load state, reset failed package to pending, then publish
+    // Phase 2: Resume â€” load state, reset failed package to pending, then publish
     let mut resumed = state::load_state(&state_dir)
         .expect("load")
         .expect("exists");
@@ -1920,7 +1923,7 @@ fn plan_filtering_single_package_no_deps() {
     let root = td.path();
     create_three_crate_workspace(root);
 
-    // Select only "base" — no transitive deps needed since base has none
+    // Select only "base" â€” no transitive deps needed since base has none
     let spec = ReleaseSpec {
         manifest_path: root.join("Cargo.toml"),
         registry: Registry::crates_io(),
@@ -1938,7 +1941,7 @@ fn plan_filtering_mid_package_pulls_base_dep() {
     let root = td.path();
     create_three_crate_workspace(root);
 
-    // Select "mid" — should pull in base as transitive dep
+    // Select "mid" â€” should pull in base as transitive dep
     let spec = ReleaseSpec {
         manifest_path: root.join("Cargo.toml"),
         registry: Registry::crates_io(),
@@ -2150,6 +2153,7 @@ fn receipt_all_fields_persisted_and_roundtrip() {
             arch: "aarch64".to_string(),
         },
         auth_evidence: None,
+        execution_result: ExecutionResult::Success,
     };
 
     state::write_receipt(&state_dir, &receipt).expect("write receipt");
@@ -2403,7 +2407,7 @@ fn lock_double_acquire_fails() {
 }
 
 // ===========================================================================
-// 38. Full lifecycle: plan → state → events → receipt through FileStore
+// 38. Full lifecycle: plan â†’ state â†’ events â†’ receipt through FileStore
 // ===========================================================================
 
 #[test]

--- a/crates/shipper/tests/pipeline_integration.rs
+++ b/crates/shipper/tests/pipeline_integration.rs
@@ -1,6 +1,6 @@
 //! Pipeline integration tests for cross-module flows.
 //!
-//! Covers: config → plan → engine pipeline, state persistence → resume →
+//! Covers: config â†’ plan â†’ engine pipeline, state persistence â†’ resume â†’
 //! completion, error propagation across module boundaries, lock contention
 //! scenarios, event logging through the full publish pipeline, and receipt
 //! generation validation.
@@ -135,11 +135,12 @@ fn make_receipt(plan_id: &str, pkgs: &[(&str, &str, PackageState)]) -> shipper::
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: ExecutionResult::Success,
     }
 }
 
 // ===========================================================================
-// 1. Config → Plan → State → Receipt end-to-end pipeline
+// 1. Config â†’ Plan â†’ State â†’ Receipt end-to-end pipeline
 // ===========================================================================
 
 #[test]
@@ -236,7 +237,7 @@ fn config_plan_state_receipt_end_to_end_pipeline() {
 }
 
 // ===========================================================================
-// 2. State persistence → Resume with failed → Re-publish → Completion
+// 2. State persistence â†’ Resume with failed â†’ Re-publish â†’ Completion
 // ===========================================================================
 
 #[test]
@@ -307,7 +308,7 @@ fn state_resume_from_partial_failure_to_completion() {
 }
 
 // ===========================================================================
-// 3. Error propagation: registry timeout → state reflects failure
+// 3. Error propagation: registry timeout â†’ state reflects failure
 // ===========================================================================
 
 #[test]
@@ -438,7 +439,7 @@ fn lock_stale_timeout_allows_reacquire() {
     {
         let mut lock = shipper_core::lock::LockFile::acquire(&state_dir, None).expect("acquire");
         lock.set_plan_id("stale-plan").expect("set plan_id");
-        // Intentionally don't release — lock file remains but process holds it
+        // Intentionally don't release â€” lock file remains but process holds it
         // For testing, we manually write a stale lock file
         lock.release().expect("release");
     }
@@ -608,13 +609,13 @@ fn event_log_complete_pipeline_with_all_phases() {
 
     // Verify per-package filtering
     let core_events = loaded.events_for_package("core@0.1.0");
-    assert_eq!(core_events.len(), 7); // ownership + started + attempted + published + readiness×3
+    assert_eq!(core_events.len(), 7); // ownership + started + attempted + published + readinessÃ—3
 
     let app_events = loaded.events_for_package("app@0.1.0");
     assert_eq!(app_events.len(), 2); // started + failed
 
     let global = loaded.events_for_package("all");
-    assert_eq!(global.len(), 6); // preflight×3 + plan + exec_start + exec_finish
+    assert_eq!(global.len(), 6); // preflightÃ—3 + plan + exec_start + exec_finish
 }
 
 // ===========================================================================
@@ -690,6 +691,7 @@ fn receipt_with_full_evidence_roundtrips() {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: ExecutionResult::Success,
     };
 
     state::write_receipt(&state_dir, &receipt).expect("write receipt");
@@ -742,6 +744,7 @@ fn receipt_with_git_context_roundtrips() {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: ExecutionResult::Success,
     };
 
     state::write_receipt(&state_dir, &receipt).expect("write receipt");
@@ -757,7 +760,7 @@ fn receipt_with_git_context_roundtrips() {
 }
 
 // ===========================================================================
-// 9. Lock → state → events → receipt: full publish simulation
+// 9. Lock â†’ state â†’ events â†’ receipt: full publish simulation
 // ===========================================================================
 
 #[test]
@@ -867,7 +870,7 @@ fn lock_state_events_receipt_full_simulation() {
 }
 
 // ===========================================================================
-// 10. Config → Plan → Registry check pipeline with mock
+// 10. Config â†’ Plan â†’ Registry check pipeline with mock
 // ===========================================================================
 
 #[test]
@@ -1020,7 +1023,7 @@ fn file_store_state_events_receipt_lifecycle() {
 }
 
 // ===========================================================================
-// 12. Ambiguous package state → Resume → Resolution
+// 12. Ambiguous package state â†’ Resume â†’ Resolution
 // ===========================================================================
 
 #[test]
@@ -1058,7 +1061,7 @@ fn ambiguous_state_resume_and_resolution() {
         "app should be Ambiguous"
     );
 
-    // Mock registry says it's actually published → resolve as Published
+    // Mock registry says it's actually published â†’ resolve as Published
     let server = tiny_http::Server::http("127.0.0.1:0").expect("start server");
     let addr = server.server_addr().to_ip().expect("addr");
     let api_base = format!("http://{}:{}", addr.ip(), addr.port());
@@ -1081,7 +1084,7 @@ fn ambiguous_state_resume_and_resolution() {
     let exists = client.version_exists("app", "0.1.0").expect("check");
     assert!(exists, "registry says app is published");
 
-    // Resolve ambiguous → published in state
+    // Resolve ambiguous â†’ published in state
     let mut resolved = loaded;
     if let Some(app) = resolved.packages.get_mut("app@0.1.0") {
         app.state = PackageState::Published;
@@ -1190,7 +1193,7 @@ core = { path = "../core", version = "0.2.0" }
 }
 
 // ===========================================================================
-// 15. Full pipeline: plan → preflight events → publish → verify → receipt
+// 15. Full pipeline: plan â†’ preflight events â†’ publish â†’ verify â†’ receipt
 // ===========================================================================
 
 #[test]
@@ -1308,7 +1311,7 @@ fn full_pipeline_plan_preflight_publish_verify_receipt() {
     let events_path = shipper::state::events::events_path(&state_dir);
     log.write_to_file(&events_path).expect("write events");
 
-    // Update state → all published
+    // Update state â†’ all published
     let mut loaded = state::load_state(&state_dir)
         .expect("load")
         .expect("exists");
@@ -1376,6 +1379,7 @@ fn full_pipeline_plan_preflight_publish_verify_receipt() {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: ExecutionResult::Success,
     };
     state::write_receipt(&state_dir, &receipt).expect("write receipt");
 
@@ -1500,7 +1504,7 @@ fn resume_from_uploaded_state_after_interruption() {
     let plan_id = "interrupt-resume";
 
     // Simulate: core fully published, app uploaded (cargo publish succeeded
-    // but readiness not yet verified — simulates interruption after upload)
+    // but readiness not yet verified â€” simulates interruption after upload)
     let initial = make_state(
         plan_id,
         &[
@@ -1780,6 +1784,7 @@ fn receipt_fields_populated_for_mixed_outcomes() {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: ExecutionResult::Success,
     };
 
     state::write_receipt(&state_dir, &receipt).expect("write receipt");
@@ -1811,7 +1816,7 @@ fn receipt_fields_populated_for_mixed_outcomes() {
 }
 
 // ===========================================================================
-// 21. Lock acquire → publish state → release lifecycle
+// 21. Lock acquire â†’ publish state â†’ release lifecycle
 // ===========================================================================
 
 #[test]
@@ -1975,7 +1980,7 @@ fn file_store_clear_removes_all_artifacts() {
 }
 
 // ===========================================================================
-// 25. Plan → levels grouping for parallel engine
+// 25. Plan â†’ levels grouping for parallel engine
 // ===========================================================================
 
 #[test]
@@ -2095,7 +2100,7 @@ fn event_log_package_filtering_is_exact() {
 }
 
 // ===========================================================================
-// 28. Registry 404 → mark as new crate (not published)
+// 28. Registry 404 â†’ mark as new crate (not published)
 // ===========================================================================
 
 #[test]

--- a/crates/shipper/tests/state_integration.rs
+++ b/crates/shipper/tests/state_integration.rs
@@ -10,6 +10,7 @@ use shipper::state::execution_state::{
     has_incomplete_state, load_receipt, load_state, receipt_path, save_state, state_path,
     write_receipt,
 };
+use shipper::types::ExecutionResult;
 use shipper_types::{
     EnvironmentFingerprint, ErrorClass, ExecutionState, PackageEvidence, PackageProgress,
     PackageReceipt, PackageState, Receipt, Registry,
@@ -63,6 +64,7 @@ fn make_receipt(plan_id: &str, packages: Vec<PackageReceipt>) -> Receipt {
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: ExecutionResult::Success,
     }
 }
 
@@ -517,18 +519,18 @@ fn has_incomplete_state_lifecycle() {
     let dir = td.path().join("lifecycle");
     fs::create_dir_all(&dir).unwrap();
 
-    // Empty dir — no incomplete state
+    // Empty dir â€” no incomplete state
     assert!(!has_incomplete_state(&dir));
 
-    // State only — incomplete
+    // State only â€” incomplete
     save_state(&dir, &make_state("lc", BTreeMap::new())).unwrap();
     assert!(has_incomplete_state(&dir));
 
-    // Add receipt — no longer incomplete
+    // Add receipt â€” no longer incomplete
     write_receipt(&dir, &make_receipt("lc", vec![])).unwrap();
     assert!(!has_incomplete_state(&dir));
 
-    // Clear state — receipt still present, not incomplete
+    // Clear state â€” receipt still present, not incomplete
     clear_state(&dir).unwrap();
     assert!(!has_incomplete_state(&dir));
 }
@@ -676,7 +678,7 @@ fn load_receipt_errors_on_truncated_json() {
 }
 
 // ---------------------------------------------------------------------------
-// State transitions: Pending → Failed → Pending (retry cycle)
+// State transitions: Pending â†’ Failed â†’ Pending (retry cycle)
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -921,7 +923,7 @@ fn state_with_empty_plan_id() {
 #[test]
 fn state_save_load_unicode_directory() {
     let td = tempdir().unwrap();
-    let dir = td.path().join("données").join("日本語");
+    let dir = td.path().join("donnÃ©es").join("æ—¥æœ¬èªž");
 
     let state = make_state("unicode-plan", BTreeMap::new());
     save_state(&dir, &state).unwrap();
@@ -1045,6 +1047,7 @@ fn make_deterministic_receipt(plan_id: &str, packages: Vec<PackageReceipt>) -> R
             arch: "x86_64".to_string(),
         },
         auth_evidence: None,
+        execution_result: ExecutionResult::Success,
     }
 }
 

--- a/docs/how-to/run-in-github-actions.md
+++ b/docs/how-to/run-in-github-actions.md
@@ -188,6 +188,31 @@ for the migration history.
 
 If a release is interrupted, manually trigger the resume workflow (a `workflow_dispatch` with `mode: resume` and `artifact_run_id: <failed run id>`) — or copy the resume job from this repo's `.github/workflows/release.yml`.
 
+### Exit codes
+
+`shipper publish` and `shipper resume` use a structured exit-code vocabulary so CI can distinguish outcomes:
+
+| Code | Meaning | CI action |
+|-----:|---------|-----------|
+| 0 | All packages published/skipped | Proceed |
+| 1 | General failure (config error, preflight failure, complete publish failure) | Alert / investigate |
+| 2 | Partial publish failure — some packages published, some failed | Trigger resume automatically |
+
+To auto-resume on partial failure:
+
+```yaml
+- name: Publish
+  run: shipper publish
+  continue-on-error: true
+  id: publish
+
+- name: Auto-resume on partial failure
+  if: steps.publish.outputs.exit-code == '2'
+  run: shipper resume
+```
+
+The `--format json` envelope also carries `execution_result` (`"success"`, `"partial_failure"`, `"complete_failure"`) for programmatic gating without parsing exit codes.
+
 ## Generate a template
 
 ```bash

--- a/docs/reference/state-files.md
+++ b/docs/reference/state-files.md
@@ -110,9 +110,12 @@ Common event types:
   ],
   "event_log_path": ".shipper/events.jsonl",
   "git_context": {...},
-  "environment": {...}
+  "environment": {...},
+  "execution_result": "success"
 }
 ```
+
+`execution_result` is the aggregate run outcome: `"success"`, `"partial_failure"`, or `"complete_failure"`. It matches the process exit code (0 / 2 / 1) and the `execution_result` field in the `--format json` envelope. The field is `#[serde(default)]` — receipts written before it existed deserialize as `"success"`.
 
 ## jq one-liners
 


### PR DESCRIPTION
## Summary

Improves the **#107 Integrate** competency by giving CI systems a machine-readable way to distinguish publish outcomes. Right now every publish failure exits `1` — indistinguishable from "fatal config error." This PR adds an exit-code vocabulary and surfaces `ExecutionResult` on the receipt and in the JSON envelope.

## Exit codes

| Code | Meaning | CI action |
|-----:|---------|-----------|
| 0 | All packages published/skipped (`Success`) | Proceed |
| 1 | General failure / complete publish failure (`CompleteFailure`) | Alert |
| 2 | Partial publish failure — resume is safe (`PartialFailure`) | Auto-resume |

```yaml
- name: Publish
  run: shipper publish
  continue-on-error: true
  id: publish

- name: Auto-resume on partial failure
  if: steps.publish.outputs.exit-code == '2'
  run: shipper resume
```

## Changes

- **`shipper-types`**: `execution_result: ExecutionResult` field on `Receipt` with `#[serde(default)]` (old receipts deserialize as `Success`). `Default` derive + `#[default]` on `Success`.
- **`shipper-core/finalize.rs`**: populates `execution_result` at receipt construction (value already computed there).
- **`shipper-cli`**: `run()` → `Result<ExitCode>`; publish/resume map exit code from `receipt.execution_result`; JSON envelope gains top-level `execution_result` field. Both `main()` entry points return `ExitCode`.
- **Docs**: `state-files.md` (new field), `run-in-github-actions.md` (exit code + auto-resume pattern).

## Scope note

The sequential publish path still fail-fasts on the first package failure (`Err` → exit 1) — this is existing behavior, unchanged. The exit-code mapping fires when a receipt is produced (parallel path, resume completion, full success). Making sequential continue-past-failure is a deliberate future change.

## Verification

- `cargo build --workspace --all-targets` — pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — **pass** (zero warnings, including the `never_loop` lint the initial code would have triggered — fixed by moving the return outside the registry loop)
- `cargo fmt --all -- --check` — pass
- `cargo run -p xtask -- no-panic check` — **0 baseline, 0 new, 0 violations**
- Tests:
  - `shipper-types` — **273 passed** (incl. new `receipt_without_execution_result_defaults_to_success` backward-compat test)
  - `shipper-core` state::execution_state — **102 passed**; snapshot_tests — **151 passed** (10 snapshots auto-updated for new field)
  - `shipper-cli --lib` — **137 passed** (incl. new `exit_code_for_result_maps_correctly`)
- 14 insta snapshots updated (4 types + 10 core) — all add the `execution_result` field, verified by diff review.

## Backward compatibility

Old `receipt.json` files (without `execution_result`) deserialize cleanly via `#[serde(default)]` → `Success`. Verified by the dedicated backward-compat test. Receipt version stays `v2` (additive field with default, not a breaking shape change).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CLI exit-code contract for publish/resume (CI may depend on exit 1 for partial failures) and extends receipt/JSON schema, though backward-compatible via serde defaults.
> 
> **Overview**
> CI can distinguish publish outcomes without parsing logs: **`shipper publish`** and **`shipper resume`** now exit **0** on full success, **1** on hard/complete failure, and **2** on **`PartialFailure`** so pipelines can branch to **`shipper resume`**.
> 
> **`run()`** returns **`Result<ExitCode>`**; both **`shipper`** and **`shipper-cli`** binaries propagate that code and still exit **1** on top-level **`anyhow`** errors.
> 
> Receipts and JSON output carry the aggregate outcome: **`Receipt`** gains **`execution_result`** (serde-default **`Success`** for older **`receipt.json`**), finalize writes it when building the receipt, and publish/resume JSON envelopes expose the same field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfddae992945ec39308b55ea24b9daa2db7caf1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->