### PR TITLE
fix(release): route binaries to matching runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@
 # Triggers:
 #   - push of a `v*.*.*` tag  -> full release (build + publish + release)
 #   - workflow_dispatch "rehearse" -> plan + preflight dry-run only
+#   - workflow_dispatch "binaries" -> build release binaries only
 #   - workflow_dispatch "resume"   -> download .shipper/ artifact and resume
 #
 # Repository guard:
@@ -31,6 +32,7 @@ on:
         type: choice
         options:
           - rehearse
+          - binaries
           - resume
       ref:
         description: 'Git ref to check out (tag/branch/SHA). Defaults to the workflow ref.'
@@ -57,28 +59,39 @@ jobs:
   # ---------------------------------------------------------------------------
   build-binaries:
     name: Build ${{ matrix.target }}
-    if: github.repository == 'EffortlessMetrics/shipper' && github.event_name == 'push'
-    runs-on:
-      group: em-ci-small
-      labels: [self-hosted, linux, x64, em-ci, cx53, rust-large, trusted-pr]
+    if: >-
+      github.repository == 'EffortlessMetrics/shipper' &&
+      (github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'binaries'))
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            runner: ubuntu-24.04
             archive: tar.gz
           - target: x86_64-apple-darwin
-            os: macos-latest
+            runner: macos-15-intel
             archive: tar.gz
           - target: aarch64-apple-darwin
-            os: macos-latest
+            runner: macos-15
             archive: tar.gz
           - target: x86_64-pc-windows-msvc
-            os: windows-latest
+            runner: windows-2025
             archive: zip
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Record runner and target
+        shell: bash
+        run: |
+          set -eu
+          echo "runner=${{ matrix.runner }}"
+          echo "target=${{ matrix.target }}"
+          rustc -vV
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -99,14 +112,14 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }} -p shipper
 
       - name: Package binary (Unix)
