### PR TITLE
fix(config): validate on load + hoist dev deps to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ shipper-output-sanitizer = { path = "crates/shipper-output-sanitizer", version =
 serde = { version = "1.0.228", features = ["derive"] }
 proptest = "1.11.0"
 insta = { version = "1.47.2", features = ["yaml"] }
+serial_test = "3.4.0"
 
 [profile.release]
 strip = true

--- a/crates/shipper-cargo-failure/Cargo.toml
+++ b/crates/shipper-cargo-failure/Cargo.toml
@@ -11,8 +11,7 @@ keywords = ["cargo", "publish", "retry", "errors"]
 categories = ["development-tools"]
 
 [dev-dependencies]
-proptest.workspace = true
+proptest = { workspace = true }
 insta = { workspace = true }
-
 [lints]
 workspace = true

--- a/crates/shipper-cli/Cargo.toml
+++ b/crates/shipper-cli/Cargo.toml
@@ -53,10 +53,10 @@ workspace = true
 [dev-dependencies]
 console = "0.16.3"
 assert_cmd = "2"
-insta = "1"
+insta = { workspace = true }
 predicates = "3"
 proptest = { workspace = true }
-serial_test = "3"
+serial_test = { workspace = true }
 tempfile = "3"
 tiny_http = "0.12"
 temp-env = "0.3"

--- a/crates/shipper-config/Cargo.toml
+++ b/crates/shipper-config/Cargo.toml
@@ -23,7 +23,6 @@ shipper-retry.workspace = true
 [dev-dependencies]
 tempfile = "3"
 proptest = { workspace = true }
-insta = { version = "1", features = ["yaml"] }
-
+insta = { workspace = true }
 [lints]
 workspace = true

--- a/crates/shipper-config/src/lib.rs
+++ b/crates/shipper-config/src/lib.rs
@@ -608,6 +608,14 @@ impl ShipperConfig {
             bail!("{} in file: {}", e, path.display());
         }
 
+        // Validate configuration values (output, retry, lock, readiness,
+        // parallel, registries). Without this, an invalid config (e.g.
+        // output.lines = 0) loads silently and only fails deep in the
+        // publish path.
+        config
+            .validate()
+            .with_context(|| format!("invalid configuration in file: {}", path.display()))?;
+
         Ok(config)
     }
 

--- a/crates/shipper-core/Cargo.toml
+++ b/crates/shipper-core/Cargo.toml
@@ -48,15 +48,14 @@ pbkdf2 = { version = "0.12", features = ["simple"] }
 # HMAC for webhook signatures
 hmac = "0.13"
 sha2 = "0.11"
-
 [lints]
 workspace = true
 
 [dev-dependencies]
 tempfile = "3.26.0"
-insta = { version = "1.46.3", features = ["yaml"] }
-proptest = "1.10.0"
-serial_test = "3.4.0"
+insta = { workspace = true }
+proptest = { workspace = true }
+serial_test = { workspace = true }
 tiny_http = "0.12.0"
 temp-env = "0.3"
 console = "0.16.3"

--- a/crates/shipper-duration/Cargo.toml
+++ b/crates/shipper-duration/Cargo.toml
@@ -16,7 +16,7 @@ humantime = "2.3.0"
 
 [dev-dependencies]
 insta = { workspace = true }
-proptest.workspace = true
+proptest = { workspace = true }
 serde_json = "1.0"
 toml = "1.1.2"
 

--- a/crates/shipper-encrypt/Cargo.toml
+++ b/crates/shipper-encrypt/Cargo.toml
@@ -20,11 +20,10 @@ anyhow = "1.0"
 
 [dev-dependencies]
 tempfile = "3"
-proptest.workspace = true
+proptest = { workspace = true }
 serde_json = "1"
-insta.workspace = true
+insta = { workspace = true }
 temp-env = "0.3"
-serial_test = "3.4.0"
-
+serial_test = { workspace = true }
 [lints]
 workspace = true

--- a/crates/shipper-output-sanitizer/Cargo.toml
+++ b/crates/shipper-output-sanitizer/Cargo.toml
@@ -13,8 +13,7 @@ categories = ["development-tools", "authentication", "web-programming"]
 [dependencies]
 
 [dev-dependencies]
-proptest.workspace = true
+proptest = { workspace = true }
 insta = { workspace = true }
