### PR TITLE
docs(release): record semver compatibility evidence

### DIFF
--- a/docs/release/0.5.0-readiness.md
+++ b/docs/release/0.5.0-readiness.md
@@ -91,12 +91,11 @@ publication authorization.
 | `shipper plan --format json` | deterministic plan `e722888e4182abe80891e770001636c9915c09e94c8ac8a479089757dbf854d1`; 13 publishable crates across 7 dependency levels |
 | Topological `cargo publish --dry-run --locked` | dependency-free crates 1 through 7 passed; the first dependent crate, `shipper-types`, correctly stopped because `shipper-duration 0.5.0` is not yet present in crates.io |
 | Topological `cargo package --locked` | the prior dependency-level probe recorded the pre-publication registry-resolution gap; the complete workspace package gate passed on PR #239 and PR #469 after package-registry isolation |
-| `cargo semver-checks check-release --workspace --baseline-version 0.4.0` | not completed within a 20-minute local run; no compatibility result is claimed |
+| Per-package semver checks against 0.4.0 | `cargo semver-checks check-release -p <publishable-crate> --baseline-version 0.4.0` passed for all 13 publishable crates: `shipper-cargo-failure`, `shipper-duration`, `shipper-encrypt`, `shipper-output-sanitizer`, `shipper-retry`, `shipper-sparse-index`, `shipper-webhook`, `shipper-types`, `shipper-config`, `shipper-registry`, `shipper-core`, `shipper-cli`, and `shipper` |
 
 The following final publication proof remains intentionally open:
-topological publish dry-run, semver comparison against the published 0.4.0
-crates, target-platform binary builds, release rehearsal, and
-publication-train recovery. Real 0.4.0 release artifacts have been loaded
+topological publish dry-run, target-platform binary builds, release rehearsal,
+and publication-train recovery. Real 0.4.0 release artifacts have been loaded
 and resumed successfully by both the 0.4.0 binary and the current candidate.
 No tag, crate publication, deployment, or release credential movement has
 occurred.


### PR DESCRIPTION
## What this does

The 0.5.0 readiness record now captures the completed compatibility proof against the published 0.4.0 crates. The workspace-wide semver invocation exceeded the local time budget, so the evidence is recorded using the equivalent per-package checks without changing the release claim.

**Change:** record all 13 publishable crates as passing `cargo semver-checks check-release -p <crate> --baseline-version 0.4.0`, and remove semver comparison from the remaining-open proof list. No code, version, publication, or release workflow behavior changes.

## Verification

| Check | Result |
| --- | --- |
| Per-package semver checks | 13/13 publishable crates passed against 0.4.0 |
| `cargo xtask check-doc-contracts --mode advisory` | 22 documents, 0 findings, 0 blocking |
| `git diff --check` | clean |

## Review map

- `docs/release/0.5.0-readiness.md`: records the exact compatibility result and keeps the remaining publication-only gaps bounded.