### PR TITLE
docs(release): finalize 0.5 readiness evidence

### DIFF
--- a/docs/release/0.5.0-readiness.md
+++ b/docs/release/0.5.0-readiness.md
@@ -68,12 +68,12 @@ The final candidate bundle must be tied to one immutable swarm SHA and include:
 ## Frozen swarm candidate and promotion evidence
 
 Captured on 2026-08-03, the frozen swarm candidate is
-`e0d9edb4788e0b8336e6a688b718aa3146816acd`. The implementation commit for
-the final webhook-secret diagnostic fix is
-`e5088e33ce0f87a93790266add0f5180b29ce4a3`; it was followed by the release
-evidence update in PR #237. The candidate was promoted to the release
-authority with non-fast-forward merge commit
-`c0711f60f0be5a4f88fe13d004af2d1bc73dcc22`. This promotion record is not
+`488734f2cfd61a82b8e5570ee9ce822546be4726`. It includes the final
+webhook-secret diagnostic fix from `e5088e33ce0f87a93790266add0f5180b29ce4a`,
+the isolated package-verification gate from PR #241, and the real 0.4.0
+resume-compatibility fix from PR #239. The candidate was promoted to the
+release authority with non-fast-forward merge commit
+`978d0cd6b598f8967ac7f9adf358192362762e9c`. This promotion record is not
 publication authorization.
 
 | Evidence | Result |
@@ -81,25 +81,30 @@ publication authorization.
 | [main CI run](https://github.com/EffortlessMetrics/shipper-swarm/actions/runs/30841367750) | success for every fan-out job, including nextest, docs, policy, security, install, BDD, fuzz, release build, target, MSRV, and crypto checks |
 | [routed Rust run](https://github.com/EffortlessMetrics/shipper-swarm/actions/runs/30841375153) | success, including the required `Shipper Rust Small Result` |
 | Clean exact-SHA local checks | `cargo fmt --all -- --check`; all 136 `shipper-webhook` tests; the `shipper-config` TOML round-trip property test; advisory doc contracts with `documents=22`, `findings=0`, `blocking=0`; `git diff --check` |
-| [webhook security PR #236](https://github.com/EffortlessMetrics/shipper-swarm/pull/236) | merged as this candidate; GitGuardian, ripr, required Rust, and focused secret-redaction checks passed on its reviewed head |
-| [promotion PR #467](https://github.com/EffortlessMetrics/shipper/pull/467) | merged non-fast-forward as `c0711f60f0be5a4f88fe13d004af2d1bc73dcc22`; no tag, publication, deployment, or credential movement |
-| [promotion routed run](https://github.com/EffortlessMetrics/shipper/actions/runs/30848858029) | success for the required routed result and hosted fallback on the promoted tree; the merge commit has the same tree as the tested integration head |
-| Post-merge release-authority checks | `cargo fmt --all -- --check`, workspace Clippy, workspace doctests, package surface, and policy report passed locally |
+| [webhook security PR #236](https://github.com/EffortlessMetrics/shipper-swarm/pull/236) | merged into the candidate; GitGuardian, ripr, required Rust, and focused secret-redaction checks passed on its reviewed head |
+| [legacy resume PR #239](https://github.com/EffortlessMetrics/shipper-swarm/pull/239) | exact-head routed result, isolated package check, interruption upload, and download/resume rehearsal passed; real v0.4.0 release-asset replay passed locally with 13/13 packages already complete and zero uploads |
+| [package-check isolation PR #241](https://github.com/EffortlessMetrics/shipper-swarm/pull/241) | exact-head hosted fallback and normalized routed result passed after isolating Cargo's temporary package registry |
+| [prior promotion PR #467](https://github.com/EffortlessMetrics/shipper/pull/467) | historical candidate promotion merged non-fast-forward as `c0711f60f0be5a4f88fe13d004af2d1bc73dcc22`; no tag, publication, deployment, or credential movement |
+| [current promotion PR #469](https://github.com/EffortlessMetrics/shipper/pull/469) | merged non-fast-forward as `978d0cd6b598f8967ac7f9adf358192362762e9c`; required routed result and hosted fallback passed, while queued auxiliary checks remain unavailable evidence |
+| [current promotion routed run](https://github.com/EffortlessMetrics/shipper/actions/runs/30860271124) | hosted fallback and normalized `Shipper Rust Small Result` passed on the sync head |
+| Post-merge release-authority checks | `cargo fmt --all -- --check`, the legacy resume consistency regression, and advisory doc contracts passed locally |
 | `shipper plan --format json` | deterministic plan `e722888e4182abe80891e770001636c9915c09e94c8ac8a479089757dbf854d1`; 13 publishable crates across 7 dependency levels |
 | Topological `cargo publish --dry-run --locked` | dependency-free crates 1 through 7 passed; the first dependent crate, `shipper-types`, correctly stopped because `shipper-duration 0.5.0` is not yet present in crates.io |
-| Topological `cargo package --locked` | dependency-free crates 1 through 7 passed; crates 8 through 13 have the same pre-publication registry-resolution gap and require a rerun after lower-level publication |
+| Topological `cargo package --locked` | the prior dependency-level probe recorded the pre-publication registry-resolution gap; the complete workspace package gate passed on PR #239 and PR #469 after package-registry isolation |
 | `cargo semver-checks check-release --workspace --baseline-version 0.4.0` | not completed within a 20-minute local run; no compatibility result is claimed |
 
 The following final publication proof remains intentionally open:
 topological publish dry-run, semver comparison against the published 0.4.0
-crates, loading and resuming real 0.4.0 fixtures, target-platform binary
-builds, release rehearsal, and publication-train recovery. No tag, crate
-publication, deployment, or release credential movement has occurred.
+crates, target-platform binary builds, release rehearsal, and
+publication-train recovery. Real 0.4.0 release artifacts have been loaded
+and resumed successfully by both the 0.4.0 binary and the current candidate.
+No tag, crate publication, deployment, or release credential movement has
+occurred.
 
 ## Promotion boundary
 
 The frozen swarm SHA has been merged into
 `EffortlessMetrics/shipper/main` with the non-fast-forward merge recorded
-above, and the release-authority integration checks have been rerun. The
-remaining publication proof must complete before any tag, crate publication,
-deployment, or release-credential use is authorized.
+above, and `shipper-swarm/main` has been fast-forwarded to that same release
+merge. The remaining publication proof must complete before any tag, crate
+publication, deployment, or release-credential use is authorized.


### PR DESCRIPTION
## What this does

Updates the release-readiness record to the resume-capable candidate now promoted into both repositories. It records PRs #239 and #241, the release-authority sync #469, the exact promotion merge `978d0cd6b598f8967ac7f9adf358192362762e9c`, and the successful real 0.4.0 artifact replay.

The document keeps publication, tagging, deployment, semver completion, target-platform builds, and publication-train recovery explicitly open. It does not authorize or perform publication.

## Verification

| Check | Result |
| --- | --- |
| `cargo xtask check-doc-contracts --mode advisory` | pass, `documents=22`, `findings=0`, `blocking=0` |
| `git diff --check` | pass |

## Review map

- `docs/release/0.5.0-readiness.md`: replaces stale candidate and promotion SHAs and separates completed 0.4 replay proof from remaining publication evidence.