### PR TITLE
docs(release): reconcile promoted candidate evidence

### DIFF
--- a/docs/release/0.5.0-readiness.md
+++ b/docs/release/0.5.0-readiness.md
@@ -65,12 +65,16 @@ The final candidate bundle must be tied to one immutable swarm SHA and include:
 - release-workflow target-platform, publication-order, and interrupted-train
   resume evidence.
 
-## Frozen swarm candidate evidence
+## Frozen swarm candidate and promotion evidence
 
 Captured on 2026-08-03, the frozen swarm candidate is
-`e5088e33ce0f87a93790266add0f5180b29ce4a3`. The evidence below is tied to
-that exact commit and establishes swarm readiness for promotion review. It is
-not publication authorization.
+`e0d9edb4788e0b8336e6a688b718aa3146816acd`. The implementation commit for
+the final webhook-secret diagnostic fix is
+`e5088e33ce0f87a93790266add0f5180b29ce4a3`; it was followed by the release
+evidence update in PR #237. The candidate was promoted to the release
+authority with non-fast-forward merge commit
+`c0711f60f0be5a4f88fe13d004af2d1bc73dcc22`. This promotion record is not
+publication authorization.
 
 | Evidence | Result |
 | --- | --- |
@@ -78,19 +82,20 @@ not publication authorization.
 | [routed Rust run](https://github.com/EffortlessMetrics/shipper-swarm/actions/runs/30841375153) | success, including the required `Shipper Rust Small Result` |
 | Clean exact-SHA local checks | `cargo fmt --all -- --check`; all 136 `shipper-webhook` tests; the `shipper-config` TOML round-trip property test; advisory doc contracts with `documents=22`, `findings=0`, `blocking=0`; `git diff --check` |
 | [webhook security PR #236](https://github.com/EffortlessMetrics/shipper-swarm/pull/236) | merged as this candidate; GitGuardian, ripr, required Rust, and focused secret-redaction checks passed on its reviewed head |
+| [promotion PR #467](https://github.com/EffortlessMetrics/shipper/pull/467) | merged non-fast-forward as `c0711f60f0be5a4f88fe13d004af2d1bc73dcc22`; no tag, publication, deployment, or credential movement |
+| [promotion routed run](https://github.com/EffortlessMetrics/shipper/actions/runs/30848858029) | success for the required routed result and hosted fallback on the promoted tree; the merge commit has the same tree as the tested integration head |
+| Post-merge release-authority checks | `cargo fmt --all -- --check`, workspace Clippy, workspace doctests, package surface, and policy report passed locally |
 
-The following promotion-authority proof remains intentionally outside this
-swarm receipt: topological publish dry-run, semver comparison against the
-published 0.4.0 crates, loading and resuming real 0.4.0 fixtures, target-
-platform binary builds, release rehearsal, and publication-train recovery.
-Those checks belong in `EffortlessMetrics/shipper` after the exact swarm SHA
-is merged there with the required non-fast-forward sync. No tag, crate
-publication, deployment, or release credential movement occurred here.
+The following final publication proof remains intentionally open:
+topological publish dry-run, semver comparison against the published 0.4.0
+crates, loading and resuming real 0.4.0 fixtures, target-platform binary
+builds, release rehearsal, and publication-train recovery. No tag, crate
+publication, deployment, or release credential movement has occurred.
 
 ## Promotion boundary
 
-After the swarm SHA is frozen and green, merge it into
-`EffortlessMetrics/shipper/main` with a non-fast-forward merge. Rerun the full
-gate there and resolve only release-authority workflow or credential
-differences. Do not publish crates, create tags, or move credentials from this
-repository as part of candidate preparation.
+The frozen swarm SHA has been merged into
+`EffortlessMetrics/shipper/main` with the non-fast-forward merge recorded
+above, and the release-authority integration checks have been rerun. The
+remaining publication proof must complete before any tag, crate publication,
+deployment, or release-credential use is authorized.

--- a/docs/release/0.5.0-readiness.md
+++ b/docs/release/0.5.0-readiness.md
@@ -88,6 +88,7 @@ publication authorization.
 | `shipper plan --format json` | deterministic plan `e722888e4182abe80891e770001636c9915c09e94c8ac8a479089757dbf854d1`; 13 publishable crates across 7 dependency levels |
 | Topological `cargo publish --dry-run --locked` | dependency-free crates 1 through 7 passed; the first dependent crate, `shipper-types`, correctly stopped because `shipper-duration 0.5.0` is not yet present in crates.io |
 | Topological `cargo package --locked` | dependency-free crates 1 through 7 passed; crates 8 through 13 have the same pre-publication registry-resolution gap and require a rerun after lower-level publication |
+| `cargo semver-checks check-release --workspace --baseline-version 0.4.0` | not completed within a 20-minute local run; no compatibility result is claimed |
 
 The following final publication proof remains intentionally open:
 topological publish dry-run, semver comparison against the published 0.4.0

--- a/docs/release/0.5.0-readiness.md
+++ b/docs/release/0.5.0-readiness.md
@@ -85,6 +85,9 @@ publication authorization.
 | [promotion PR #467](https://github.com/EffortlessMetrics/shipper/pull/467) | merged non-fast-forward as `c0711f60f0be5a4f88fe13d004af2d1bc73dcc22`; no tag, publication, deployment, or credential movement |
 | [promotion routed run](https://github.com/EffortlessMetrics/shipper/actions/runs/30848858029) | success for the required routed result and hosted fallback on the promoted tree; the merge commit has the same tree as the tested integration head |
 | Post-merge release-authority checks | `cargo fmt --all -- --check`, workspace Clippy, workspace doctests, package surface, and policy report passed locally |
+| `shipper plan --format json` | deterministic plan `e722888e4182abe80891e770001636c9915c09e94c8ac8a479089757dbf854d1`; 13 publishable crates across 7 dependency levels |
+| Topological `cargo publish --dry-run --locked` | dependency-free crates 1 through 7 passed; the first dependent crate, `shipper-types`, correctly stopped because `shipper-duration 0.5.0` is not yet present in crates.io |
+| Topological `cargo package --locked` | dependency-free crates 1 through 7 passed; crates 8 through 13 have the same pre-publication registry-resolution gap and require a rerun after lower-level publication |
 
 The following final publication proof remains intentionally open:
 topological publish dry-run, semver comparison against the published 0.4.0


### PR DESCRIPTION
## What this does

The release-readiness record now names the exact swarm candidate, the implementation commit, and the non-fast-forward promotion merge. It also records the checks that ran after promotion and keeps publication-only proof explicitly open.

**Change:** Corrects stale release evidence without changing product behavior, publication state, tags, deployment, or credentials.

## Verification

| Check | Result |
| --- | --- |
| cargo xtask check-doc-contracts --mode advisory | documents=22, findings=0, blocking=0 |
| git diff --check | clean |

## Review map

- docs/release/0.5.0-readiness.md: distinguishes the frozen swarm candidate, implementation commit, promotion merge, and remaining publication proof.