-        if: matrix.os != 'windows-latest'
+        if: matrix.archive != 'zip'
         run: |
           cd target/${{ matrix.target }}/release
           tar czvf ../../../shipper-${{ matrix.target }}.tar.gz shipper
           cd -
 
       - name: Package binary (Windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.archive == 'zip'
         run: |
           cd target/${{ matrix.target }}/release
           7z a ../../../shipper-${{ matrix.target }}.zip shipper.exe

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -47,10 +47,19 @@ The authoritative order for a given release is whatever `shipper plan` prints fo
 
 1. **CI is green on `main`.** Every lane in the latest `CI` run for `main` must show success (`gh run list --workflow=ci.yml --branch=main --limit=1`). `architecture-guard` has a `paths:` trigger gate — if it hasn't re-posted a status since the last `crates/shipper/src/**` commit, verify the workflow file on `main` still has the `--include='*.rs'` filter (false-red guard from #85).
 2. **Rehearsal is green.** `gh workflow run release.yml --ref main --field mode=rehearse` completed successfully. The plan ID in the uploaded `shipper-rehearse-<run_id>` artifact must match the plan ID from a local `shipper plan` on the same SHA.
-3. **No mainline changes since the rehearsal.** Any commit to `main` after the rehearsal invalidates the plan ID. If mainline moved, re-rehearse.
-4. **Version is bumped and committed.** `cargo metadata --format-version 1 | jq -r '.workspace_default_members[0]' | ...` → every publishable crate in `Cargo.toml` reads the intended `vX.Y.Z`. `CHANGELOG.md` has an entry for the new version (not `[Unreleased]`).
-5. **crates.io is healthy.** Open [status.crates.io](https://status.crates.io/) immediately before starting. If the **git index** is running behind but the **sparse index** is healthy, that's OK — the workflow uses `--readiness-method both` and will use the sparse index path. If the **sparse index** itself is reporting incidents, abort and wait.
-6. **Auth is present.**
+3. **Binary matrix is green.** For the approved SHA, run the non-publishing binary check and retain all four artifacts:
+
+   ```bash
+   gh workflow run release.yml --ref main \
+     --field mode=binaries \
+     --field ref=<approved-sha>
+   ```
+
+   This exercises Linux x64, Intel macOS, arm64 macOS, and Windows x64 without publishing crates or creating a GitHub Release. Confirm each job's runner/target evidence and archive before proceeding.
+4. **No mainline changes since the rehearsal.** Any commit to `main` after the rehearsal or binary check invalidates the proof. If mainline moved, rerun both checks.
+5. **Version is bumped and committed.** `cargo metadata --format-version 1 | jq -r '.workspace_default_members[0]' | ...` → every publishable crate in `Cargo.toml` reads the intended `vX.Y.Z`. `CHANGELOG.md` has an entry for the new version (not `[Unreleased]`).
+6. **crates.io is healthy.** Open [status.crates.io](https://status.crates.io/) immediately before starting. If the **git index** is running behind but the **sparse index** is healthy, that's OK — the workflow uses `--readiness-method both` and will use the sparse index path. If the **sparse index** itself is reporting incidents, abort and wait.
+7. **Auth is present.**
    - **Token fallback (primary path today).** `CARGO_REGISTRY_TOKEN` repo secret must be set with publish scope for every crate in the plan. Trusted Publishing is wired in `release.yml` but not yet configured per-crate on crates.io — the OIDC step has `continue-on-error: true` and cleanly falls through to the token. Until Trusted Publishing is registered for every crate (see below), the token is what's actually doing the auth.
    - **Trusted Publishing (target path).** When you're ready to switch, follow the one-time-registration checklist in [`how-to/run-in-github-actions.md`](./how-to/run-in-github-actions.md#token-vs-trusted-publishing). Every crate in the plan must be registered as a trusted publisher for this repo + `release.yml` + `release` environment before the next tag push, or you'll mid-train 401 on the unregistered ones. Rehearse with the `release` environment bound (the workflow already does) to prove the scope wiring before going live.
 

--- a/docs/release/0.5.0-readiness.md
+++ b/docs/release/0.5.0-readiness.md
@@ -64,6 +64,9 @@ The final candidate bundle must be tied to one immutable swarm SHA and include:
   semver reports against 0.4.0;
 - release-workflow target-platform, publication-order, and interrupted-train
   resume evidence.
+- The release workflow's binary matrix must be exercised with the non-publishing
+  `mode=binaries` dispatch and retained artifacts before any target-platform
+  asset claim is made.
 
 ## Frozen swarm candidate and promotion evidence
 
@@ -92,6 +95,7 @@ publication authorization.
 | Topological `cargo publish --dry-run --locked` | dependency-free crates 1 through 7 passed; the first dependent crate, `shipper-types`, correctly stopped because `shipper-duration 0.5.0` is not yet present in crates.io |
 | Topological `cargo package --locked` | the prior dependency-level probe recorded the pre-publication registry-resolution gap; the complete workspace package gate passed on PR #239 and PR #469 after package-registry isolation |
 | Per-package semver checks against 0.4.0 | `cargo semver-checks check-release -p <publishable-crate> --baseline-version 0.4.0` passed for all 13 publishable crates: `shipper-cargo-failure`, `shipper-duration`, `shipper-encrypt`, `shipper-output-sanitizer`, `shipper-retry`, `shipper-sparse-index`, `shipper-webhook`, `shipper-types`, `shipper-config`, `shipper-registry`, `shipper-core`, `shipper-cli`, and `shipper` |
+| Release binary matrix routing | PR #472 routes each target to a matching platform runner and adds a non-publishing `mode=binaries` dispatch; exact-head artifact proof is still required before this row can be marked passed |
 
 The following final publication proof remains intentionally open:
 topological publish dry-run, target-platform binary builds, release rehearsal,


### PR DESCRIPTION
## What this does

The release workflow can now prove its four binary targets on matching platforms without starting the publish train. Previously, the target matrix ran every leg on one Linux self-hosted runner and used its `os` field only for packaging decisions, leaving the Intel macOS asset unproved.

**Fix:** route Linux x64, Intel macOS, arm64 macOS, and Windows x64 to explicit matching runners, record runner and target metadata, and add an opt-in `mode=binaries` dispatch. The dispatch checks out the requested SHA and builds/uploads archives only; publish and GitHub Release jobs remain push-only and repository-guarded. Closes #472.

## Verification

| Check | Result |
| --- | --- |
| `actionlint .github/workflows/release.yml` | clean |
| Workflow, file, process, and network policy checks | clean, 0 unknown or unreceipted entries |
| `cargo xtask check-doc-contracts --mode advisory` | 22 documents, 0 findings, 0 blocking |
| `git diff --check` | clean |

## Review map

- `.github/workflows/release.yml`: matching runner matrix, safe binary-only dispatch, exact-ref checkout, and archive selection.
- `docs/release-runbook.md`: operator command and proof boundary for the non-publishing binary check.
- `docs/release/0.5.0-readiness.md`: records that artifact proof is still required before claiming target coverage.