-
 [lints]
 workspace = true

--- a/crates/shipper-registry/Cargo.toml
+++ b/crates/shipper-registry/Cargo.toml
@@ -22,7 +22,7 @@ shipper-types.workspace = true
 
 [dev-dependencies]
 insta = { workspace = true }
-proptest.workspace = true
+proptest = { workspace = true }
 tempfile = "3"
 tiny_http = "0.12"
 

--- a/crates/shipper-retry/Cargo.toml
+++ b/crates/shipper-retry/Cargo.toml
@@ -16,8 +16,7 @@ humantime-serde = "1.1"
 rand = { version = "0.10.0", features = ["std"] }
 
 [dev-dependencies]
-proptest.workspace = true
+proptest = { workspace = true }
 insta = { workspace = true }
-
 [lints]
 workspace = true

--- a/crates/shipper-sparse-index/Cargo.toml
+++ b/crates/shipper-sparse-index/Cargo.toml
@@ -16,7 +16,6 @@ serde_json = "1.0"
 
 [dev-dependencies]
 insta = { workspace = true }
-proptest.workspace = true
-
+proptest = { workspace = true }
 [lints]
 workspace = true

--- a/crates/shipper-types/Cargo.toml
+++ b/crates/shipper-types/Cargo.toml
@@ -22,8 +22,7 @@ shipper-duration.workspace = true
 
 [dev-dependencies]
 serde_json = "1.0"
-proptest = "1.10.0"
-insta = { version = "1", features = ["yaml"] }
-
+proptest = { workspace = true }
+insta = { workspace = true }
 [lints]
 workspace = true

--- a/crates/shipper-webhook/Cargo.toml
+++ b/crates/shipper-webhook/Cargo.toml
@@ -17,10 +17,9 @@ serde.workspace = true
 serde_json = "1.0"
 reqwest = { version = "0.13", features = ["blocking", "json", "rustls"] }
 sha2 = "0.10"
-
 [dev-dependencies]
-insta.workspace = true
-proptest.workspace = true
+insta = { workspace = true }
+proptest = { workspace = true }
 tempfile = "3"
 tiny_http = "0.12"
 tokio = { version = "1.52", features = ["rt", "macros"] }

--- a/crates/shipper/Cargo.toml
+++ b/crates/shipper/Cargo.toml
@@ -54,9 +54,9 @@ shipper-core.workspace = true
 shipper-types.workspace = true
 
 tempfile = "3.26.0"
-insta = { version = "1.46.3", features = ["yaml"] }
-proptest = "1.10.0"
-serial_test = "3.4.0"
+insta = { workspace = true }
+proptest = { workspace = true }
+serial_test = { workspace = true }
 tiny_http = "0.12.0"
 temp-env = "0.3"
 console = "0.16.3"


### PR DESCRIPTION
## Summary

Two friction fixes from the post-0.4.0 codebase audit.

### 1. Config validation on load

`ShipperConfig::load_from_file()` now calls `validate()` before returning. Previously, an invalid config (e.g. `output.lines = 0`, `retry.max_attempts = 0`, `jitter = 2.0`) parsed silently and only failed deep in the publish path. `validate()` already checked 7 config sections (output, retry, lock, readiness, parallel, registry/registries) — it was just never wired into the load path.

### 2. Dependency version alignment

Hoisted `proptest`, `insta`, and `serial_test` to `[workspace.dependencies]` so all crates resolve to a single version. Eliminates:

| Dep | Before | After |
|---|---|---|
| `proptest` | `1.10.0` (3 crates) vs `1.11.0` (workspace) | `workspace = true` everywhere |
| `insta` | `1` / `1.46.3` / `1.47.2` (mixed) | `workspace = true` everywhere |
| `serial_test` | `"3"` / `"3.4.0"` (mixed) | `workspace = true` everywhere |

`sha2` and `hmac` remain per-crate pending a focused crypto migration (`0.10`→`0.11` and `0.12`→`0.13` are API-breaking changes to `new_from_slice`, `pbkdf2` trait bounds, and AES-GCM construction).

## Verification

- `cargo build --workspace` — pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — pass
- `cargo fmt --all -- --check` — pass
- `cargo test -p shipper-config` — **349 passed, 0 failed** (no existing test config fails validation)
