### PR TITLE
docs(release): record merged binary proof

### DIFF
--- a/docs/release/0.5.0-readiness.md
+++ b/docs/release/0.5.0-readiness.md
@@ -64,9 +64,9 @@ The final candidate bundle must be tied to one immutable swarm SHA and include:
   semver reports against 0.4.0;
 - release-workflow target-platform, publication-order, and interrupted-train
   resume evidence.
-- The release workflow's binary matrix must be exercised with the non-publishing
-  `mode=binaries` dispatch and retained artifacts before any target-platform
-  asset claim is made.
+- The release workflow's binary matrix has been exercised with the
+  non-publishing `mode=binaries` dispatch and retained artifacts on the merged
+  release-authority SHA below.
 
 ## Frozen swarm candidate and promotion evidence
 
@@ -95,11 +95,11 @@ publication authorization.
 | Topological `cargo publish --dry-run --locked` | dependency-free crates 1 through 7 passed; the first dependent crate, `shipper-types`, correctly stopped because `shipper-duration 0.5.0` is not yet present in crates.io |
 | Topological `cargo package --locked` | the prior dependency-level probe recorded the pre-publication registry-resolution gap; the complete workspace package gate passed on PR #239 and PR #469 after package-registry isolation |
 | Per-package semver checks against 0.4.0 | `cargo semver-checks check-release -p <publishable-crate> --baseline-version 0.4.0` passed for all 13 publishable crates: `shipper-cargo-failure`, `shipper-duration`, `shipper-encrypt`, `shipper-output-sanitizer`, `shipper-retry`, `shipper-sparse-index`, `shipper-webhook`, `shipper-types`, `shipper-config`, `shipper-registry`, `shipper-core`, `shipper-cli`, and `shipper` |
-| Release binary matrix routing | PR #472 routes each target to a matching platform runner and adds a non-publishing `mode=binaries` dispatch; exact-head artifact proof is still required before this row can be marked passed |
+| Release binary matrix | [PR #473](https://github.com/EffortlessMetrics/shipper/pull/473) merged the runner correction as `8d80ff0d8301578fc8d71291076809dd46c8534d`; [workflow run 30867482676](https://github.com/EffortlessMetrics/shipper/actions/runs/30867482676) passed on that exact SHA and retained four unexpired artifacts: Linux x64, Intel macOS, arm64 macOS, and Windows x64. Publish, rehearse, resume, policy, and GitHub Release jobs were skipped. |
 
 The following final publication proof remains intentionally open:
-topological publish dry-run, target-platform binary builds, release rehearsal,
-and publication-train recovery. Real 0.4.0 release artifacts have been loaded
+topological publish dry-run, release rehearsal, and publication-train recovery.
+Real 0.4.0 release artifacts have been loaded
 and resumed successfully by both the 0.4.0 binary and the current candidate.
 No tag, crate publication, deployment, or release credential movement has
 occurred.


### PR DESCRIPTION
## What this does

The 0.5.0 readiness record now includes the completed non-publishing binary matrix proof for the merged release-authority SHA `8d80ff0`. This closes the target-platform evidence gap without changing publication authorization or release credentials.

**Change:** record workflow run `30867482676` as passing for Linux x64, Intel macOS, arm64 macOS, and Windows x64, with four retained unexpired artifacts. The record also removes target-platform builds from the remaining-open proof list while keeping publication-only rehearsal and recovery work open.

## Verification

| Check | Result |
| --- | --- |
| `mode=binaries` workflow run `30867482676` | all four build jobs passed; publish, rehearse, resume, policy, and GitHub Release jobs skipped |
| `cargo xtask check-doc-contracts --mode advisory` | 22 documents, 0 findings, 0 blocking |
| `git diff --check` | clean |

## Review map

- `docs/release/0.5.0-readiness.md`: ties target-platform evidence to merged SHA `8d80ff0` and retained run artifacts.